### PR TITLE
fix(macos): app.log launch diagnostics (v0.2.3.6)

### DIFF
--- a/apps/netllm-mac/Sources/App/AppDelegate.swift
+++ b/apps/netllm-mac/Sources/App/AppDelegate.swift
@@ -13,12 +13,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, AppControlHandling {
     private var runtime: PythonRuntime?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        AppLogger.log("applicationDidFinishLaunching started (v\(version))")
         NSApp.setActivationPolicy(.accessory)
         updateApplicationIcon()
         observeInterfaceTheme()
 
         let runtime = PythonRuntime()
         self.runtime = runtime
+        AppLogger.log("PythonRuntime ready")
         let config = AppConfig.load()
         server = ServerProcess(
             runtime: runtime,
@@ -26,15 +29,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, AppControlHandling {
             port: config.port,
             configPath: config.configPath
         )
+        AppLogger.log("ServerProcess configured host=\(config.bindHost) port=\(config.port)")
         controlServer = AppControlServer()
         controlServer?.handler = self
+        let controlSock = AppConfig.appSupportURL().appendingPathComponent("control.sock")
         do {
             try controlServer?.start()
+            AppLogger.log("control.sock listening at \(controlSock.path)")
         } catch {
-            try? FileManager.default.removeItem(
-                at: AppConfig.appSupportURL().appendingPathComponent("control.sock")
-            )
-            try? controlServer?.start()
+            AppLogger.log("control.sock start failed: \(error.localizedDescription); retrying after unlink")
+            try? FileManager.default.removeItem(at: controlSock)
+            do {
+                try controlServer?.start()
+                AppLogger.log("control.sock listening at \(controlSock.path) (after retry)")
+            } catch {
+                AppLogger.log("control.sock retry failed: \(error.localizedDescription)")
+            }
         }
 
         menubar = MenubarController(
@@ -54,6 +64,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, AppControlHandling {
                 self?.openLogFolder()
             }
         )
+        AppLogger.log("menubar created")
         ShellEnvWriter.ensureCLIShim(bundleCLI: runtime.bundleCLIPath)
 
         UpdateController.shared.configure(server: server!)
@@ -64,25 +75,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, AppControlHandling {
         }
 
         closeStraySwiftUISettingsWindows()
+        AppLogger.log("applicationDidFinishLaunching finished")
 
         Task { @MainActor in
             guard let server else { return }
+            AppLogger.log("launch task: reconcileListeningPort adoptOrphan=\(config.autoStartOnLaunch)")
             await server.reconcileListeningPort(adoptOrphan: config.autoStartOnLaunch)
+            AppLogger.log("launch task: after reconcile state=\(Self.describe(server.state))")
             if config.needsWelcome || !config.autoStartOnLaunch {
+                AppLogger.log("launch task: showing welcome (needsWelcome=\(config.needsWelcome) autoStart=\(config.autoStartOnLaunch))")
                 showWelcome()
             } else if config.autoStartOnLaunch {
                 switch server.state {
                 case .stopped, .failed:
-                    try? server.start()
+                    do {
+                        let result = try server.start()
+                        AppLogger.log("launch task: auto_start result=\(result) state=\(Self.describe(server.state))")
+                    } catch {
+                        AppLogger.log("launch task: auto_start failed: \(error.localizedDescription)")
+                    }
                 default:
-                    break
+                    AppLogger.log("launch task: auto_start skipped state=\(Self.describe(server.state))")
                 }
             }
         }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        AppLogger.log("applicationWillTerminate started")
         controlServer?.stop()
+        AppLogger.log("control.sock stopped")
         guard let server else { return }
         // Do not block the main thread on DispatchGroup.wait while a MainActor Task
         // runs stop() — that deadlocks and leaves the agent orphaned on :11400.
@@ -94,6 +116,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, AppControlHandling {
         let deadline = Date().addingTimeInterval(15)
         while done.wait(timeout: .now() + 0.05) == .timedOut, Date() < deadline {
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        AppLogger.log("applicationWillTerminate finished state=\(Self.describe(server.state))")
+    }
+
+    private static func describe(_ state: ServerProcess.State) -> String {
+        switch state {
+        case .stopped: "stopped"
+        case .starting: "starting"
+        case .running(let pid): "running(pid=\(pid))"
+        case .stopping: "stopping"
+        case .failed(let message): "failed(\(message))"
+        case .unresponsive(let pid): "unresponsive(pid=\(pid))"
         }
     }
 

--- a/apps/netllm-mac/Sources/App/NetllmMacApp.swift
+++ b/apps/netllm-mac/Sources/App/NetllmMacApp.swift
@@ -4,6 +4,11 @@ import SwiftUI
 struct NetllmMacApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
 
+    init() {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        AppLogger.log("NetllmMacApp.init (v\(version) pid=\(ProcessInfo.processInfo.processIdentifier))")
+    }
+
     var body: some Scene {
         Settings {
             EmptyView()

--- a/apps/netllm-mac/Sources/Config/AppLogger.swift
+++ b/apps/netllm-mac/Sources/Config/AppLogger.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum AppLogger {
+    private static let logURL: URL = {
+        let dir = AppConfig.appSupportURL().appendingPathComponent("logs", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("app.log")
+    }()
+
+    private static let queue = DispatchQueue(label: "com.netllm.app-log")
+
+    static func log(_ message: String) {
+        let line = "\(isoTimestamp()) \(message)\n"
+        guard let data = line.data(using: .utf8) else { return }
+        queue.async {
+            if !FileManager.default.fileExists(atPath: logURL.path) {
+                FileManager.default.createFile(atPath: logURL.path, contents: nil)
+            }
+            guard let handle = try? FileHandle(forWritingTo: logURL) else { return }
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            _ = try? handle.write(contentsOf: data)
+        }
+    }
+
+    private static func isoTimestamp() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date())
+    }
+}

--- a/docs/macos-troubleshooting.md
+++ b/docs/macos-troubleshooting.md
@@ -8,6 +8,7 @@ Install guide: [macos-install.md](macos-install.md) · Overview: [platform-matri
 netllm doctor
 curl -sf http://127.0.0.1:11400/health
 netllm status
+tail -20 ~/Library/Application\ Support/netllm/logs/app.log   # menubar native launch (v0.2.3.6+)
 ```
 
 Dashboard: http://127.0.0.1:11400/ui/ · menubar **Open Dashboard** or **Copy Client Env**.

--- a/docs/release-notes/v0.2.3.6.md
+++ b/docs/release-notes/v0.2.3.6.md
@@ -1,0 +1,26 @@
+## 0.2.3.6: macOS native launch diagnostics
+
+Patch release adding `app.log` so menubar startup failures are visible on disk when the process runs but the menu bar icon and agent never appear.
+
+### Fixes
+
+- **`app.log`:** `~/Library/Application Support/netllm/logs/app.log` records SwiftUI init, `applicationDidFinishLaunching`, control socket bind, menubar creation, agent auto-start, and quit
+- **Control socket retry:** log bind failures before/after unlinking a stale `control.sock`
+
+### Diagnose a stuck launch
+
+```bash
+tail -30 ~/Library/Application\ Support/netllm/logs/app.log
+```
+
+- `NetllmMacApp.init` without `applicationDidFinishLaunching started` → delegate never wired (partial app shell)
+- Stops before `menubar created` → last line shows which step failed
+
+### Install / upgrade
+
+- **macOS:** [v0.2.3.6](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.6) — menubar **Updates** or `scripts/upgrade-mac-app.sh`
+- **Source:** `git pull && uv sync`
+
+### Previous release
+
+- [v0.2.3.5 notes](v0.2.3.5.md): macOS update UX + agent port recovery

--- a/docs/release-notes/v0.2.3.md
+++ b/docs/release-notes/v0.2.3.md
@@ -24,6 +24,7 @@ All platforms get a redesigned local dashboard at http://127.0.0.1:11400/ui/ tha
 
 ### Follow-up
 
+- [v0.2.3.6 notes](v0.2.3.6.md): macOS native launch diagnostics (`app.log`)
 - [v0.2.3.5 notes](v0.2.3.5.md): macOS update UX + agent port recovery
 - [v0.2.3.4 notes](v0.2.3.4.md): macOS agent lifecycle + release gates
 - [v0.2.3.3 notes](v0.2.3.3.md): About fix + Logs access

--- a/packages/netllm-agent/pyproject.toml
+++ b/packages/netllm-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-agent"
-version = "0.2.3.5"
+version = "0.2.3.6"
 description = "FastAPI agent daemon for netllm swarm routing"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-cli/pyproject.toml
+++ b/packages/netllm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-cli"
-version = "0.2.3.5"
+version = "0.2.3.6"
 description = "CLI for netllm network LLM router"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-core/pyproject.toml
+++ b/packages/netllm-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-core"
-version = "0.2.3.5"
+version = "0.2.3.6"
 description = "Core routing, health, and config for netllm"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-core/src/netllm_core/version.py
+++ b/packages/netllm-core/src/netllm_core/version.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 
-_FALLBACK_VERSION = "0.2.3.5"
+_FALLBACK_VERSION = "0.2.3.6"
 
 
 def get_version() -> str:

--- a/packages/netllm-discovery/pyproject.toml
+++ b/packages/netllm-discovery/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-discovery"
-version = "0.2.3.5"
+version = "0.2.3.6"
 description = "Local and swarm discovery for netllm agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-sdk-anthropic/pyproject.toml
+++ b/packages/netllm-sdk-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-sdk-anthropic"
-version = "0.2.3.5"
+version = "0.2.3.6"
 description = "Anthropic SDK adapter for netllm upstream calls"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-sdk-openai/pyproject.toml
+++ b/packages/netllm-sdk-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-sdk-openai"
-version = "0.2.3.5"
+version = "0.2.3.6"
 description = "OpenAI SDK adapter for netllm upstream calls"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm"
-version = "0.2.3.5"
+version = "0.2.3.6"
 description = "Network LLM router — swarm agents with OpenAI-compatible gateway"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "netllm"
-version = "0.2.3.5"
+version = "0.2.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "netllm-cli" },
@@ -625,7 +625,7 @@ dev = [
 
 [[package]]
 name = "netllm-agent"
-version = "0.2.3.5"
+version = "0.2.3.6"
 source = { editable = "packages/netllm-agent" }
 dependencies = [
     { name = "fastapi" },
@@ -653,7 +653,7 @@ provides-extras = ["mdns"]
 
 [[package]]
 name = "netllm-cli"
-version = "0.2.3.5"
+version = "0.2.3.6"
 source = { editable = "packages/netllm-cli" }
 dependencies = [
     { name = "httpx" },
@@ -676,7 +676,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-core"
-version = "0.2.3.5"
+version = "0.2.3.6"
 source = { editable = "packages/netllm-core" }
 dependencies = [
     { name = "httpx" },
@@ -695,7 +695,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-discovery"
-version = "0.2.3.5"
+version = "0.2.3.6"
 source = { editable = "packages/netllm-discovery" }
 dependencies = [
     { name = "httpx" },
@@ -713,7 +713,7 @@ provides-extras = ["mdns"]
 
 [[package]]
 name = "netllm-sdk-anthropic"
-version = "0.2.3.5"
+version = "0.2.3.6"
 source = { editable = "packages/netllm-sdk-anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -728,7 +728,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-sdk-openai"
-version = "0.2.3.5"
+version = "0.2.3.6"
 source = { editable = "packages/netllm-sdk-openai" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Add `~/Library/Application Support/netllm/logs/app.log` with native menubar startup milestones (SwiftUI init, delegate, control socket, menubar, agent auto-start, quit)
- Log control.sock bind failures before/after stale-socket retry
- Bump workspace to **v0.2.3.6** (macOS DMG patch only in scope; no agent/API changes)

## Test plan
- [ ] CI green on PR
- [ ] Install DMG; confirm `app.log` lines through `applicationDidFinishLaunching finished`
- [ ] Menubar icon + `curl http://127.0.0.1:11400/health` still OK