### PR TITLE
chore(homebrew): bump formula to v0.3.0.1

### DIFF
--- a/Formula/netllm.rb
+++ b/Formula/netllm.rb
@@ -3,8 +3,8 @@ class Netllm < Formula
 
   desc "Mesh router for local LLM backends — swarm agents with OpenAI/Anthropic gateway"
   homepage "https://github.com/matthewdcage/llm-swarm-router"
-  url "https://github.com/matthewdcage/llm-swarm-router/archive/refs/tags/v0.2.3.3.tar.gz"
-  sha256 "55adb0a44f7215b03dd28cf34e929c420f42ba0ff919d61a9e595ff118070027"
+  url "https://github.com/matthewdcage/llm-swarm-router/archive/refs/tags/v0.3.0.1.tar.gz"
+  sha256 "a1c3a86db7da3f77aad5aaa488d9e2be5fea0c6fc08a319a11db6f9b2dce8462"
   license "MIT"
   head "https://github.com/matthewdcage/llm-swarm-router.git", branch: "main"
 


### PR DESCRIPTION
Bring `Formula/netllm.rb` up to the latest release (v0.3.0.1).

Automated bump from the release workflow branch; main was still pinned to v0.2.3.3.