### PR TITLE
fix(macos): repair in-app update install path and update UX

### DIFF
--- a/apps/netllm-mac/Sources/Server/PythonRuntime.swift
+++ b/apps/netllm-mac/Sources/Server/PythonRuntime.swift
@@ -9,9 +9,15 @@ struct PythonRuntime: Sendable {
     init() {
         if let env = ProcessInfo.processInfo.environment["NETLLM_BUNDLE_PATH"],
            !env.isEmpty {
-            bundleRoot = URL(fileURLWithPath: env)
+            let candidate = URL(fileURLWithPath: env)
+            let bundledCLI = candidate.appendingPathComponent("Contents/MacOS/netllm-cli")
+            if FileManager.default.isExecutableFile(atPath: bundledCLI.path) {
+                bundleRoot = candidate
+            } else {
+                bundleRoot = Bundle.main.bundleURL
+            }
         } else {
-            // bundleURL is the .app root (…/netllm-mac.app), not Contents/.
+            // bundleURL is the .app root (…/llm-swarm-router.app), not Contents/.
             bundleRoot = Bundle.main.bundleURL
         }
 
@@ -49,8 +55,14 @@ struct PythonRuntime: Sendable {
 
     func makeEnvironment() -> [String: String] {
         var env = ProcessInfo.processInfo.environment
-        env["PYTHONHOME"] = pythonHome.path
-        env["PYTHONPATH"] = pythonPath
+        let bundledPython = pythonHome.appendingPathComponent("bin/python3")
+        if FileManager.default.isExecutableFile(atPath: bundledPython.path) {
+            env["PYTHONHOME"] = pythonHome.path
+            env["PYTHONPATH"] = pythonPath
+        } else {
+            env.removeValue(forKey: "PYTHONHOME")
+            env.removeValue(forKey: "PYTHONPATH")
+        }
         env["PYTHONDONTWRITEBYTECODE"] = "1"
         env["NETLLM_SUPERVISED"] = "menubar"
         env["NETLLM_BUNDLE_PATH"] = bundleRoot.path

--- a/apps/netllm-mac/Sources/Updater/UpdateController.swift
+++ b/apps/netllm-mac/Sources/Updater/UpdateController.swift
@@ -67,34 +67,29 @@ final class UpdateController {
     func prepareCacheOnLaunch() async {
         UpdateLogger.log("prepareCacheOnLaunch (app v\(currentVersion))")
         prunePartialDownloadsOnly()
-        await restoreCachedDownloadOnLaunch()
         await reconcileDownloadWithDisk()
     }
 
-    /// If UI says "downloading" but the DMG is already on disk, promote to ready-to-install.
+    /// Promote a verified cached DMG to ready-to-install regardless of download UI state.
     func reconcileDownloadWithDisk() async {
-        guard case .downloading = state else { return }
+        if case .readyToInstall = state { return }
+        if case .installing = state { return }
+
         let release: GitHubRelease?
         if let activeDownloadRelease {
             release = activeDownloadRelease
+        } else if case .available(let available) = state {
+            release = available
         } else {
             release = await checker.latestRelease(userAgent: userAgent)
         }
-        guard let release else { return }
-        let destination = cachedDMGURL(for: release)
-        if await adoptCachedDMGIfValid(destination: destination, release: release, notify: false) {
-            UpdateLogger.log("reconciled stuck download → readyToInstall v\(release.version)")
-        }
-    }
-
-    private func restoreCachedDownloadOnLaunch() async {
-        guard let release = await checker.latestRelease(userAgent: userAgent),
+        guard let release,
               release.version.compare(currentVersion, options: .numeric) == .orderedDescending else {
             return
         }
         let destination = cachedDMGURL(for: release)
         if await adoptCachedDMGIfValid(destination: destination, release: release, notify: false) {
-            UpdateLogger.log("restored cached DMG for v\(release.version) at \(destination.path)")
+            UpdateLogger.log("reconciled cache → readyToInstall v\(release.version)")
         }
     }
 
@@ -204,13 +199,18 @@ final class UpdateController {
         if !force && !AppConfig.load().checkForUpdatesAutomatically {
             return
         }
-        if case .downloading = state {
-            await reconcileDownloadWithDisk()
-            return
-        }
         if case .installing = state {
             return
         }
+
+        await reconcileDownloadWithDisk()
+        if case .readyToInstall(_, let release) = state {
+            if force {
+                presentUpdateAlreadyCachedAlert(version: release.version)
+            }
+            return
+        }
+
         let preservedReady: (URL, GitHubRelease)? = {
             if case .readyToInstall(let dmg, let release) = state {
                 return (dmg, release)
@@ -221,6 +221,7 @@ final class UpdateController {
         guard let release = await checker.latestRelease(userAgent: userAgent) else {
             if force {
                 setState(.failed("Unable to check for updates"))
+                presentCheckFailedAlert("Could not reach GitHub to check for updates. Check your network and try again.")
             } else if let preservedReady {
                 setState(.readyToInstall(localDMG: preservedReady.0, release: preservedReady.1))
             } else {
@@ -233,6 +234,16 @@ final class UpdateController {
                 setState(.readyToInstall(localDMG: preservedReady.0, release: preservedReady.1))
             } else {
                 setState(.idle)
+                if force {
+                    presentUpToDateAlert()
+                }
+            }
+            return
+        }
+        await reconcileDownloadWithDisk()
+        if case .readyToInstall(_, let cached) = state {
+            if force {
+                presentUpdateAlreadyCachedAlert(version: cached.version)
             }
             return
         }
@@ -241,6 +252,9 @@ final class UpdateController {
             return
         }
         setState(.available(release))
+        if force {
+            presentUpdateAvailableAlert(release: release)
+        }
     }
 
     func downloadUpdate(release: GitHubRelease) {
@@ -345,9 +359,46 @@ final class UpdateController {
         NSApp.activate(ignoringOtherApps: true)
         let readyAlert = NSAlert()
         readyAlert.messageText = "Update v\(version) ready"
-        readyAlert.informativeText = "Choose Install Update from the menubar Updates menu, or open Settings → Install and Quit."
+        readyAlert.informativeText = "Open the menubar popover and choose Install, or use Settings → Install and Quit."
         readyAlert.addButton(withTitle: "OK")
         readyAlert.runModal()
+    }
+
+    private func presentUpToDateAlert() {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "You're up to date"
+        alert.informativeText = "\(AppBranding.displayName) v\(currentVersion) is the latest release available from GitHub."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func presentCheckFailedAlert(_ message: String) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "Update check failed"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func presentUpdateAvailableAlert(release: GitHubRelease) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "Update available"
+        alert.informativeText = "Version \(release.version) is available. Use Download in the menubar popover or Settings → Updates."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func presentUpdateAlreadyCachedAlert(version: String) {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "Update v\(version) ready to install"
+        alert.informativeText = "The update is already downloaded. Choose Install in the menubar popover or Settings → Install and Quit."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 
     func installUpdate(release: GitHubRelease, localDMG: URL) async {
@@ -381,8 +432,18 @@ final class UpdateController {
             withExtension: "sh",
             subdirectory: "Scripts"
         ) else {
-            setState(.failed("Installer script missing from app bundle"))
+            let message = "Installer script missing from app bundle"
+            UpdateLogger.log("install failed: \(message)")
+            setState(.failed(message))
+            presentCheckFailedAlert(message)
             return
+        }
+
+        let logsDir = AppConfig.appSupportURL().appendingPathComponent("logs", isDirectory: true)
+        try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
+        let installLogURL = logsDir.appendingPathComponent("install.log")
+        if !FileManager.default.fileExists(atPath: installLogURL.path) {
+            FileManager.default.createFile(atPath: installLogURL.path, contents: nil)
         }
 
         let process = Process()
@@ -394,13 +455,24 @@ final class UpdateController {
             "--dmg", localDMG.path,
             "--install-path", installPath.path,
             "--cache-cleanup", cacheDirectory.path,
+            "--log-file", installLogURL.path,
         ]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
+        if let logHandle = try? FileHandle(forWritingTo: installLogURL) {
+            try? logHandle.seekToEnd()
+            let header = "\n--- install v\(release.version) \(ISO8601DateFormatter().string(from: Date())) ---\n"
+            if let data = header.data(using: .utf8) {
+                try? logHandle.write(contentsOf: data)
+            }
+            process.standardOutput = logHandle
+            process.standardError = logHandle
+        }
         do {
             try process.run()
         } catch {
-            setState(.failed("Failed to start installer: \(error.localizedDescription)"))
+            let message = "Failed to start installer: \(error.localizedDescription)"
+            UpdateLogger.log("install failed: \(message)")
+            setState(.failed(message))
+            presentCheckFailedAlert(message)
             return
         }
         NSApp.terminate(nil)

--- a/docs/release-notes/v0.2.3.6.md
+++ b/docs/release-notes/v0.2.3.6.md
@@ -1,11 +1,26 @@
-## 0.2.3.6: macOS native launch diagnostics
+## 0.2.3.6: macOS in-app update + launch diagnostics
 
-Patch release adding `app.log` so menubar startup failures are visible on disk when the process runs but the menu bar icon and agent never appear.
+Patch release fixing broken in-app install (`mount-dmg` path, installer flags), cached-DMG promotion, update-check feedback, and `app.log` for menubar startup failures.
 
 ### Fixes
 
+- **In-app install:** bundled `macos-app-install.sh` resolves co-located `mount-dmg.sh` (fixes `Contents/packaging/…` path on installed apps); implements `--in-app-update`, `--wait-for-pid`, `--cache-cleanup`, and `--log-file`
+- **Update UX:** promote verified cached DMGs to **Install Update** on launch; manual **Check for Updates** shows up-to-date / available / ready alerts; installer output in `~/Library/Application Support/netllm/logs/install.log`
+- **Agent env:** ignore invalid `NETLLM_BUNDLE_PATH`; only set `PYTHONHOME` when bundled Python exists (fixes `encodings` crash with global `uv netllm` fallback)
 - **`app.log`:** `~/Library/Application Support/netllm/logs/app.log` records SwiftUI init, `applicationDidFinishLaunching`, control socket bind, menubar creation, agent auto-start, and quit
 - **Control socket retry:** log bind failures before/after unlinking a stale `control.sock`
+- **CI:** release e2e gates bundled installer path resolution and in-app flag parsing
+
+### Diagnose update / launch issues
+
+```bash
+tail -30 ~/Library/Application\ Support/netllm/logs/update.log
+tail -30 ~/Library/Application\ Support/netllm/logs/install.log
+tail -30 ~/Library/Application\ Support/netllm/logs/app.log
+```
+
+- Cached DMG but no **Install** menu → upgrade to this build once via `--source` if `--dmg` fails on an older app
+- `Update install failed` in a modal → read `install.log` for the underlying error
 
 ### Diagnose a stuck launch
 

--- a/packaging/scripts/macos-app-install.sh
+++ b/packaging/scripts/macos-app-install.sh
@@ -10,13 +10,24 @@
 #
 # Options:
 #   --install-path PATH   Default: /Applications/llm-swarm-router.app
+#   --in-app-update       Menubar-driven update: wait for caller PID, skip osascript quit
+#   --wait-for-pid PID    Wait for this process to exit before replacing the .app
+#   --cache-cleanup DIR   Remove verified update DMGs from this cache directory after install
+#   --log-file PATH       Append installer output to this log file
 #   --no-launch           Install only; do not open the app
 #   --no-verify           Skip post-launch /health and /ui/ checks
 #   --no-stop             Skip process teardown (maintainer debugging only)
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-MOUNT_DMG="$ROOT/packaging/scripts/mount-dmg.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MOUNT_DMG="$SCRIPT_DIR/mount-dmg.sh"
+# Repo dev fallback only (packaging/scripts/ → repo root).
+if [[ ! -x "$MOUNT_DMG" ]]; then
+  repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  if [[ -x "$repo_root/packaging/scripts/mount-dmg.sh" ]]; then
+    MOUNT_DMG="$repo_root/packaging/scripts/mount-dmg.sh"
+  fi
+fi
 
 APP_NAME="llm-swarm-router.app"
 LEGACY_APP_NAME="netllm-mac.app"
@@ -29,10 +40,35 @@ INSTALL_PATH="$DEFAULT_INSTALL"
 DO_LAUNCH=1
 DO_VERIFY=1
 DO_STOP=1
+IN_APP_UPDATE=0
+WAIT_FOR_PID=""
+CACHE_CLEANUP=""
+INSTALL_LOG=""
 
 usage() {
-  sed -n '2,12p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-0}"
+}
+
+log_line() {
+  local line="==> $*"
+  echo "$line"
+  if [[ -n "$INSTALL_LOG" ]]; then
+    mkdir -p "$(dirname "$INSTALL_LOG")"
+    printf '%s\n' "$line" >> "$INSTALL_LOG"
+  fi
+}
+
+install_fail() {
+  local msg="$1"
+  echo "FAIL: $msg" >&2
+  if [[ -n "$INSTALL_LOG" ]]; then
+    printf 'FAIL: %s\n' "$msg" >> "$INSTALL_LOG"
+  fi
+  if [[ "$IN_APP_UPDATE" == 1 ]]; then
+    osascript -e "display alert \"Update install failed\" message \"$msg\" as critical" 2>/dev/null || true
+  fi
+  exit 1
 }
 
 while [[ $# -gt 0 ]]; do
@@ -40,6 +76,10 @@ while [[ $# -gt 0 ]]; do
     --dmg) DMG="$2"; shift 2 ;;
     --source) SOURCE="$2"; shift 2 ;;
     --install-path) INSTALL_PATH="$2"; shift 2 ;;
+    --in-app-update) IN_APP_UPDATE=1; shift ;;
+    --wait-for-pid) WAIT_FOR_PID="$2"; shift 2 ;;
+    --cache-cleanup) CACHE_CLEANUP="$2"; shift 2 ;;
+    --log-file) INSTALL_LOG="$2"; shift 2 ;;
     --no-launch) DO_LAUNCH=0; shift ;;
     --no-verify) DO_VERIFY=0; shift ;;
     --no-stop) DO_STOP=0; shift ;;
@@ -49,10 +89,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$DMG" || -n "$SOURCE" ]] || usage 1
-[[ -z "$DMG" || -z "$SOURCE" ]] || {
-  echo "Use only one of --dmg or --source" >&2
-  exit 1
-}
+[[ -z "$DMG" || -z "$SOURCE" ]] || install_fail "Use only one of --dmg or --source"
 
 agent_listen_port() {
   local config="${HOME}/.config/netllm/config.toml"
@@ -90,6 +127,22 @@ wait_for_exit() {
   return 1
 }
 
+wait_for_pid() {
+  local pid="$1"
+  local seconds="${2:-45}"
+  [[ -n "$pid" ]] || return 0
+  log_line "Waiting for menubar app (pid $pid) to exit"
+  local i
+  for ((i = 0; i < seconds * 2; i++)); do
+    kill -0 "$pid" 2>/dev/null || {
+      log_line "Menubar app exited"
+      return 0
+    }
+    sleep 0.5
+  done
+  install_fail "Menubar app (pid $pid) still running after ${seconds}s"
+}
+
 wait_port_free() {
   local port="$1"
   local seconds="${2:-20}"
@@ -108,32 +161,39 @@ stop_homebrew_agent() {
     return 0
   fi
   if brew services list 2>/dev/null | grep -qE '^netllm[[:space:]]+started'; then
-    echo "==> Stopping Homebrew netllm service (avoids port conflict with menubar app)"
+    log_line "Stopping Homebrew netllm service (avoids port conflict with menubar app)"
     brew services stop netllm 2>/dev/null || true
   fi
 }
 
 stop_menubar_apps() {
-  echo "==> Quitting menubar app (graceful)"
+  log_line "Quitting menubar app (graceful)"
   osascript -e 'tell application "llm-swarm-router" to quit' 2>/dev/null || true
   osascript -e 'tell application "netllm-mac" to quit' 2>/dev/null || true
   wait_for_exit "Contents/MacOS/netllm-mac" 8 || true
+  wait_for_exit "Contents/MacOS/llm-swarm-router" 8 || true
 
-  if pgrep -f "Contents/MacOS/netllm-mac" >/dev/null 2>&1; then
-    echo "==> Sending SIGTERM to remaining menubar processes"
+  if pgrep -f "Contents/MacOS/netllm-mac" >/dev/null 2>&1 \
+    || pgrep -f "Contents/MacOS/llm-swarm-router" >/dev/null 2>&1; then
+    log_line "Sending SIGTERM to remaining menubar processes"
     pkill -TERM -f "Contents/MacOS/netllm-mac" 2>/dev/null || true
+    pkill -TERM -f "Contents/MacOS/llm-swarm-router" 2>/dev/null || true
     wait_for_exit "Contents/MacOS/netllm-mac" 5 || true
+    wait_for_exit "Contents/MacOS/llm-swarm-router" 5 || true
   fi
-  if pgrep -f "Contents/MacOS/netllm-mac" >/dev/null 2>&1; then
-    echo "==> Sending SIGKILL to stubborn menubar processes"
+  if pgrep -f "Contents/MacOS/netllm-mac" >/dev/null 2>&1 \
+    || pgrep -f "Contents/MacOS/llm-swarm-router" >/dev/null 2>&1; then
+    log_line "Sending SIGKILL to stubborn menubar processes"
     pkill -KILL -f "Contents/MacOS/netllm-mac" 2>/dev/null || true
+    pkill -KILL -f "Contents/MacOS/llm-swarm-router" 2>/dev/null || true
     wait_for_exit "Contents/MacOS/netllm-mac" 3 || true
+    wait_for_exit "Contents/MacOS/llm-swarm-router" 3 || true
   fi
 }
 
 stop_orphan_agents() {
   local port="$1"
-  echo "==> Clearing orphaned netllm agents on port $port"
+  log_line "Clearing orphaned netllm agents on port $port"
 
   pkill -TERM -f "Contents/MacOS/netllm-cli.* serve" 2>/dev/null || true
   pkill -TERM -f "netllm_cli\.main.*serve" 2>/dev/null || true
@@ -159,16 +219,30 @@ stop_orphan_agents() {
   if ! wait_port_free "$port" 20; then
     echo "WARN: port $port still in use after cleanup:" >&2
     lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null || true
-    echo "      Stop the process above manually, then re-run this script." >&2
-    exit 1
+    install_fail "Port $port still in use. Stop the process above manually, then retry."
   fi
-  echo "==> Port $port is free"
+  log_line "Port $port is free"
 }
 
 stop_netllm_stack() {
   stop_homebrew_agent
   stop_menubar_apps
   stop_orphan_agents "$(agent_listen_port)"
+}
+
+stop_for_in_app_update() {
+  local port
+  port="$(agent_listen_port)"
+  stop_homebrew_agent
+  stop_orphan_agents "$port"
+  wait_for_pid "$WAIT_FOR_PID" 45
+}
+
+cleanup_update_cache() {
+  [[ -n "$CACHE_CLEANUP" ]] || return 0
+  [[ -d "$CACHE_CLEANUP" ]] || return 0
+  log_line "Removing update cache at $CACHE_CLEANUP"
+  rm -f "$CACHE_CLEANUP"/*.dmg "$CACHE_CLEANUP"/*.download 2>/dev/null || true
 }
 
 verify_bundle_contents() {
@@ -178,16 +252,9 @@ verify_bundle_contents() {
   local version
   version="$(defaults read "$app/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo unknown)"
 
-  [[ -d "$app" ]] || {
-    echo "FAIL: install path missing: $app" >&2
-    exit 1
-  }
-  [[ -f "$index" ]] || {
-    echo "FAIL: dashboard static files missing in bundle (expected $index)" >&2
-    echo "      This build cannot serve /ui/ — rebuild or use a newer release DMG." >&2
-    exit 1
-  }
-  echo "==> Installed app version $version with web dashboard static assets"
+  [[ -d "$app" ]] || install_fail "install path missing: $app"
+  [[ -f "$index" ]] || install_fail "dashboard static files missing in bundle (expected $index)"
+  log_line "Installed app version $version with web dashboard static assets"
 }
 
 verify_agent_endpoints() {
@@ -195,58 +262,42 @@ verify_agent_endpoints() {
   local base="http://127.0.0.1:${port}"
   local i code
 
-  echo "==> Waiting for agent on $base"
+  log_line "Waiting for agent on $base"
   for ((i = 0; i < 40; i++)); do
     if curl -sf "${base}/health" >/dev/null 2>&1; then
       break
     fi
     sleep 0.5
   done
-  curl -sf "${base}/health" >/dev/null || {
-    echo "FAIL: agent not healthy at ${base}/health after launch" >&2
-    echo "      Open the menubar app and choose Start Agent, or check logs in Settings." >&2
-    exit 1
-  }
+  curl -sf "${base}/health" >/dev/null || install_fail "agent not healthy at ${base}/health after launch"
 
   if ! curl -sf "${base}/" | grep -q '"dashboard"'; then
-    echo "FAIL: agent on $port is too old (root JSON lacks dashboard field)" >&2
-    echo "      Another netllm process may still own the port — re-run without --no-stop." >&2
-    exit 1
+    install_fail "agent on $port is too old (root JSON lacks dashboard field)"
   fi
 
   code="$(curl -s -o /dev/null -w "%{http_code}" "${base}/ui/")"
-  [[ "$code" == "200" ]] || {
-    echo "FAIL: GET ${base}/ui/ returned HTTP $code (expected 200)" >&2
-    exit 1
-  }
-  echo "==> Verified ${base}/ui/ (HTTP 200)"
+  [[ "$code" == "200" ]] || install_fail "GET ${base}/ui/ returned HTTP $code (expected 200)"
+  log_line "Verified ${base}/ui/ (HTTP 200)"
 }
 
-# Global set by resolve_source_app; trap registered in main script scope so
-# $DMG_MOUNT is in scope when the EXIT trap fires (avoids "unbound variable"
-# from local vars going out of scope after a $() subshell returns).
 DMG_MOUNT=""
 SOURCE_APP=""
 
 resolve_source_app() {
   if [[ -n "$SOURCE" ]]; then
-    [[ -d "$SOURCE" ]] || {
-      echo "Source app not found: $SOURCE" >&2
-      exit 1
-    }
+    [[ -d "$SOURCE" ]] || install_fail "Source app not found: $SOURCE"
     SOURCE_APP="$SOURCE"
     return 0
   fi
 
-  [[ -f "$DMG" ]] || {
-    echo "DMG not found: $DMG" >&2
-    exit 1
-  }
+  [[ -f "$DMG" ]] || install_fail "DMG not found: $DMG"
+  if [[ ! -x "$MOUNT_DMG" ]]; then
+    install_fail "mount-dmg.sh not found next to this script ($SCRIPT_DIR). Mount the DMG manually and pass --source /Volumes/.../llm-swarm-router.app"
+  fi
 
-  echo "==> Mounting DMG"
+  log_line "Mounting DMG"
   if ! DMG_MOUNT="$("$MOUNT_DMG" "$DMG")"; then
-    echo "Failed to mount DMG: $DMG" >&2
-    exit 1
+    install_fail "Failed to mount DMG: $DMG"
   fi
 
   local source="$DMG_MOUNT/$APP_NAME"
@@ -254,38 +305,42 @@ resolve_source_app() {
   [[ -d "$source" ]] || {
     echo "App not found on DMG volume ($DMG_MOUNT). Contents:" >&2
     ls -la "$DMG_MOUNT" >&2 || true
-    exit 1
+    install_fail "App bundle not found on mounted DMG"
   }
   SOURCE_APP="$source"
 }
 
 if [[ "$DO_STOP" == 1 ]]; then
-  stop_netllm_stack
+  if [[ "$IN_APP_UPDATE" == 1 ]]; then
+    stop_for_in_app_update
+  else
+    stop_netllm_stack
+  fi
 else
   echo "WARN: --no-stop set; stale processes may cause /ui/ 404 after install" >&2
 fi
 
 resolve_source_app
-# Trap registered here in main script scope so $DMG_MOUNT is always in scope.
 [[ -z "$DMG_MOUNT" ]] || trap 'hdiutil detach "$DMG_MOUNT" -quiet 2>/dev/null || true' EXIT
 
 if [[ -d "$LEGACY_INSTALL" && "$INSTALL_PATH" != "$LEGACY_INSTALL" ]]; then
-  echo "==> Removing legacy /Applications install ($LEGACY_APP_NAME)"
+  log_line "Removing legacy /Applications install ($LEGACY_APP_NAME)"
   rm -rf "$LEGACY_INSTALL"
 fi
 if [[ -d "$INSTALL_PATH" ]]; then
-  echo "==> Replacing $INSTALL_PATH"
+  log_line "Replacing $INSTALL_PATH"
   rm -rf "$INSTALL_PATH"
 fi
 
-echo "==> Copying app to $INSTALL_PATH"
+log_line "Copying app to $INSTALL_PATH"
 ditto "$SOURCE_APP" "$INSTALL_PATH"
 xattr -dr com.apple.quarantine "$INSTALL_PATH" 2>/dev/null || true
 
 verify_bundle_contents "$INSTALL_PATH"
+cleanup_update_cache
 
 if [[ "$DO_LAUNCH" == 1 ]]; then
-  echo "==> Launching $INSTALL_PATH"
+  log_line "Launching $INSTALL_PATH"
   open -a "$INSTALL_PATH"
   if [[ "$DO_VERIFY" == 1 ]]; then
     verify_agent_endpoints "$(agent_listen_port)"

--- a/scripts/test-menubar-e2e.sh
+++ b/scripts/test-menubar-e2e.sh
@@ -28,6 +28,10 @@ trap cleanup EXIT
 echo "==> brand icons"
 bash "$ROOT/scripts/test-brand-icons.sh"
 
+echo "==> bundled install scripts (mount-dmg path, in-app flags)"
+bash "$ROOT/tests/test_bundled_install_scripts.sh"
+bash "$ROOT/tests/test_macos_app_install_flags.sh"
+
 echo "==> bundled CLI version"
 VER="$("$CLI" --version 2>/dev/null | tail -1)"
 [[ "$VER" == netllm\ * ]] || fail "unexpected version: $VER"

--- a/tests/test_bundled_install_scripts.sh
+++ b/tests/test_bundled_install_scripts.sh
@@ -20,7 +20,15 @@ fi
   exit 1
 }
 
-# Simulate in-app resolution without running install.
+if grep -q 'Contents/packaging/scripts/mount-dmg.sh' "$SCRIPTS/macos-app-install.sh"; then
+  echo "FAIL: bundled macos-app-install.sh still uses broken Contents/packaging mount path" >&2
+  exit 1
+fi
+if ! grep -q 'MOUNT_DMG="$SCRIPT_DIR/mount-dmg.sh"' "$SCRIPTS/macos-app-install.sh"; then
+  echo "FAIL: bundled macos-app-install.sh must set MOUNT_DMG from SCRIPT_DIR" >&2
+  exit 1
+fi
+
 resolved="$(
   SCRIPT_DIR="$SCRIPTS" bash -c '
     if [[ -x "$SCRIPT_DIR/mount-dmg.sh" ]]; then

--- a/tests/test_macos_app_install_flags.sh
+++ b/tests/test_macos_app_install_flags.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Verify macos-app-install.sh accepts in-app update flags and rejects unknown options.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/packaging/scripts/macos-app-install.sh"
+
+[[ -x "$SCRIPT" ]] || {
+  echo "FAIL: macos-app-install.sh missing" >&2
+  exit 1
+}
+
+"$SCRIPT" --help >/dev/null
+
+grep -q -- '--in-app-update' "$SCRIPT" || {
+  echo "FAIL: macos-app-install.sh missing --in-app-update flag" >&2
+  exit 1
+}
+grep -q -- '--wait-for-pid' "$SCRIPT" || {
+  echo "FAIL: macos-app-install.sh missing --wait-for-pid flag" >&2
+  exit 1
+}
+
+if "$SCRIPT" --not-a-real-flag 2>/dev/null; then
+  echo "FAIL: unknown option should exit non-zero" >&2
+  exit 1
+fi
+
+# Co-located mount helper (bundled app layout).
+STAGE="$ROOT/apps/netllm-mac/build/Stage/llm-swarm-router.app/Contents/Resources/Scripts"
+if [[ -d "$STAGE" ]]; then
+  [[ -x "$STAGE/mount-dmg.sh" ]] || {
+    echo "FAIL: bundled mount-dmg.sh missing" >&2
+    exit 1
+  }
+fi
+
+echo "OK: macos-app-install.sh accepts documented flags"


### PR DESCRIPTION
## Summary

- Fix bundled `macos-app-install.sh` to use co-located `mount-dmg.sh` (resolves the `Contents/packaging/…` path failure on installed apps)
- Implement `--in-app-update`, `--wait-for-pid`, `--cache-cleanup`, and `--log-file` flags that `UpdateController` already passes
- Promote verified cached DMGs to **Install Update** on launch regardless of download UI state
- Show alerts for manual **Check for Updates** (up to date, available, ready, network failure)
- Stop injecting broken `PYTHONHOME` when bundled Python is missing or `NETLLM_BUNDLE_PATH` is invalid
- Gate release e2e on installer script smoke tests (`test_bundled_install_scripts.sh`, `test_macos_app_install_flags.sh`)

## Local validation

- `./tests/test_macos_app_install_flags.sh` — pass
- `./tests/test_bundled_install_scripts.sh` — pass (after `build.sh release`)
- `scripts/test-menubar-e2e.sh` — pass (includes new install gates)
- `./scripts/ci.sh test` — 144 passed
- `scripts/test-menubar-lifecycle.sh` — L1 timed out locally (agent stuck in `starting`; unrelated to this diff)

## Test plan

- [ ] CI macOS release job green
- [ ] Install from cached DMG via menubar **Install Update** on Mac Mini
- [ ] `macos-app-install.sh --dmg …` works from `/Applications/llm-swarm-router.app/Contents/Resources/Scripts/`