### PR TITLE
fix(macos): v0.3.0.2 menubar agent start on LAN listen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,22 @@ jobs:
         run: brew install ripgrep
       - run: bash scripts/test-menubar-e2e.sh
       - run: bash scripts/test-menubar-lifecycle.sh
+      - name: Import Developer ID certificate
+        env:
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: bash packaging/scripts/import-codesign-cert.sh
+      - name: Sign app bundle (Developer ID)
+        if: env.CODESIGN_IDENTITY != ''
+        run: bash packaging/scripts/codesign-mac-app.sh apps/netllm-mac/build/Stage/llm-swarm-router.app
       - run: bash packaging/scripts/create-dmg.sh
+      - name: Notarize and staple DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: bash packaging/scripts/maybe-notarize-dmg.sh dist/llm-swarm-router.dmg
       - run: chmod +x packaging/scripts/write-sha256-sidecar.sh
       - run: |
           packaging/scripts/write-sha256-sidecar.sh dist/llm-swarm-router.dmg | tee dist/SHA256SUMS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 # Agent & developer guide
 
+## DOX rail
+
+Full protocol: [`.cursor/agents/AGENTS.md`](.cursor/agents/AGENTS.md).
+
+- Before editing: walk root → target path; read every `AGENTS.md` on the route (nearest doc controls local detail)
+- After meaningful edits: update the closest owning `AGENTS.md`; refresh Child DOX Index when boundaries change
+- Child docs must not weaken parent DOX
+
 ## Project overview
 
 **swarm-llm (netllm)** is a mesh router for local LLM backends. Each host runs a lightweight agent that discovers oMLX (macOS), Ollama, LM Studio, and vLLM on localhost, finds sibling agents on the LAN via mDNS, and exposes dual API surfaces: OpenAI-compatible `http://<host>:11400/v1` and Anthropic Messages API `http://<host>:11400/v1/messages` (with translation to local backends).
@@ -21,16 +29,18 @@ Honcho integration: [docs/honcho-integration.md](docs/honcho-integration.md).
 
 ## Repository layout
 
-| Path | Purpose |
-|------|---------|
-| `packages/` | Python source of truth (uv workspace) |
-| `apps/` | Native apps: macOS menubar today (`apps/netllm-mac/`) |
-| `packaging/` | Release builds per OS: [packaging/README.md](packaging/README.md) |
-| `docs/` | User install/troubleshoot/editor guides: [docs/README.md](docs/README.md) |
-| `tests/` | Cross-package integration tests |
-| `scripts/` | CI, skill sync, install emulation |
-| `Formula/` | Homebrew formula |
-| `.agents/skills/` | Canonical agent skills → sync via `scripts/sync-agent-skills.sh` to `.claude/`, `.cursor/`, `.github/` |
+| Path | Purpose | DOX |
+|------|---------|-----|
+| `packages/` | Python source of truth (uv workspace) | [packages/AGENTS.md](packages/AGENTS.md) |
+| `apps/` | Native apps: macOS menubar today (`apps/netllm-mac/`) | [apps/AGENTS.md](apps/AGENTS.md) |
+| `packaging/` | Release builds per OS: [packaging/README.md](packaging/README.md) | [packaging/AGENTS.md](packaging/AGENTS.md) |
+| `docs/` | User install/troubleshoot/editor guides: [docs/README.md](docs/README.md) | [docs/AGENTS.md](docs/AGENTS.md) |
+| `tests/` | Cross-package integration tests | [tests/AGENTS.md](tests/AGENTS.md) |
+| `scripts/` | CI, skill sync, install emulation | (root rail) |
+| `Formula/` | Homebrew formula | (root rail) |
+| `archived/` | Local deprecated/moved files (gitignored; not on remote) | (root rail) |
+| `.agents/skills/` | Canonical agent skills → sync via `scripts/sync-agent-skills.sh` | [.agents/AGENTS.md](.agents/AGENTS.md) |
+| `.cursor/agents/` | DOX protocol + tracked Cursor coordinator subagents | [.cursor/agents/AGENTS.md](.cursor/agents/AGENTS.md) |
 
 Edit skills only under `.agents/`; run `scripts/sync-agent-skills.sh` after changes.
 
@@ -158,13 +168,13 @@ Editor wiring reference: [docs/editor-integration.md](docs/editor-integration.md
 Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow, issue templates, and review expectations.
 
 - Conventional commit messages; focus on why
-- Do not commit `.cursor/plans/`, `.cursor/outreach/`, `.cursor/hooks/`, `.cursor/mcp.json`, `.cursor/rules/graphify.mdc`, or secrets
+- Do not commit `.cursor/plans/`, `.cursor/outreach/`, `.cursor/hooks/`, `.cursor/mcp.json`, `.cursor/rules/graphify.mdc`, `archived/`, or secrets
 - Do not commit unless the user explicitly asks (agents); human contributors open PRs per CONTRIBUTING.md
 
 ## Do not
 
 - Edit user `.env` files or replace keys/values unless explicitly directed
-- Delete files: move to `archived/` and log the action (project convention)
+- Delete files: move to local `archived/` and log in `archived/ARCHIVE_LOG.txt` (gitignored; never commit)
 - Commit secrets, API keys, or real credentials
 - Assume `netllm` is on PATH: prefer `./netllm` from repo root in instructions
 - Skip `./netllm doctor` before declaring setup complete
@@ -174,10 +184,17 @@ Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow,
 ## Learned User Preferences
 
 - Validate macOS updater/install fixes locally (`tests/test_bundled_install_scripts.sh`, `scripts/test-menubar-e2e.sh`) before release commits or tags
-- Run `./scripts/verify-before-pr.sh` (or `--full` with menubar e2e) before pushing macOS menubar PRs
+- Run `./scripts/verify-before-pr.sh` (or `--full` with menubar e2e) before pushing macOS menubar PRs; after editing `design-tokens.json`, run `scripts/generate-dashboard-tokens.py` (CI enforces via `--check`)
 - macOS in-app update must stop the agent and free `:11400` as part of install — not require manual **Stop** first
 - Commit macOS update/install fixes as focused slices separate from unrelated feature work when possible
 - Run local agent smoke (`./netllm test`, menubar e2e) before PR, merge, and release
+- Never auto-post GitHub comments, discussion replies, or community posts — draft only unless the user explicitly says post/ship/submit
+- User submits outreach manually (headed browser with logged-in profile; Reddit as u/dreamsofsoaring via `reddit` CDP `:9224`; GitHub/forums as matthew@hydradigital.com.au / @matthewdcage via `work` CDP `:9223`; awesome-list PRs via `gh pr create` with OAuth, not `GITHUB_TOKEN` PAT)
+- Reply-first on live community threads before new posts; defer Show HN until reply traction (not same week as DevHunt)
+- Coordinator agents monitor Reddit and GitHub inbound and draft follow-ups (harvest → monitor → draft); user posts manually — not one-off "watch manually" reminders
+- No em dashes in coordinator drafts, briefs, and community replies (`.cursor/coordinator/voice.md`)
+- Qualify ~7× throughput as aggregate parallel load across machines, not single-chat speed (same framing as oMLX #1762)
+- No star asks or star emoji in community posts after reply-first credibility is earned
 
 ## Learned Workspace Facts
 
@@ -188,10 +205,30 @@ Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow,
 - mDNS (swarm discovery) requires zeroconf from `uv sync`; `serve` on loopback blocks LAN peers — use `--host 0.0.0.0` for swarm; set `swarm.cluster_token` on untrusted networks
 - Do not run the macOS menubar app and `./netllm serve` together; both bind `:11400`. Before quitting the app, use **Stop** so the agent subprocess exits; otherwise an orphan can hold `:11400` and block the next launch.
 - oMLX discovery probes `:8080` by default; backends on other ports need `[discovery].custom_endpoints` or `[[routing.backends]]` in `~/.config/netllm/config.toml`.
-- macOS in-app auto-update notifies only when the latest GitHub release includes a `llm-swarm-router.dmg` asset; logs under `~/Library/Application Support/netllm/logs/` (`update.log`, `install.log`, `app.log`)
-- Release tag must match root `pyproject.toml` version; bump all workspace packages + `uv lock` before `gh release create`. **v0.3.0.1** patches URLSession download staging (`CFNetworkDownload_*.tmp`); **v0.3.0.0** shipped Phase 1–2 Apple AI work (App Intents, MenuBarExtra, routing policies)
-- Repo checkout changes do **not** update `/Applications/llm-swarm-router.app` — install from GitHub DMG or `scripts/upgrade-mac-app.sh`; verify with `defaults read …/Info CFBundleShortVersionString` (don't assume `~/Downloads/llm-swarm-router.dmg` is latest)
-- Bundled `macos-app-install.sh` resolves co-located `Contents/Resources/Scripts/mount-dmg.sh` (not `Contents/packaging/…`); in-app update uses `--in-app-update` to stop agent and replace the bundle
-- Gate macOS menubar changes with `scripts/verify-before-pr.sh` and bundled install tests in `test-menubar-e2e.sh`; after editing `design-tokens.json`, run `scripts/generate-dashboard-tokens.py` (CI enforces via `--check`)
+- macOS menubar install/update: repo checkout does not update `/Applications/llm-swarm-router.app` — use GitHub DMG, menubar **Updates**, or bundled `macos-app-install.sh` (`/Applications/llm-swarm-router.app/Contents/Resources/Scripts/` or mounted DMG); `scripts/upgrade-mac-app.sh` is repo-only; in-app update stops agent via `--in-app-update`, logs under `~/Library/Application Support/netllm/logs/`; release notes must not lead with `./scripts/` alone ([docs/release-notes/v0.3.0.1.md](docs/release-notes/v0.3.0.1.md))
+- **macOS Gatekeeper (26+):** GitHub ad-hoc DMGs fail launch (`no usable signature`); notarized Developer ID releases required — [docs/macos-code-signing.md](docs/macos-code-signing.md). CI secrets: `MACOS_CERTIFICATE_P12`, `MACOS_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPLE_ID`, `APPLE_TEAM_ID`, `APPLE_APP_SPECIFIC_PASSWORD`. Local maintainer path: `packaging/scripts/local-notarized-dmg.sh`
+- Release tag must match root `pyproject.toml` version; bump all workspace packages + `uv lock` before `gh release create`
+- `.cursor/coordinator/` is gitignored local PR overseer (state, drafts, scripts); orchestration via six tracked **Cursor subagents** in `.cursor/agents/coordinator-*.md` (incl. **prospector**) — [`.cursor/coordinator/AGENTS.md`](.cursor/coordinator/AGENTS.md); run `run-coordinator-pass.sh` + `test-coordinator-loop.sh` before paste work; `test-discovery.sh` for offline discover-all smoke
+- `.cursor/outreach/` is gitignored local outreach research/drafts; paste-ready convention: **Target:** / **Title:** / body after `---` (plain markdown, no YAML); neither tree belongs in the remote repo
+- Prefer posted voice examples in `.cursor/coordinator/examples/` (`examples/index.json`) over generic `voice.md` when drafting community replies
+- Stagehand fork for browser automation lives outside this repo (maintainer-local path in `.cursor/coordinator/state/browser-profiles.json`; example checkout: `/path/to/agent-stagehand-browser-agent`); coordinator resolves it via `browse-env.sh`; `browse` CLI via `npm link` in that repo's `packages/cli`
+- Reddit automation login persists under `~/.cursor/chrome-automation/reddit/Default/` (Chrome user-data-dir layout); seed with `browser-seed-profile.sh reddit --force`, verify with `verify-reddit-session.sh --apply` — daily Profile 5 login alone does not wire through unless seeded
+- Work automation login (matthew@hydradigital.com.au / GitHub @matthewdcage) persists under `~/.cursor/chrome-automation/work/Default/`; seed with `browser-seed-profile.sh work --force`, login with `browser-login-work.sh`, verify with `verify-work-session.sh --apply` — daily Default profile login alone does not wire through unless seeded
+- Headed outreach: **browse CLI** primary; `browser-ensure-up.sh` → `browse-session-lifecycle.sh ensure` (Chrome preserved, `state/browse-session-registry.json`); after manual Post run `clear-pending`; `test-coordinator-loop.sh` **config-only by default** (`BROWSE_E2E_LIVE=1` for live paste prep; `BROWSE_E2E_SMOKE=1` optional example.com); coordinator subagents can run **in parallel** when profiles differ (reddit `:9224` vs work `:9223`); **`stagehand-local` MCP fallback only** when browse refs fail
+- Outreach prospector: weekly Monday pass via `coordinator-prospector` + `discover-all.sh` + `qualify-prospector-candidates.sh` (live HTTP before approval); **Recommend approve** only when `state/prospector-qualification.json` shows `ok` + `live_checked` for reddit/HN; promote with `promote-candidates.sh --apply-approved` only after Matthew approves summary rows; then draft replies from `examples/index.json` before browser paste prep
+- HN reply-first: `HN_MAX_AGE_DAYS` default **14** (Algolia discovery window matches); bare **Sorry.** on item page = comment closed; dead ids in `.cursor/coordinator/state/hn-dead-threads.json`. Reddit: `REDDIT_MAX_AGE_DAYS` default 365 for new discovery; deleted threads in `reddit-dead-threads.json`
 
-Updated: 2026-06-09
+## Child DOX Index
+
+| Path | Contract |
+|------|----------|
+| [`packages/AGENTS.md`](packages/AGENTS.md) | Python uv workspace (6 packages) |
+| [`apps/AGENTS.md`](apps/AGENTS.md) | Native platform apps |
+| [`docs/AGENTS.md`](docs/AGENTS.md) | User-facing guides and release notes |
+| [`packaging/AGENTS.md`](packaging/AGENTS.md) | Cross-platform release builds |
+| [`tests/AGENTS.md`](tests/AGENTS.md) | Cross-package integration tests |
+| [`.agents/AGENTS.md`](.agents/AGENTS.md) | Canonical agent skills (sync to tool paths) |
+| [`.cursor/agents/AGENTS.md`](.cursor/agents/AGENTS.md) | DOX protocol + coordinator subagent index |
+| [`.cursor/coordinator/AGENTS.md`](.cursor/coordinator/AGENTS.md) | Local PR coordinator (gitignored): scripts, state, browse-first stack |
+
+Updated: 2026-06-10 (macOS Developer ID signing/notarization; Gatekeeper on macOS 26+)

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -1,0 +1,35 @@
+# apps — native platform applications
+
+## Purpose
+
+Native shells around the shared Python agent. Today: macOS menubar (`netllm-mac`). Linux/Windows use packaged agent + web dashboard at `/ui/` (no native app yet).
+
+## Ownership
+
+Parent rail: [../AGENTS.md](../AGENTS.md). Release builds: [../packaging/AGENTS.md](../packaging/AGENTS.md).
+
+## Local Contracts
+
+- Native apps supervise the same agent core on `:11400`; never run menubar app and `./netllm serve` concurrently
+- macOS in-app install/update only from `/Applications/llm-swarm-router.app` or staged `netllm-mac.app`
+- macOS release DMGs require Developer ID notarization for Gatekeeper on macOS 26+ ([../docs/macos-code-signing.md](../docs/macos-code-signing.md))
+- Design tokens shared with agent dashboard via `design-tokens.json` + `scripts/generate-dashboard-tokens.py`
+
+## Work Guidance
+
+- Platform-specific install/update logic stays in app + packaging scripts, not duplicated in Python agent
+- macOS PRs touching this tree trigger `menubar-lifecycle` CI on `macos-14`
+
+## Verification
+
+```bash
+scripts/verify-before-pr.sh          # macOS Swift build
+scripts/verify-before-pr.sh --full   # + menubar e2e when Stage .app exists
+scripts/test-menubar-e2e.sh
+```
+
+## Child DOX Index
+
+| Path | Contract |
+|------|----------|
+| [`netllm-mac/AGENTS.md`](netllm-mac/AGENTS.md) | Swift menubar app |

--- a/apps/netllm-mac/AGENTS.md
+++ b/apps/netllm-mac/AGENTS.md
@@ -1,0 +1,51 @@
+# netllm-mac — macOS menubar app
+
+Parent: [../AGENTS.md](../AGENTS.md).
+
+## Purpose
+
+Swift menubar application that supervises the netllm Python agent, exposes settings/welcome/updater UI, and embeds venvstacks Python layers from packaging export.
+
+## Ownership
+
+| Path | Role |
+|------|------|
+| `Sources/App/` | Entry, delegate, lifecycle |
+| `Sources/Menubar/` | Status item, stats polling |
+| `Sources/Server/` | Process supervisor, control socket |
+| `Sources/Config/` | TOML slices, CLI shim, branding, tokens |
+| `Sources/AppView/` | Settings, welcome, about, glass chrome |
+| `Sources/Updater/` | GitHub Releases check, in-app install |
+| `Sources/Welcome/` | First-run wizard |
+| `Scripts/build.sh` | Release/stage build (venvstacks + Swift); ad-hoc sign unless `CODESIGN_IDENTITY` set |
+| `design-tokens.json` | Dashboard token source (sync via `scripts/generate-dashboard-tokens.py`) |
+
+## Local Contracts
+
+- `Package.swift`: swift-tools **5.9** (CI runs Swift 5.10 on macos-14)
+- SwiftUI views: `@MainActor`; gate Tahoe `glassEffect` behind `LIQUID_GLASS_SDK` in `build.sh`
+- In-app update must stop agent and free `:11400` — no manual **Stop** required first
+- Repo checkout does not update `/Applications/llm-swarm-router.app`; user upgrade: menubar **Updates** or bundled `macos-app-install.sh` (embedded under `Contents/Resources/Scripts/`); `scripts/upgrade-mac-app.sh` is repo-maintainer wrapper only
+- Logs: `~/Library/Application Support/netllm/logs/`
+- **Gatekeeper:** ad-hoc Stage/DMG builds do not launch on macOS 26+; release path is Developer ID + notarize via [packaging/scripts/local-notarized-dmg.sh](../../packaging/scripts/local-notarized-dmg.sh) or CI ([macos-code-signing.md](../../docs/macos-code-signing.md))
+
+## Work Guidance
+
+- Build: `uv sync`, `uv pip install venvstacks`, `apps/netllm-mac/Scripts/build.sh release`
+- Validate updater/install with `tests/test_bundled_install_scripts.sh` before release tags
+- Commit macOS install/update fixes as focused slices separate from unrelated work
+
+## Verification
+
+```bash
+apps/netllm-mac/Scripts/build.sh release
+scripts/verify-before-pr.sh
+scripts/test-menubar-e2e.sh
+tests/test_bundled_install_scripts.sh
+```
+
+User docs: [../../docs/macos-install.md](../../docs/macos-install.md), [../../docs/macos-troubleshooting.md](../../docs/macos-troubleshooting.md).
+
+## Child DOX Index
+
+None — Swift sources grouped under `Sources/` by concern; no nested AGENTS.md until a subtree gains independent release or ownership.

--- a/apps/netllm-mac/Scripts/build.sh
+++ b/apps/netllm-mac/Scripts/build.sh
@@ -159,11 +159,15 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
-# Ad-hoc sign embedded Mach-O + bundle
+# Sign embedded Mach-O + bundle (Developer ID when CODESIGN_IDENTITY is set, else ad-hoc)
 echo "==> Codesigning"
-find "$APP" -type f \( -name '*.dylib' -o -name '*.so' -o -perm -111 \) -print0 2>/dev/null | \
-  while IFS= read -r -d '' f; do codesign -f -s - "$f" 2>/dev/null || true; done
-codesign -f -s - "$APP" 2>/dev/null || true
+if [[ -n "${CODESIGN_IDENTITY:-}" ]]; then
+  bash "$ROOT/packaging/scripts/codesign-mac-app.sh" "$APP"
+else
+  find "$APP" -type f \( -name '*.dylib' -o -name '*.so' -o -perm -111 \) -print0 2>/dev/null | \
+    while IFS= read -r -d '' f; do codesign -f -s - "$f" 2>/dev/null || true; done
+  codesign -f -s - "$APP" 2>/dev/null || true
+fi
 xattr -dr com.apple.quarantine "$APP" 2>/dev/null || true
 
 echo "==> Staged: $APP"

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,51 @@
+# docs — user and developer documentation
+
+## Purpose
+
+User-facing install, troubleshoot, editor wiring, platform matrix, CI/release, and SDK version guides. Index: [README.md](README.md).
+
+## Ownership
+
+| Area | Key files |
+|------|-----------|
+| Platform install | `macos-install.md`, `linux-install.md`, `windows-install.md` |
+| Troubleshooting | `macos-troubleshooting.md`, `linux-troubleshooting.md`, `windows-troubleshooting.md` |
+| Cross-platform | `platform-matrix.md`, `editor-integration.md`, `honcho-integration.md` |
+| macOS signing | `macos-code-signing.md` |
+| Release / CI | `ci-and-release.md`, `release-notes/` |
+| Learnings | `solutions/` |
+| SDK maintenance | `sdk-versions.md` |
+
+Parent rail: [../AGENTS.md](../AGENTS.md).
+
+## Local Contracts
+
+- User docs stay plain and actionable; agent commands use `./netllm` from repo root
+- Release tag must match root `pyproject.toml` version
+- Do not commit `.cursor/plans/`, `.cursor/outreach/`, or coordinator drafts here
+- User-facing command examples use placeholders (`/path/to/llm-swarm-router`, `~/Downloads/…`); never maintainer machine paths (`/Volumes/…`, named dev hardware)
+- **macOS Gatekeeper (macOS 26+):** ad-hoc GitHub DMGs are rejected at launch (`no usable signature`); terminal `macos-app-install.sh` copies the bundle but does not bypass Gatekeeper — notarized Developer ID DMG required ([macos-code-signing.md](macos-code-signing.md), [macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch))
+- **macOS DMG upgrade (users):** menubar **Updates**, then bundled `Contents/Resources/Scripts/macos-app-install.sh` (from `/Applications/…` or mounted DMG at `/Volumes/llm-swarm-router/…`). `./scripts/upgrade-mac-app.sh` is **repo-checkout only** — never the sole path in release notes or install guides
+- **Release notes:** macOS install order documented in [ci-and-release.md](ci-and-release.md); canonical example [release-notes/v0.3.0.1.md](release-notes/v0.3.0.1.md)
+
+## Work Guidance
+
+- New platform behavior: update install + troubleshooting + platform-matrix together
+- SDK bumps: update `sdk-versions.md` in same PR as package dep change
+- Release notes go under `release-notes/` with version in filename; macOS blocks follow v0.3.0.1 pattern (in-app → bundled installer → optional repo script)
+- macOS signing/notarization changes: update `macos-code-signing.md`, `ci-and-release.md`, and install/troubleshooting Gatekeeper sections together
+
+## Verification
+
+- Links resolve from README index
+- Command snippets match current CLI (`./netllm doctor`, etc.)
+- macOS upgrade snippets do not assume a git clone unless labeled “repo checkout”
+
+## Child DOX Index
+
+| Path | Contract |
+|------|----------|
+| [`release-notes/`](release-notes/) | Versioned release notes (no AGENTS.md — filenames are the index) |
+| [`solutions/`](solutions/) | Durable QA and workflow learnings |
+
+Nested folders are content collections; add child AGENTS.md only if a subtree gains its own release or editorial workflow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,18 +33,20 @@ Overview: [platform-matrix.md](platform-matrix.md)
 | Topic | Doc |
 |-------|-----|
 | CI, macOS build, release | [ci-and-release.md](ci-and-release.md) |
+| macOS Developer ID + notarization | [macos-code-signing.md](macos-code-signing.md) |
 | Pre-push verification | `scripts/verify-before-pr.sh` from repo root |
+| DOX hierarchy (agents) | [AGENTS.md](../AGENTS.md) Child DOX Index; [`.cursor/agents/AGENTS.md`](../.cursor/agents/AGENTS.md) protocol |
 
 ## Repository map
 
-| Path | Purpose |
-|------|---------|
-| [`packages/`](../packages/) | Python source of truth (uv workspace) |
-| [`apps/`](../apps/) | Native apps: macOS menubar today (`apps/netllm-mac/`) |
-| [`packaging/`](../packaging/) | Release builds per OS: [packaging/README.md](../packaging/README.md) |
-| [`docs/`](.) | Install, troubleshoot, and editor guides (this folder) |
-| [`tests/`](../tests/) | Cross-package integration tests |
-| [`scripts/`](../scripts/) | CI, skill sync, install emulation |
-| [`.agents/skills/`](../.agents/skills/) | Canonical agent skills (sync to `.claude/`, `.cursor/`, `.github/`) |
+| Path | Purpose | DOX |
+|------|---------|-----|
+| [`packages/`](../packages/) | Python source of truth (uv workspace) | [packages/AGENTS.md](../packages/AGENTS.md) |
+| [`apps/`](../apps/) | Native apps: macOS menubar today (`apps/netllm-mac/`) | [apps/AGENTS.md](../apps/AGENTS.md) |
+| [`packaging/`](../packaging/) | Release builds per OS: [packaging/README.md](../packaging/README.md) | [packaging/AGENTS.md](../packaging/AGENTS.md) |
+| [`docs/`](.) | Install, troubleshoot, and editor guides (this folder) | [docs/AGENTS.md](AGENTS.md) |
+| [`tests/`](../tests/) | Cross-package integration tests | [tests/AGENTS.md](../tests/AGENTS.md) |
+| [`scripts/`](../scripts/) | CI, skill sync, install emulation | (root [AGENTS.md](../AGENTS.md)) |
+| [`.agents/skills/`](../.agents/skills/) | Canonical agent skills (sync to tool paths) | [.agents/AGENTS.md](../.agents/AGENTS.md) |
 
 Architecture (packages, commands, env): [AGENTS.md](../AGENTS.md). Contributing: [CONTRIBUTING.md](../CONTRIBUTING.md). Help routing: [SUPPORT.md](../SUPPORT.md).

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -70,7 +70,11 @@ Triggered by publishing a GitHub Release whose tag matches `pyproject.toml` (e.g
 5. `git push origin main`
 6. `gh release create vX.Y.Z --title "..." --notes-file docs/release-notes/vX.Y.Z.md`
 
+**macOS upgrade text in release notes:** prefer menubar **Updates**, then the bundled `macos-app-install.sh` path (no git clone), then optional `cd /path/to/llm-swarm-router && ./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg` for contributors. Do not assume readers have a repo checkout. See [v0.3.0.1 notes](release-notes/v0.3.0.1.md) for the pattern.
+
 Release job builds and attaches: `llm-swarm-router.dmg`, `.deb`, `.rpm`, Windows zip, `netllm.yaml`, SHA256 sidecars.
+
+**macOS Gatekeeper:** configure Developer ID + notarization secrets per [macos-code-signing.md](macos-code-signing.md). Release workflow signs after menubar tests, notarizes the DMG, then writes SHA256 sidecars. Without secrets, DMGs remain ad-hoc signed — point users at [macos-troubleshooting.md](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch).
 
 Watch: `gh run list --workflow=release.yml --limit 1` then `gh run view <id>`.
 

--- a/docs/macos-code-signing.md
+++ b/docs/macos-code-signing.md
@@ -1,0 +1,101 @@
+# macOS code signing and notarization
+
+Release DMGs are **Developer ID signed and notarized** when GitHub Actions secrets are configured. Without secrets, builds fall back to ad-hoc signing and users may see Gatekeeper prompts ([macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch)).
+
+## One-time setup
+
+### 1. Confirm your Developer ID certificate
+
+On your Mac:
+
+```bash
+security find-identity -v -p codesigning | grep "Developer ID Application"
+```
+
+You should see something like `Developer ID Application: Your Name (TEAMID)`.
+
+### 2. Export the certificate for CI
+
+1. Open **Keychain Access**
+2. Select **login** keychain → **My Certificates**
+3. Expand **Developer ID Application: …**
+4. Select the certificate **and** its private key
+5. **File → Export Items…** → format **Personal Information Exchange (.p12)**
+6. Choose a strong export password (this becomes `MACOS_CERTIFICATE_PASSWORD`)
+
+Base64-encode for GitHub:
+
+```bash
+base64 -i ~/Downloads/DeveloperID.p12 | pbcopy
+# paste into GitHub secret MACOS_CERTIFICATE_P12
+```
+
+### 3. Create an app-specific password
+
+At [appleid.apple.com](https://appleid.apple.com) → **Sign-In and Security** → **App-Specific Passwords** → generate one for `notarytool` / GitHub Actions.
+
+### 4. Add GitHub repository secrets
+
+Repo → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**:
+
+| Secret | Value |
+|--------|--------|
+| `MACOS_CERTIFICATE_P12` | Full base64 output of your `.p12` (single line) |
+| `MACOS_CERTIFICATE_PASSWORD` | Password you set when exporting the `.p12` |
+| `KEYCHAIN_PASSWORD` | Any strong random string (ephemeral CI keychain only) |
+| `APPLE_ID` | Apple ID email used for the developer account |
+| `APPLE_TEAM_ID` | 10-character Team ID ([Membership details](https://developer.apple.com/account#MembershipDetailsCard)) |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password from step 3 |
+
+All six secrets are required for notarized releases. If only the first three are set, the app is signed but the DMG is not notarized (Gatekeeper may still warn on first open).
+
+### 5. Verify locally before the next tag
+
+```bash
+apps/netllm-mac/Scripts/build.sh release
+bash packaging/scripts/import-codesign-cert.sh   # after exporting env vars locally
+bash packaging/scripts/codesign-mac-app.sh apps/netllm-mac/build/Stage/llm-swarm-router.app
+bash packaging/scripts/create-dmg.sh
+bash packaging/scripts/notarize-dmg.sh dist/llm-swarm-router.dmg
+```
+
+Local import (paste base64 into a temp file or export from Keychain directly):
+
+```bash
+export MACOS_CERTIFICATE_P12="$(base64 -i ~/Downloads/DeveloperID.p12)"
+export MACOS_CERTIFICATE_PASSWORD='your-p12-export-password'
+export KEYCHAIN_PASSWORD='local-test-keychain'
+export APPLE_ID='you@example.com'
+export APPLE_TEAM_ID='XXXXXXXXXX'
+export APPLE_APP_SPECIFIC_PASSWORD='xxxx-xxxx-xxxx-xxxx'
+```
+
+Verify Gatekeeper acceptance:
+
+```bash
+spctl -a -t exec -vv apps/netllm-mac/build/Stage/llm-swarm-router.app
+hdiutil attach dist/llm-swarm-router.dmg
+spctl -a -t open --context context:primary-signature -v /Volumes/llm-swarm-router/llm-swarm-router.app
+```
+
+## CI flow (release workflow)
+
+`.github/workflows/release.yml` `build-macos` job:
+
+1. Build Stage app (ad-hoc during `build.sh` if cert not imported yet)
+2. Run menubar e2e + lifecycle tests
+3. `import-codesign-cert.sh` — import `.p12` into ephemeral keychain
+4. `codesign-mac-app.sh` — Developer ID + Hardened Runtime + entitlements (`packaging/macos/entitlements.plist`)
+5. `create-dmg.sh`
+6. `maybe-notarize-dmg.sh` — submit DMG to Apple, staple ticket
+7. SHA256 sidecar (computed **after** notarization/staple)
+
+## Entitlements
+
+Embedded venvstacks Python requires relaxed hardened-runtime flags in `packaging/macos/entitlements.plist` (unsigned executable memory, library validation). Adjust only if notary returns specific entitlement errors.
+
+## Related
+
+- Build: [packaging/README.md](../packaging/README.md)
+- CI/release: [ci-and-release.md](ci-and-release.md)
+- User install: [macos-install.md](macos-install.md)

--- a/docs/macos-install.md
+++ b/docs/macos-install.md
@@ -15,21 +15,31 @@ existing Python agent on port **11400**, it does not replace oMLX inference on p
 4. Launch from Applications, the llm-swarm-router bee logo appears in the menu bar (switches for light/dark menu bar).
 5. Complete the welcome wizard (config path, LAN mode, auto-start).
 
+If macOS blocks drag-to-Applications (*cannot verify free from malware*), use the **terminal installer** below or see [Gatekeeper troubleshooting](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch).
+
 ### Upgrade from a release DMG (clean, recommended)
 
 Avoid `/ui/` 404 and port conflicts after upgrade: stop stale agents, replace the bundle, verify the dashboard.
 
-From a repo checkout (Mac mini with git clone):
+From a repo checkout (after `git clone`):
 
 ```bash
+cd /path/to/llm-swarm-router
 ./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
 ```
 
-Without a clone, use the installer bundled inside the app (v0.2.3.1+ DMG):
+Without a clone, use the installer bundled inside the app (v0.2.3.1+ DMG) or on the mounted DMG volume:
 
 ```bash
+# Upgrade (app already in /Applications)
 INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
 chmod +x "$INSTALLER"
+"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+
+# First install (open DMG first, then run from the volume)
+open ~/Downloads/llm-swarm-router.dmg
+INSTALLER="/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
+chmod +x "$INSTALLER" "/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/Resources/Scripts/mount-dmg.sh"
 "$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
 ```
 

--- a/docs/macos-troubleshooting.md
+++ b/docs/macos-troubleshooting.md
@@ -18,7 +18,13 @@ Dashboard: http://127.0.0.1:11400/ui/ · menubar **Open Dashboard** or **Copy Cl
 Usually an **old agent still owns the port** after a drag-to-Applications upgrade (the running process was not quit before replace).
 
 ```bash
-# Clean upgrade from a downloaded release DMG
+# DMG-only install (no git clone): bundled installer in the app
+INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
+chmod +x "$INSTALLER"
+"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+
+# Or from a repo checkout:
+cd /path/to/llm-swarm-router
 ./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
 ```
 
@@ -36,12 +42,80 @@ From a repo checkout, prefer `./netllm` if PATH is uncertain.
 
 ---
 
+## Gatekeeper blocks install or launch
+
+Release DMGs are **ad-hoc signed** until [Developer ID notarization](macos-code-signing.md) is enabled in CI. macOS may show *cannot verify free from malware* when you drag to **Applications**, or on first launch.
+
+**macOS 26 (Tahoe) and later:** clearing quarantine or using the terminal installer is **not enough** for ad-hoc builds. Gatekeeper reports `no usable signature` and blocks launch (dialog with only **Done**). You need a **notarized Developer ID** DMG, or use the source CLI path below.
+
+**Recommended:** use the bundled terminal installer (fixes copy + port cleanup; does not bypass Gatekeeper on Tahoe for ad-hoc builds):
+
+**Upgrade** (app already installed):
+
+```bash
+# Eject stale DMG mounts first if install says mount failed
+hdiutil detach "/Volumes/llm-swarm-router" -quiet 2>/dev/null || true
+hdiutil detach "/Volumes/llm-swarm-router 1" -quiet 2>/dev/null || true
+
+INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
+chmod +x "$INSTALLER"
+"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+```
+
+**First install** (no app in Applications yet):
+
+```bash
+open ~/Downloads/llm-swarm-router.dmg
+INSTALLER="/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
+chmod +x "$INSTALLER" "/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/Resources/Scripts/mount-dmg.sh"
+"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+```
+
+If mount fails, install from the mounted volume without re-mounting:
+
+```bash
+open ~/Downloads/llm-swarm-router.dmg
+"$INSTALLER" --source "/Volumes/llm-swarm-router/llm-swarm-router.app"
+```
+
+**Run without the menubar app (works today on ad-hoc / Gatekeeper-blocked Macs):**
+
+```bash
+cd /path/to/llm-swarm-router   # git clone
+uv sync && ./netllm init && ./netllm serve
+# Dashboard: http://127.0.0.1:11400/ui/
+```
+
+**Maintainer: build a notarized DMG locally** (after Developer ID cert is in Keychain):
+
+```bash
+export APPLE_ID='you@example.com'
+export APPLE_TEAM_ID='XXXXXXXXXX'
+export APPLE_APP_SPECIFIC_PASSWORD='xxxx-xxxx-xxxx-xxxx'
+packaging/scripts/local-notarized-dmg.sh
+```
+
+**Manual alternatives (older macOS or signed builds only):**
+
+| Step | Action |
+|------|--------|
+| Clear download quarantine | `xattr -cr ~/Downloads/llm-swarm-router.dmg` then open the DMG and drag again |
+| First launch only | Right-click **llm-swarm-router** in Applications → **Open** once (not double-click) |
+| After a blocked attempt | **System Settings → Privacy & Security → Open Anyway** (appears after macOS blocks the app) |
+| Avoid | Disabling Gatekeeper globally (`spctl --master-disable`) — not recommended |
+
+**Homebrew** (`brew install netllm`) uses Apple's brew signing path and usually avoids this for the CLI agent; the menubar DMG is separate.
+
+Maintainers: enable notarized releases per [macos-code-signing.md](macos-code-signing.md).
+
+---
+
 ## Agent unreachable
 
 | Symptom | Fix |
 |---------|-----|
 | `curl` to `/health` fails | Menubar → **Start Agent**, or `netllm start` |
-| Port 11400 in use | Expected while the menubar app runs the agent. Settings → **Restart Agent** or `netllm restart`: not a second `netllm serve`. After upgrade, run `upgrade-mac-app.sh` if an old process still holds the port |
+| Port 11400 in use | Expected while the menubar app runs the agent. Settings → **Restart Agent** or `netllm restart`: not a second `netllm serve`. After upgrade, run the bundled `macos-app-install.sh` or [repo upgrade script](macos-install.md#upgrade-from-a-release-dmg-clean-recommended) if an old process still holds the port |
 | DMG app won’t launch | Right-click **llm-swarm-router** in Applications → **Open** once (Gatekeeper) |
 | Homebrew agent down | `brew services restart netllm` · logs: `$(brew --prefix)/var/log/netllm.log` |
 

--- a/docs/release-notes/v0.3.0.1.md
+++ b/docs/release-notes/v0.3.0.1.md
@@ -10,7 +10,7 @@ Patch release fixing menubar **Download** failures (`CFNetworkDownload_*.tmp` co
 ### Notes
 
 - [v0.3.0.0](v0.3.0.0.md) already included bundled installer fixes (`mount-dmg` co-location, in-app install flags, cached DMG promotion). This patch fixes the **download** step only.
-- Always install from the GitHub Release DMG (or `./scripts/upgrade-mac-app.sh /path/to/release.dmg`); stale files in `~/Downloads/` may be older builds.
+- Always install from the GitHub Release DMG; stale files in `~/Downloads/` may be older builds. CLI upgrade paths are in **Install / upgrade** below (`macos-app-install.sh` from the app or mounted DMG — not `./scripts/` unless you have a repo clone).
 
 ### Diagnose update issues
 
@@ -22,12 +22,32 @@ defaults read /Applications/llm-swarm-router.app/Contents/Info CFBundleShortVers
 
 ### Install / upgrade
 
-- **macOS:** [v0.3.0.1](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.1) — menubar **Updates** or:
+- **macOS (in-app):** [v0.3.0.1](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.1) — menubar **Updates → Install** (or web dashboard `/ui/`).
+
+- **macOS (DMG, no git clone):** download the release DMG, then use the bundled installer (not `./scripts/` — that path exists only in a git clone).
+
+**Upgrade** (app already in `/Applications`):
 
 ```bash
-curl -fL -o /tmp/llm-swarm-router.dmg \
-  "https://github.com/matthewdcage/llm-swarm-router/releases/download/v0.3.0.1/llm-swarm-router.dmg"
-./scripts/upgrade-mac-app.sh /tmp/llm-swarm-router.dmg
+INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
+chmod +x "$INSTALLER"
+"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+```
+
+**First install** (no app yet): open the DMG, drag **llm-swarm-router** to **Applications**, then launch once. Or from a mounted DMG:
+
+```bash
+open ~/Downloads/llm-swarm-router.dmg
+INSTALLER="/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
+chmod +x "$INSTALLER" "/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/Resources/Scripts/mount-dmg.sh"
+"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+```
+
+- **macOS (repo checkout):** if you cloned the repo for development, from the repo root:
+
+```bash
+cd /path/to/llm-swarm-router
+./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
 ```
 
 - **Source:** `git pull && uv sync`

--- a/docs/release-notes/v0.3.0.2.md
+++ b/docs/release-notes/v0.3.0.2.md
@@ -1,0 +1,47 @@
+## 0.3.0.2: macOS menubar agent start (quiet serve + LAN)
+
+Patch release fixing menubar **Agent: starting…** / **Agent: failed — exited with code 1** when the agent listens on `0.0.0.0` (LAN/swarm welcome path).
+
+### Fixes
+
+- **Bundled agent crash:** `netllm serve -q` with LAN listen printed startup warnings via `console.print(..., file=sys.stderr)`, which Rich 13+ rejects — menubar supervises with `-q`, so the agent never reached `/health`
+- **CI regression gate:** `tests/test_serve_quiet_lan.py` plus menubar e2e **quiet + 0.0.0.0** smoke on the Stage `.app` before DMG attach
+- **Release signing path:** Developer ID sign + notarize hooks in `release.yml` when GitHub secrets are set ([macos-code-signing.md](../macos-code-signing.md)); ad-hoc DMGs still require Gatekeeper workarounds on macOS 26 until secrets are configured
+
+### Notes
+
+- Always download the DMG from the [latest GitHub Release](https://github.com/matthewdcage/llm-swarm-router/releases/latest) — stale `~/Downloads/llm-swarm-router.dmg` files may be older builds (e.g. 0.2.3.1 while the app offers **Update available (v0.3.0.x)**).
+- Verify installed version: `defaults read /Applications/llm-swarm-router.app/Contents/Info CFBundleShortVersionString`
+
+### Diagnose agent start failures
+
+```bash
+tail -40 ~/Library/Application\ Support/netllm/logs/app.log
+tail -40 ~/Library/Application\ Support/netllm/logs/agent.log
+curl -sf http://127.0.0.1:11400/health
+```
+
+### Install / upgrade
+
+- **macOS (in-app):** menubar **Updates → Install** after this release is published.
+
+- **macOS (DMG, no git clone):**
+
+```bash
+INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
+chmod +x "$INSTALLER"
+"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+```
+
+First install or Gatekeeper blocks drag-to-Applications: see [macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](../macos-troubleshooting.md#gatekeeper-blocks-install-or-launch).
+
+- **macOS (repo checkout):**
+
+```bash
+cd /path/to/llm-swarm-router
+./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
+```
+
+### Previous release
+
+- [v0.3.0.1 notes](v0.3.0.1.md): in-app update download fix

--- a/packages/netllm-agent/pyproject.toml
+++ b/packages/netllm-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-agent"
-version = "0.3.0.1"
+version = "0.3.0.2"
 description = "FastAPI agent daemon for netllm swarm routing"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-cli/pyproject.toml
+++ b/packages/netllm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-cli"
-version = "0.3.0.1"
+version = "0.3.0.2"
 description = "CLI for netllm network LLM router"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-cli/src/netllm_cli/main.py
+++ b/packages/netllm-cli/src/netllm_cli/main.py
@@ -6,7 +6,6 @@ import asyncio
 import json
 import os
 import subprocess
-import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -704,8 +703,7 @@ def serve(
             "Dashboard: [cyan]" + base + "/ui/[/] · API help JSON at [cyan]/[/][/]\n"
         )
     elif warnings:
-        for w in warnings:
-            console.print(f"[yellow]note:[/] {w}", file=sys.stderr)
+        print_warnings(warnings)
 
     import logging
 

--- a/packages/netllm-core/pyproject.toml
+++ b/packages/netllm-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-core"
-version = "0.3.0.1"
+version = "0.3.0.2"
 description = "Core routing, health, and config for netllm"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-core/src/netllm_core/version.py
+++ b/packages/netllm-core/src/netllm_core/version.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 
-_FALLBACK_VERSION = "0.3.0.1"
+_FALLBACK_VERSION = "0.3.0.2"
 
 
 def get_version() -> str:

--- a/packages/netllm-discovery/pyproject.toml
+++ b/packages/netllm-discovery/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-discovery"
-version = "0.3.0.1"
+version = "0.3.0.2"
 description = "Local and swarm discovery for netllm agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-sdk-anthropic/pyproject.toml
+++ b/packages/netllm-sdk-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-sdk-anthropic"
-version = "0.3.0.1"
+version = "0.3.0.2"
 description = "Anthropic SDK adapter for netllm upstream calls"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-sdk-openai/pyproject.toml
+++ b/packages/netllm-sdk-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-sdk-openai"
-version = "0.3.0.1"
+version = "0.3.0.2"
 description = "OpenAI SDK adapter for netllm upstream calls"
 requires-python = ">=3.11"
 dependencies = [

--- a/packaging/AGENTS.md
+++ b/packaging/AGENTS.md
@@ -1,0 +1,68 @@
+# packaging — cross-platform release builds
+
+## Purpose
+
+Build scripts and artifacts for macOS (venvstacks layers + DMG), Linux (deb/rpm), and Windows (portable zip). Attached to GitHub Releases via `.github/workflows/release.yml`.
+
+## Ownership
+
+| Path | Role |
+|------|------|
+| `build.py` | venvstacks export, fingerprint |
+| `_export/` | Python layer tree for Swift embed (generated) |
+| `linux/` | deb/rpm staging |
+| `windows/` | zip + winget metadata |
+| `scripts/` | Shared packaging helpers (see table below) |
+| `macos/` | Hardened-runtime entitlements for Developer ID sign |
+
+**`packaging/scripts/` (macOS release path):**
+
+| Script | Role |
+|--------|------|
+| `macos-app-install.sh` | User DMG upgrade/install (bundled in `.app`) |
+| `mount-dmg.sh` | Mount release DMG; co-located with installer |
+| `create-dmg.sh` | Stage → `dist/llm-swarm-router.dmg` |
+| `codesign-mac-app.sh` | Developer ID + entitlements on Stage `.app` |
+| `import-codesign-cert.sh` | Import `.p12` into CI keychain |
+| `notarize-dmg.sh` | Submit DMG to Apple + staple |
+| `maybe-notarize-dmg.sh` | Notarize when Apple secrets present (CI) |
+| `local-notarized-dmg.sh` | Maintainer one-shot: build → sign → DMG → notarize |
+
+Index: [README.md](README.md). macOS app bundle: [../apps/netllm-mac/Scripts/build.sh](../apps/netllm-mac/Scripts/build.sh). Signing setup: [../docs/macos-code-signing.md](../docs/macos-code-signing.md).
+
+## Local Contracts
+
+- macOS: `packaging/build.py --venvstacks-only` then `apps/netllm-mac/Scripts/build.sh release`
+- **macOS distribution:** ad-hoc DMGs fail Gatekeeper on macOS 26+ (`no usable signature`); stable releases require Developer ID sign + notarize ([macos-code-signing.md](../docs/macos-code-signing.md)). CI: `release.yml` imports cert → `codesign-mac-app.sh` → `create-dmg.sh` → `maybe-notarize-dmg.sh` → SHA256
+- `build.sh` uses ad-hoc sign locally unless `CODESIGN_IDENTITY` is set; maintainer gatekeeper-safe DMG: `packaging/scripts/local-notarized-dmg.sh`
+- End-user DMG install/upgrade: bundled `macos-app-install.sh` + co-located `mount-dmg.sh`; repo `scripts/upgrade-mac-app.sh` wraps the same installer for maintainers only
+- Release workflow renames DMG to `llm-swarm-router.dmg`
+- Linux/Windows alpha artifacts include systemd/service install paths documented in platform docs
+- Do not commit `_build/`, `_export/` churn unless intentional lock/export updates
+
+## Work Guidance
+
+- Bump all workspace package versions + `uv lock` before `gh release create`
+- macOS notarized release: configure GitHub secrets per [macos-code-signing.md](../docs/macos-code-signing.md) before tagging; verify with `local-notarized-dmg.sh` locally when cert is in Keychain
+- Packaging smoke: `./scripts/ci.sh packaging`
+- macOS packaging PRs may touch both `packaging/` and `apps/netllm-mac/`
+
+## Verification
+
+```bash
+./scripts/ci.sh packaging
+uv run python packaging/build.py --print-fingerprint
+apps/netllm-mac/Scripts/build.sh release   # macOS full path
+```
+
+Details: [../docs/ci-and-release.md](../docs/ci-and-release.md).
+
+## Child DOX Index
+
+| Path | Contract |
+|------|----------|
+| [`macos/`](macos/) | `entitlements.plist` for embedded Python (hardened runtime) |
+| [`linux/`](linux/) | deb/rpm stage trees (generated) |
+| [`windows/`](windows/) | zip and winget manifests |
+
+Platform subfolders are build outputs and scripts; no nested AGENTS.md unless ownership splits by OS team.

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/packaging/scripts/codesign-mac-app.sh
+++ b/packaging/scripts/codesign-mac-app.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Sign llm-swarm-router.app for distribution (Developer ID + hardened runtime).
+#
+# Requires:
+#   CODESIGN_IDENTITY — e.g. "Developer ID Application: Your Name (TEAMID)"
+#
+# Usage:
+#   CODESIGN_IDENTITY="Developer ID Application: …" \
+#     packaging/scripts/codesign-mac-app.sh apps/netllm-mac/build/Stage/llm-swarm-router.app
+set -euo pipefail
+
+APP="${1:-}"
+IDENTITY="${CODESIGN_IDENTITY:-}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENTITLEMENTS="${ENTITLEMENTS:-$SCRIPT_DIR/../macos/entitlements.plist}"
+
+if [[ -z "$APP" || ! -d "$APP" ]]; then
+  echo "Usage: CODESIGN_IDENTITY=\"Developer ID Application: …\" $0 /path/to/llm-swarm-router.app" >&2
+  exit 1
+fi
+
+if [[ -z "$IDENTITY" ]]; then
+  echo "CODESIGN_IDENTITY is not set — skipping Developer ID sign (build.sh uses ad-hoc for local dev)." >&2
+  exit 0
+fi
+
+if [[ ! -f "$ENTITLEMENTS" ]]; then
+  echo "Entitlements file not found: $ENTITLEMENTS" >&2
+  exit 1
+fi
+
+echo "==> Signing with: $IDENTITY"
+
+needs_entitlements() {
+  local f="$1"
+  [[ "$f" == *.dylib || "$f" == *.so ]] && return 1
+  file "$f" 2>/dev/null | grep -q 'Mach-O.*executable'
+}
+
+sign_file() {
+  local f="$1"
+  if needs_entitlements "$f"; then
+    codesign --force --options runtime --timestamp \
+      --entitlements "$ENTITLEMENTS" \
+      --sign "$IDENTITY" "$f"
+  else
+    codesign --force --options runtime --timestamp \
+      --sign "$IDENTITY" "$f" 2>/dev/null \
+      || codesign --force --options runtime --sign "$IDENTITY" "$f"
+  fi
+}
+
+# Deepest Mach-O first (dylibs, helpers, python, CLI wrappers)
+while IFS= read -r -d '' f; do
+  sign_file "$f"
+done < <(
+  find "$APP" -type f \( -perm -111 -o -name '*.dylib' -o -name '*.so' \) -print0 2>/dev/null \
+    | sort -rz
+)
+
+codesign --force --options runtime --timestamp \
+  --entitlements "$ENTITLEMENTS" \
+  --sign "$IDENTITY" "$APP"
+
+codesign --verify --deep --strict --verbose=2 "$APP"
+spctl -a -t exec -vv "$APP" 2>&1 || true
+echo "==> Signed: $APP"

--- a/packaging/scripts/import-codesign-cert.sh
+++ b/packaging/scripts/import-codesign-cert.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Import Developer ID certificate into an ephemeral keychain (CI or local).
+#
+# Inputs (env):
+#   MACOS_CERTIFICATE_P12 — base64-encoded .p12 (required to import)
+#   MACOS_CERTIFICATE_PASSWORD — export password for the .p12
+#   KEYCHAIN_PASSWORD — password for the ephemeral keychain
+#
+# Outputs:
+#   Sets CODESIGN_IDENTITY in GITHUB_ENV when running in Actions, else exports it.
+#
+# When MACOS_CERTIFICATE_P12 is unset, prints a notice and exits 0 (ad-hoc fallback).
+set -euo pipefail
+
+if [[ -z "${MACOS_CERTIFICATE_P12:-}" ]]; then
+  echo "MACOS_CERTIFICATE_P12 not set — release build will use ad-hoc signing."
+  exit 0
+fi
+
+for var in MACOS_CERTIFICATE_PASSWORD KEYCHAIN_PASSWORD; do
+  [[ -n "${!var:-}" ]] || {
+    echo "$var is required when MACOS_CERTIFICATE_P12 is set" >&2
+    exit 1
+  }
+done
+
+CERT_PATH="$(mktemp -t netllm-cert).p12"
+KEYCHAIN="${RUNNER_TEMP:-/tmp}/netllm-build.keychain-db"
+trap 'rm -f "$CERT_PATH"' EXIT
+
+echo "$MACOS_CERTIFICATE_P12" | base64 --decode > "$CERT_PATH"
+
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+security default-keychain -s "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security import "$CERT_PATH" -k "$KEYCHAIN" -P "$MACOS_CERTIFICATE_PASSWORD" \
+  -T /usr/bin/codesign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN" \
+  | awk -F'"' '/Developer ID Application/ {print $2; exit}')"
+
+if [[ -z "$IDENTITY" ]]; then
+  echo "No Developer ID Application identity found in imported certificate" >&2
+  security find-identity -v -p codesigning "$KEYCHAIN" >&2 || true
+  exit 1
+fi
+
+echo "Imported signing identity: $IDENTITY"
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "CODESIGN_IDENTITY=$IDENTITY"
+    echo "KEYCHAIN_PATH=$KEYCHAIN"
+  } >> "$GITHUB_ENV"
+else
+  export CODESIGN_IDENTITY="$IDENTITY"
+  export KEYCHAIN_PATH="$KEYCHAIN"
+fi

--- a/packaging/scripts/local-notarized-dmg.sh
+++ b/packaging/scripts/local-notarized-dmg.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Build, sign, notarize, and stage a Gatekeeper-safe macOS DMG (maintainer local release).
+#
+# Requires Developer ID Application in login keychain + Apple notary credentials.
+#
+# Usage:
+#   export APPLE_ID='you@example.com'
+#   export APPLE_TEAM_ID='XXXXXXXXXX'
+#   export APPLE_APP_SPECIFIC_PASSWORD='xxxx-xxxx-xxxx-xxxx'
+#   packaging/scripts/local-notarized-dmg.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+IDENTITY="$(security find-identity -v -p codesigning \
+  | awk -F'"' '/Developer ID Application/ {print $2; exit}')"
+if [[ -z "$IDENTITY" ]]; then
+  cat >&2 <<'EOF'
+No Developer ID Application certificate in your login keychain.
+
+Fix in Xcode (about 2 minutes):
+  1. Xcode → Settings → Accounts → your Apple ID → Manage Certificates…
+  2. + → Developer ID Application
+  3. Re-run this script
+
+Verify:
+  security find-identity -v -p codesigning | grep "Developer ID Application"
+EOF
+  exit 1
+fi
+
+for var in APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD; do
+  [[ -n "${!var:-}" ]] || {
+    echo "Set $var for notarization (see docs/macos-code-signing.md)" >&2
+    exit 1
+  }
+done
+
+echo "==> Building release app"
+apps/netllm-mac/Scripts/build.sh release
+
+APP="$ROOT/apps/netllm-mac/build/Stage/llm-swarm-router.app"
+export CODESIGN_IDENTITY="$IDENTITY"
+echo "==> Signing with: $IDENTITY"
+bash packaging/scripts/codesign-mac-app.sh "$APP"
+
+echo "==> Creating DMG"
+bash packaging/scripts/create-dmg.sh
+
+DMG="$ROOT/dist/llm-swarm-router.dmg"
+bash packaging/scripts/notarize-dmg.sh "$DMG"
+
+echo ""
+echo "Gatekeeper-safe DMG ready:"
+echo "  $DMG"
+echo ""
+echo "Install:"
+echo "  open \"$DMG\""
+echo "  # drag llm-swarm-router to Applications — should work without malware prompts on macOS 26+"
+echo ""
+spctl -a -t open --context context:primary-signature -v "$DMG" 2>&1 || true

--- a/packaging/scripts/macos-app-install.sh
+++ b/packaging/scripts/macos-app-install.sh
@@ -280,17 +280,28 @@ verify_agent_endpoints() {
   log_line "Verified ${base}/ui/ (HTTP 200)"
 }
 
+strip_download_quarantine() {
+  local path="$1"
+  [[ -e "$path" ]] || return 0
+  if xattr -p com.apple.quarantine "$path" >/dev/null 2>&1; then
+    log_line "Clearing Gatekeeper quarantine on $path"
+    xattr -dr com.apple.quarantine "$path" 2>/dev/null || true
+  fi
+}
+
 DMG_MOUNT=""
 SOURCE_APP=""
 
 resolve_source_app() {
   if [[ -n "$SOURCE" ]]; then
     [[ -d "$SOURCE" ]] || install_fail "Source app not found: $SOURCE"
+    strip_download_quarantine "$SOURCE"
     SOURCE_APP="$SOURCE"
     return 0
   fi
 
   [[ -f "$DMG" ]] || install_fail "DMG not found: $DMG"
+  strip_download_quarantine "$DMG"
   if [[ ! -x "$MOUNT_DMG" ]]; then
     install_fail "mount-dmg.sh not found next to this script ($SCRIPT_DIR). Mount the DMG manually and pass --source /Volumes/.../llm-swarm-router.app"
   fi

--- a/packaging/scripts/maybe-notarize-dmg.sh
+++ b/packaging/scripts/maybe-notarize-dmg.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Notarize DMG when Apple notary credentials are present; skip otherwise.
+set -euo pipefail
+
+DMG="${1:-}"
+[[ -f "$DMG" ]] || {
+  echo "DMG not found: $DMG" >&2
+  exit 1
+}
+
+if [[ -z "${APPLE_ID:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]]; then
+  echo "Apple notary credentials not set — skipping DMG notarization (Gatekeeper workarounds still apply)."
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec bash "$SCRIPT_DIR/notarize-dmg.sh" "$DMG"

--- a/packaging/scripts/mount-dmg.sh
+++ b/packaging/scripts/mount-dmg.sh
@@ -12,10 +12,24 @@ DMG="$1"
 [[ -f "$DMG" ]] || { echo "DMG not found: $DMG" >&2; exit 1; }
 
 VOL_BASENAME="$(basename "$DMG" .dmg)"
-LIKELY_MOUNT="/Volumes/$VOL_BASENAME"
+APP_NAME="llm-swarm-router.app"
+LEGACY_APP_NAME="netllm-mac.app"
 
-if [[ -d "$LIKELY_MOUNT" ]]; then
-  echo "$LIKELY_MOUNT"
+find_mounted_app() {
+  local vol
+  for vol in "/Volumes/$VOL_BASENAME" "/Volumes/$VOL_BASENAME "[0-9]*; do
+    [[ -d "$vol" ]] || continue
+    if [[ -d "$vol/$APP_NAME" || -d "$vol/$LEGACY_APP_NAME" ]]; then
+      echo "$vol"
+      return 0
+    fi
+  done
+  return 1
+}
+
+existing="$(find_mounted_app || true)"
+if [[ -n "$existing" ]]; then
+  echo "$existing"
   exit 0
 fi
 

--- a/packaging/scripts/notarize-dmg.sh
+++ b/packaging/scripts/notarize-dmg.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Notarize a release DMG and staple the ticket (run after create-dmg.sh).
+#
+# Requires:
+#   APPLE_ID, APPLE_TEAM_ID, APPLE_APP_SPECIFIC_PASSWORD
+#
+# Usage:
+#   APPLE_ID=… APPLE_TEAM_ID=… APPLE_APP_SPECIFIC_PASSWORD=… \
+#     packaging/scripts/notarize-dmg.sh dist/llm-swarm-router.dmg
+set -euo pipefail
+
+DMG="${1:-}"
+for var in APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD; do
+  [[ -n "${!var:-}" ]] || {
+    echo "$var is required" >&2
+    exit 1
+  }
+done
+
+[[ -f "$DMG" ]] || {
+  echo "DMG not found: $DMG" >&2
+  exit 1
+}
+
+echo "==> Submitting $DMG to Apple notary service"
+xcrun notarytool submit "$DMG" \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+  --team-id "$APPLE_TEAM_ID" \
+  --wait
+
+echo "==> Stapling notarization ticket"
+xcrun stapler staple "$DMG"
+spctl -a -t open --context context:primary-signature -v "$DMG" 2>&1 || true
+echo "==> Notarized: $DMG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm"
-version = "0.3.0.1"
+version = "0.3.0.2"
 description = "Network LLM router — swarm agents with OpenAI-compatible gateway"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/test-menubar-e2e.sh
+++ b/scripts/test-menubar-e2e.sh
@@ -68,6 +68,47 @@ done
 curl -sf "${BASE}/health" >/dev/null || fail "agent not healthy — see $LOG"
 ok "health ${BASE}/health"
 
+echo "==> bundled agent quiet + LAN listen (menubar path regression)"
+LAN_CFG="${NETLLM_TEST_LAN_CONFIG:-/tmp/netllm-e2e-lan-config.toml}"
+LAN_PORT="${NETLLM_TEST_LAN_PORT:-11402}"
+LAN_BASE="http://127.0.0.1:${LAN_PORT}"
+LAN_PIDFILE="/tmp/netllm-e2e-lan-agent.pid"
+LAN_LOG="/tmp/netllm-e2e-lan-agent.log"
+cat > "$LAN_CFG" <<EOF
+[agent]
+listen = "0.0.0.0:${LAN_PORT}"
+role = "peer"
+advertise = true
+
+[discovery]
+providers = ["omlx", "ollama", "lmstudio"]
+
+[swarm]
+mdns = true
+
+[routing]
+default_strategy = "local_first"
+EOF
+"$CLI" serve -q --config "$LAN_CFG" >"$LAN_LOG" 2>&1 &
+echo $! >"$LAN_PIDFILE"
+for i in $(seq 1 30); do
+  if curl -sf "${LAN_BASE}/health" >/dev/null 2>&1; then
+    break
+  fi
+  if rg -q "unexpected keyword argument 'file'" "$LAN_LOG" 2>/dev/null; then
+    fail "bundled serve -q crashed on Rich file= kwarg — see $LAN_LOG"
+  fi
+  sleep 0.5
+done
+curl -sf "${LAN_BASE}/health" >/dev/null || {
+  echo "--- $LAN_LOG ---" >&2
+  tail -40 "$LAN_LOG" >&2 || true
+  fail "LAN quiet agent not healthy on ${LAN_BASE}/health"
+}
+kill "$(cat "$LAN_PIDFILE")" 2>/dev/null || true
+rm -f "$LAN_PIDFILE"
+ok "quiet serve -q with 0.0.0.0 listen (${LAN_BASE}/health)"
+
 echo "==> logs API"
 curl -sf "${BASE}/netllm/v1/logs?tail=10" | rg -q '"log_file"' || fail "logs API"
 ok "GET /netllm/v1/logs"

--- a/tests/test_serve_quiet_lan.py
+++ b/tests/test_serve_quiet_lan.py
@@ -1,0 +1,46 @@
+"""Regression: menubar `serve -q` with LAN listen must not crash on startup warnings."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from netllm_cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_serve_quiet_lan_warnings_reaches_uvicorn(tmp_path) -> None:
+    """Quiet LAN serve must print warnings without Rich file= kwarg."""
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        """
+[agent]
+listen = "0.0.0.0:11400"
+role = "peer"
+advertise = true
+
+[discovery]
+providers = ["omlx"]
+
+[swarm]
+mdns = true
+
+[routing]
+default_strategy = "local_first"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with patch("netllm_discovery.runtime.check_listen_port", return_value=None):
+        with patch("netllm_cli.main.asyncio.run", return_value=[]):
+            with patch("netllm_agent.app.create_app", return_value=object()):
+                with patch("uvicorn.run") as uvicorn_run:
+                    result = runner.invoke(
+                        app,
+                        ["serve", "-q", "--config", str(cfg)],
+                    )
+
+    assert result.exit_code == 0, result.output
+    assert "unexpected keyword argument 'file'" not in result.output
+    uvicorn_run.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "netllm"
-version = "0.3.0.1"
+version = "0.3.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "netllm-cli" },
@@ -625,7 +625,7 @@ dev = [
 
 [[package]]
 name = "netllm-agent"
-version = "0.3.0.1"
+version = "0.3.0.2"
 source = { editable = "packages/netllm-agent" }
 dependencies = [
     { name = "fastapi" },
@@ -653,7 +653,7 @@ provides-extras = ["mdns"]
 
 [[package]]
 name = "netllm-cli"
-version = "0.3.0.1"
+version = "0.3.0.2"
 source = { editable = "packages/netllm-cli" }
 dependencies = [
     { name = "httpx" },
@@ -676,7 +676,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-core"
-version = "0.3.0.1"
+version = "0.3.0.2"
 source = { editable = "packages/netllm-core" }
 dependencies = [
     { name = "httpx" },
@@ -695,7 +695,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-discovery"
-version = "0.3.0.1"
+version = "0.3.0.2"
 source = { editable = "packages/netllm-discovery" }
 dependencies = [
     { name = "httpx" },
@@ -713,7 +713,7 @@ provides-extras = ["mdns"]
 
 [[package]]
 name = "netllm-sdk-anthropic"
-version = "0.3.0.1"
+version = "0.3.0.2"
 source = { editable = "packages/netllm-sdk-anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -728,7 +728,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-sdk-openai"
-version = "0.3.0.1"
+version = "0.3.0.2"
 source = { editable = "packages/netllm-sdk-openai" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Fixes menubar **Agent: starting…** / **exit code 1** when config uses `listen = "0.0.0.0:11400"` (bundled `serve -q` crashed on Rich `file=` kwarg)
- Adds CI regression: `tests/test_serve_quiet_lan.py` + menubar e2e quiet+LAN smoke before DMG packaging
- Adds Developer ID sign/notarize hooks in release workflow (requires GitHub secrets per `docs/macos-code-signing.md`)
- Documents Gatekeeper / stale-DMG pitfalls for macOS 26+ downloaders

Fixes #14

## Test plan

- [x] `./scripts/ci.sh lint`
- [x] `./scripts/ci.sh test` (164 passed)
- [ ] `menubar-lifecycle` CI on PR
- [ ] After merge: publish `v0.3.0.2` release (upload fresh DMG from Actions; delete stale `~/Downloads/llm-swarm-router.dmg` before install)
- [ ] Upload `MACOS_CERTIFICATE_P12` secret then re-run release job for notarized DMG

## Release

Bump to **0.3.0.2** — notes in `docs/release-notes/v0.3.0.2.md`.