### PR TITLE
docs(macos): source-build install until notarized DMGs ship

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,45 @@
+# .agents — canonical agent skills
+
+## Purpose
+
+Source of truth for netllm agent skills. Sync to `.claude/`, `.cursor/`, and `.github/` via `scripts/sync-agent-skills.sh` after any edit.
+
+## Ownership
+
+| Skill | Path | Triggers |
+|-------|------|----------|
+| `netllm-setup` | `skills/netllm-setup/SKILL.md` | install, `/netllm-setup` |
+| `netllm-connect-editor` | `skills/netllm-connect-editor/SKILL.md` | connect Cursor/Claude/Codex, `/netllm-connect` |
+| `netllm-swarm` | `skills/netllm-swarm/SKILL.md` | LAN mesh, `/netllm-swarm` |
+| `netllm-doctor` | `skills/netllm-doctor/SKILL.md` | troubleshoot, `/netllm-doctor` |
+
+Parent rail: [../AGENTS.md](../AGENTS.md). Editor reference: [../docs/editor-integration.md](../docs/editor-integration.md).
+
+## Local Contracts
+
+- Edit skills only under `.agents/`; never edit synced copies directly
+- Run `scripts/sync-agent-skills.sh` after changes before commit
+- Slash commands in `.claude/commands/` point at these skills
+
+## Work Guidance
+
+- Skill descriptions must include trigger phrases for reliable agent routing
+- Keep setup/connect/swarm/doctor flows aligned with `./netllm` CLI behavior
+
+## Verification
+
+```bash
+scripts/sync-agent-skills.sh
+# Diff synced copies under .claude/skills/, .cursor/skills/, .github/skills/
+```
+
+## Child DOX Index
+
+| Path | Contract |
+|------|----------|
+| [`skills/netllm-setup/`](skills/netllm-setup/) | First-time install skill |
+| [`skills/netllm-connect-editor/`](skills/netllm-connect-editor/) | Editor wiring skill |
+| [`skills/netllm-swarm/`](skills/netllm-swarm/) | LAN swarm skill |
+| [`skills/netllm-doctor/`](skills/netllm-doctor/) | Troubleshooting skill |
+
+Individual skill folders use SKILL.md as their contract; no per-skill AGENTS.md unless a skill grows multi-file maintenance docs.

--- a/.agents/skills/netllm-setup/SKILL.md
+++ b/.agents/skills/netllm-setup/SKILL.md
@@ -39,7 +39,8 @@ allowed-tools:
 
 | User preference | Steps |
 |-----------------|-------|
-| **macOS DMG** | Download [latest Release](https://github.com/matthewdcage/llm-swarm-router/releases/latest) `llm-swarm-router.dmg` → drag to Applications → launch menubar app → welcome wizard. See [docs/macos-install.md](../../docs/macos-install.md). |
+| **macOS menubar (macOS 26+)** | Clone [latest release tag](https://github.com/matthewdcage/llm-swarm-router/releases/latest) → `uv sync` → `uv pip install venvstacks` → `apps/netllm-mac/Scripts/build.sh release` → `packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app`. GitHub DMG is ad-hoc until notarized — see [docs/macos-install.md](../../docs/macos-install.md). |
+| **macOS DMG (when notarized)** | Download `llm-swarm-router.dmg` from Releases → bundled `macos-app-install.sh --dmg` — not Gatekeeper-safe on macOS 26 until Developer ID notarization ships |
 | **Homebrew** | `brew tap matthewdcage/netllm <repo>` → `brew install netllm` → `brew services start netllm` |
 | **Linux deb/rpm** | Install `netllm_*_amd64.deb` or `netllm-*.rpm` from Releases → `netllm init` → `systemctl --user enable --now netllm`. See [docs/linux-install.md](../../docs/linux-install.md). |
 | **Windows zip** | Extract `netllm-*-windows-x64.zip` → run `install-service.ps1` as Admin → `netllm init` → `netllm start`. See [docs/windows-install.md](../../docs/windows-install.md). |

--- a/.claude/skills/netllm-setup/SKILL.md
+++ b/.claude/skills/netllm-setup/SKILL.md
@@ -39,7 +39,8 @@ allowed-tools:
 
 | User preference | Steps |
 |-----------------|-------|
-| **macOS DMG** | Download [latest Release](https://github.com/matthewdcage/llm-swarm-router/releases/latest) `llm-swarm-router.dmg` → drag to Applications → launch menubar app → welcome wizard. See [docs/macos-install.md](../../docs/macos-install.md). |
+| **macOS menubar (macOS 26+)** | Clone [latest release tag](https://github.com/matthewdcage/llm-swarm-router/releases/latest) → `uv sync` → `uv pip install venvstacks` → `apps/netllm-mac/Scripts/build.sh release` → `packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app`. GitHub DMG is ad-hoc until notarized — see [docs/macos-install.md](../../docs/macos-install.md). |
+| **macOS DMG (when notarized)** | Download `llm-swarm-router.dmg` from Releases → bundled `macos-app-install.sh --dmg` — not Gatekeeper-safe on macOS 26 until Developer ID notarization ships |
 | **Homebrew** | `brew tap matthewdcage/netllm <repo>` → `brew install netllm` → `brew services start netllm` |
 | **Linux deb/rpm** | Install `netllm_*_amd64.deb` or `netllm-*.rpm` from Releases → `netllm init` → `systemctl --user enable --now netllm`. See [docs/linux-install.md](../../docs/linux-install.md). |
 | **Windows zip** | Extract `netllm-*-windows-x64.zip` → run `install-service.ps1` as Admin → `netllm init` → `netllm start`. See [docs/windows-install.md](../../docs/windows-install.md). |

--- a/.cursor/skills/netllm-setup/SKILL.md
+++ b/.cursor/skills/netllm-setup/SKILL.md
@@ -39,7 +39,8 @@ allowed-tools:
 
 | User preference | Steps |
 |-----------------|-------|
-| **macOS DMG** | Download [latest Release](https://github.com/matthewdcage/llm-swarm-router/releases/latest) `llm-swarm-router.dmg` → drag to Applications → launch menubar app → welcome wizard. See [docs/macos-install.md](../../docs/macos-install.md). |
+| **macOS menubar (macOS 26+)** | Clone [latest release tag](https://github.com/matthewdcage/llm-swarm-router/releases/latest) → `uv sync` → `uv pip install venvstacks` → `apps/netllm-mac/Scripts/build.sh release` → `packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app`. GitHub DMG is ad-hoc until notarized — see [docs/macos-install.md](../../docs/macos-install.md). |
+| **macOS DMG (when notarized)** | Download `llm-swarm-router.dmg` from Releases → bundled `macos-app-install.sh --dmg` — not Gatekeeper-safe on macOS 26 until Developer ID notarization ships |
 | **Homebrew** | `brew tap matthewdcage/netllm <repo>` → `brew install netllm` → `brew services start netllm` |
 | **Linux deb/rpm** | Install `netllm_*_amd64.deb` or `netllm-*.rpm` from Releases → `netllm init` → `systemctl --user enable --now netllm`. See [docs/linux-install.md](../../docs/linux-install.md). |
 | **Windows zip** | Extract `netllm-*-windows-x64.zip` → run `install-service.ps1` as Admin → `netllm init` → `netllm start`. See [docs/windows-install.md](../../docs/windows-install.md). |

--- a/.github/skills/netllm-setup/SKILL.md
+++ b/.github/skills/netllm-setup/SKILL.md
@@ -39,7 +39,8 @@ allowed-tools:
 
 | User preference | Steps |
 |-----------------|-------|
-| **macOS DMG** | Download [latest Release](https://github.com/matthewdcage/llm-swarm-router/releases/latest) `llm-swarm-router.dmg` → drag to Applications → launch menubar app → welcome wizard. See [docs/macos-install.md](../../docs/macos-install.md). |
+| **macOS menubar (macOS 26+)** | Clone [latest release tag](https://github.com/matthewdcage/llm-swarm-router/releases/latest) → `uv sync` → `uv pip install venvstacks` → `apps/netllm-mac/Scripts/build.sh release` → `packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app`. GitHub DMG is ad-hoc until notarized — see [docs/macos-install.md](../../docs/macos-install.md). |
+| **macOS DMG (when notarized)** | Download `llm-swarm-router.dmg` from Releases → bundled `macos-app-install.sh --dmg` — not Gatekeeper-safe on macOS 26 until Developer ID notarization ships |
 | **Homebrew** | `brew tap matthewdcage/netllm <repo>` → `brew install netllm` → `brew services start netllm` |
 | **Linux deb/rpm** | Install `netllm_*_amd64.deb` or `netllm-*.rpm` from Releases → `netllm init` → `systemctl --user enable --now netllm`. See [docs/linux-install.md](../../docs/linux-install.md). |
 | **Windows zip** | Extract `netllm-*-windows-x64.zip` → run `install-service.ps1` as Admin → `netllm init` → `netllm start`. See [docs/windows-install.md](../../docs/windows-install.md). |

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ apps/netllm-mac/build/
 # Local archive for moved/deprecated files (project convention; not shipped)
 archived/
 
+# Local maintainer secrets (Apple signing / notarization)
+.env
+.env.local
+
 # Cursor — local/personal (shared copies: .cursor/skills/, .cursor/rules/netllm.mdc, mcp.json.example)
 .cursor/plans/
 .cursor/outreach/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,9 +112,10 @@ Native app (oMLX-style): [docs/macos-install.md](docs/macos-install.md) · Troub
 
 | Channel | Install |
 |---------|---------|
-| DMG | GitHub Releases → drag `llm-swarm-router.app` to Applications |
+| **Source build (recommended macOS 26+)** | Clone tag → `build.sh release` → `packaging/scripts/macos-app-install.sh --source …` — [macos-install.md](docs/macos-install.md) |
 | Homebrew | `brew install netllm` + `brew services start netllm` |
-| Source | `./netllm serve` (unchanged dev path) |
+| CLI / dev | `./netllm serve` from repo root |
+| GitHub DMG | When notarized — until then ad-hoc DMGs fail Gatekeeper on macOS 26+ |
 
 Build: `apps/netllm-mac/Scripts/build.sh release` (requires `venvstacks` + `uv sync`).
 
@@ -168,7 +169,7 @@ Editor wiring reference: [docs/editor-integration.md](docs/editor-integration.md
 Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow, issue templates, and review expectations.
 
 - Conventional commit messages; focus on why
-- Do not commit `.cursor/plans/`, `.cursor/outreach/`, `.cursor/hooks/`, `.cursor/mcp.json`, `.cursor/rules/graphify.mdc`, `archived/`, or secrets
+- Do not commit `.cursor/plans/`, `.cursor/outreach/`, `.cursor/hooks/`, `.cursor/mcp.json`, `.cursor/rules/graphify.mdc`, `archived/`, `.env`, or secrets
 - Do not commit unless the user explicitly asks (agents); human contributors open PRs per CONTRIBUTING.md
 
 ## Do not
@@ -205,8 +206,8 @@ Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow,
 - mDNS (swarm discovery) requires zeroconf from `uv sync`; `serve` on loopback blocks LAN peers — use `--host 0.0.0.0` for swarm; set `swarm.cluster_token` on untrusted networks
 - Do not run the macOS menubar app and `./netllm serve` together; both bind `:11400`. Before quitting the app, use **Stop** so the agent subprocess exits; otherwise an orphan can hold `:11400` and block the next launch.
 - oMLX discovery probes `:8080` by default; backends on other ports need `[discovery].custom_endpoints` or `[[routing.backends]]` in `~/.config/netllm/config.toml`.
-- macOS menubar install/update: repo checkout does not update `/Applications/llm-swarm-router.app` — use GitHub DMG, menubar **Updates**, or bundled `macos-app-install.sh` (`/Applications/llm-swarm-router.app/Contents/Resources/Scripts/` or mounted DMG); `scripts/upgrade-mac-app.sh` is repo-only; in-app update stops agent via `--in-app-update`, logs under `~/Library/Application Support/netllm/logs/`; release notes must not lead with `./scripts/` alone ([docs/release-notes/v0.3.0.1.md](docs/release-notes/v0.3.0.1.md))
-- **macOS Gatekeeper (26+):** GitHub ad-hoc DMGs fail launch (`no usable signature`); notarized Developer ID releases required — [docs/macos-code-signing.md](docs/macos-code-signing.md). CI secrets: `MACOS_CERTIFICATE_P12`, `MACOS_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPLE_ID`, `APPLE_TEAM_ID`, `APPLE_APP_SPECIFIC_PASSWORD`. Local maintainer path: `packaging/scripts/local-notarized-dmg.sh`
+- macOS menubar install/update: **recommended on macOS 26+:** clone release tag → `apps/netllm-mac/Scripts/build.sh release` → `packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app` ([docs/macos-install.md](docs/macos-install.md)); GitHub DMG + menubar **Updates** when notarized; bundled `macos-app-install.sh` under `Contents/Resources/Scripts/`; `scripts/upgrade-mac-app.sh` is repo-only; in-app update stops agent via `--in-app-update`, logs under `~/Library/Application Support/netllm/logs/`; **v0.3.0.2** fixes menubar **Agent: starting…** when `listen = "0.0.0.0:11400"` — [docs/release-notes/v0.3.0.2.md](docs/release-notes/v0.3.0.2.md)
+- **macOS Gatekeeper (26+):** ad-hoc GitHub DMGs fail launch (`no usable signature`); user docs point to **source build + install script** until notarized Developer ID releases ship — [docs/macos-code-signing.md](docs/macos-code-signing.md), [docs/macos-install.md](docs/macos-install.md)
 - Release tag must match root `pyproject.toml` version; bump all workspace packages + `uv lock` before `gh release create`
 - `.cursor/coordinator/` is gitignored local PR overseer (state, drafts, scripts); orchestration via six tracked **Cursor subagents** in `.cursor/agents/coordinator-*.md` (incl. **prospector**) — [`.cursor/coordinator/AGENTS.md`](.cursor/coordinator/AGENTS.md); run `run-coordinator-pass.sh` + `test-coordinator-loop.sh` before paste work; `test-discovery.sh` for offline discover-all smoke
 - `.cursor/outreach/` is gitignored local outreach research/drafts; paste-ready convention: **Target:** / **Title:** / body after `---` (plain markdown, no YAML); neither tree belongs in the remote repo
@@ -231,4 +232,4 @@ Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow,
 | [`.cursor/agents/AGENTS.md`](.cursor/agents/AGENTS.md) | DOX protocol + coordinator subagent index |
 | [`.cursor/coordinator/AGENTS.md`](.cursor/coordinator/AGENTS.md) | Local PR coordinator (gitignored): scripts, state, browse-first stack |
 
-Updated: 2026-06-10 (macOS Developer ID signing/notarization; Gatekeeper on macOS 26+)
+Updated: 2026-06-11 (macOS install: source build + install script primary until notarized DMG)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,11 +199,11 @@ Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow,
 
 ## Learned Workspace Facts
 
-- Local web dashboard at http://127.0.0.1:11400/ui/ on all platforms; macOS menubar has **Open Dashboard**
+- Local web dashboard at http://127.0.0.1:11400/ui/ on all platforms; macOS menubar has **Open Dashboard**; same-host `http://<LAN-IP>:11400/ui/` has full admin; remote LAN browsers are read-only unless `swarm.cluster_token` is set
 - Linux/Windows **alpha** use `/ui/` + CLI; macOS stable adds menubar app: same agent core
 - Published GitHub Releases attach DMG (macOS), `.deb`/`.rpm` (Linux), Windows zip, and `netllm.yaml` via `.github/workflows/release.yml`: see [docs/platform-matrix.md](docs/platform-matrix.md)
 - `./netllm` wrapper runs `uv run --directory $ROOT netllm`: no global install needed; `scripts/agent-verify-setup.sh` prefers global `netllm` when on PATH — use `./netllm` for repo-local smoke
-- mDNS (swarm discovery) requires zeroconf from `uv sync`; `serve` on loopback blocks LAN peers — use `--host 0.0.0.0` for swarm; set `swarm.cluster_token` on untrusted networks
+- mDNS (swarm discovery) requires zeroconf from `uv sync`; `serve` on loopback blocks LAN peers — use `--host 0.0.0.0` for swarm; set `swarm.cluster_token` on untrusted networks; macOS menubar **LAN welcome** enables `swarm.subnet_scan`; Settings polls live agent status while open (see [apps/netllm-mac/AGENTS.md](apps/netllm-mac/AGENTS.md))
 - Do not run the macOS menubar app and `./netllm serve` together; both bind `:11400`. Before quitting the app, use **Stop** so the agent subprocess exits; otherwise an orphan can hold `:11400` and block the next launch.
 - oMLX discovery probes `:8080` by default; backends on other ports need `[discovery].custom_endpoints` or `[[routing.backends]]` in `~/.config/netllm/config.toml`.
 - macOS menubar install/update: **recommended on macOS 26+:** clone release tag → `apps/netllm-mac/Scripts/build.sh release` → `packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app` ([docs/macos-install.md](docs/macos-install.md)); GitHub DMG + menubar **Updates** when notarized; bundled `macos-app-install.sh` under `Contents/Resources/Scripts/`; `scripts/upgrade-mac-app.sh` is repo-only; in-app update stops agent via `--in-app-update`, logs under `~/Library/Application Support/netllm/logs/`; **v0.3.0.2** fixes menubar **Agent: starting…** when `listen = "0.0.0.0:11400"` — [docs/release-notes/v0.3.0.2.md](docs/release-notes/v0.3.0.2.md)
@@ -232,4 +232,4 @@ Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow,
 | [`.cursor/agents/AGENTS.md`](.cursor/agents/AGENTS.md) | DOX protocol + coordinator subagent index |
 | [`.cursor/coordinator/AGENTS.md`](.cursor/coordinator/AGENTS.md) | Local PR coordinator (gitignored): scripts, state, browse-first stack |
 
-Updated: 2026-06-11 (macOS install: source build + install script primary until notarized DMG)
+Updated: 2026-06-11 (dashboard admin on same-host LAN IP; Settings live poll)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude Code: swarm-llm
 
-Primary project guide: **[AGENTS.md](AGENTS.md)** (commands, architecture, do-not rules).
+Primary project guide: **[AGENTS.md](AGENTS.md)** (commands, architecture, do-not rules). DOX protocol: **[`.cursor/agents/AGENTS.md`](.cursor/agents/AGENTS.md)**; per-folder contracts under `packages/`, `apps/`, `docs/`, etc.
 
 **Slash commands** (`.claude/commands/`):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ This repo uses consistent Python tooling:
 - Match existing package layout under `packages/`
 - Typer + Rich patterns for CLI changes in `netllm-cli`
 - Vendor SDKs stay isolated: `netllm-sdk-openai` and `netllm-sdk-anthropic` only: `netllm-core` must not import `openai` or `anthropic`
-- Do not delete files: move to `archived/` and log the action (project convention)
+- Do not delete files: move to local `archived/` and log in `archived/ARCHIVE_LOG.txt` (gitignored; never commit)
 - Do not commit secrets, API keys, or `.cursor/mcp.json`
 
 ### Agent skills

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 # llm-swarm-router
 
 <p align="center">
-  <a href="https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.1"><img src="https://img.shields.io/badge/version-0.3.0.1-orange?style=for-the-badge" alt="Version 0.3.0.1"></a>
+  <a href="https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.2"><img src="https://img.shields.io/badge/version-0.3.0.2-orange?style=for-the-badge" alt="Version 0.3.0.2"></a>
   <a href="docs/macos-install.md"><img src="https://img.shields.io/badge/macOS-Menubar%20app-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS app"></a>
   <a href="docs/linux-install.md"><img src="https://img.shields.io/badge/Linux-deb%2Frpm%20alpha-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Linux alpha"></a>
   <a href="docs/windows-install.md"><img src="https://img.shields.io/badge/Windows-zip%20alpha-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Windows alpha"></a>
@@ -78,25 +78,34 @@ Point **Cursor**, **Claude Code**, **Codex**, **Honcho**, or any compatible clie
 
 | Platform | Status | Install | Troubleshooting |
 |----------|--------|---------|-----------------|
-| **macOS** | Stable: menubar app + CLI | [docs/macos-install.md](docs/macos-install.md) · [DMG](https://github.com/matthewdcage/llm-swarm-router/releases) | [docs/macos-troubleshooting.md](docs/macos-troubleshooting.md) |
+| **macOS** | Stable: menubar app + CLI | [docs/macos-install.md](docs/macos-install.md) (build + install script on macOS 26+) | [docs/macos-troubleshooting.md](docs/macos-troubleshooting.md) |
 | **Linux** | Alpha: deb/rpm + systemd | [docs/linux-install.md](docs/linux-install.md) | [docs/linux-troubleshooting.md](docs/linux-troubleshooting.md) |
 | **Windows** | Alpha: zip + Windows service | [docs/windows-install.md](docs/windows-install.md) | [docs/windows-troubleshooting.md](docs/windows-troubleshooting.md) |
 | **All** (dev/CI) | Source: `uv sync` + `./netllm serve` | [CLI / source](#cli--source-install-all-platforms) below | `./netllm doctor` · http://127.0.0.1:11400/ui/ |
 
 Overview: [docs/platform-matrix.md](docs/platform-matrix.md) · Full doc index: [docs/README.md](docs/README.md)
 
-**Latest release:** [v0.3.0.1](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.1): macOS in-app update download fix; [v0.3.0.0](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.0): App Intents & Shortcuts, SwiftUI MenuBarExtra, `[[routing.policies]]`, launch at login. [All releases](https://github.com/matthewdcage/llm-swarm-router/releases).
+**Latest release:** [v0.3.0.2](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.2): macOS menubar agent start fix (quiet serve + LAN); [v0.3.0.1](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.1): in-app update download fix. [All releases](https://github.com/matthewdcage/llm-swarm-router/releases).
 
 ---
 
-## macOS: install in one step
+## macOS: install (recommended)
 
-**Recommended for Mac users:** download, drag, open. No terminal setup required.
+**On macOS 26 (Tahoe)+:** GitHub release DMGs are ad-hoc signed until Apple notarization is enabled — Gatekeeper may block them. **Build from source and run the install script** (tested path):
 
-1. Download **`llm-swarm-router.dmg`** from [GitHub Releases](https://github.com/matthewdcage/llm-swarm-router/releases/latest) (or [build from source](#build-the-macos-app-developers)).
-2. Open the DMG and drag **llm-swarm-router** to **Applications**.
-3. Launch from Applications. The bee icon appears in the menu bar.
-4. Complete the short welcome wizard (optional LAN mode, auto-start agent).
+```bash
+git clone https://github.com/matthewdcage/llm-swarm-router.git
+cd llm-swarm-router && git checkout v0.3.0.2
+uv sync && uv pip install venvstacks
+apps/netllm-mac/Scripts/build.sh release
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
+```
+
+Launch from Applications. The bee icon appears in the menu bar. Complete the welcome wizard (optional LAN mode, auto-start agent).
+
+**CLI only (no menubar):** `uv sync && ./netllm init && ./netllm serve` — dashboard at http://127.0.0.1:11400/ui/
+
+Full steps: [docs/macos-install.md](docs/macos-install.md)
 
 <p align="center">
   <img src="assets/screenshots/llm-swarm-router-osx-menu.png" alt="llm-swarm-router MenuBarExtra popover v0.3.0.1 showing agent status, routing stats, and quick actions" width="360">
@@ -209,7 +218,7 @@ Pick a model ID from `./netllm models` (or the app **Settings → Models** tab).
 ## What you get
 
 <table>
-<tr><td><b>Native macOS app</b></td><td>Drag-to-Applications install. Menubar supervisor, welcome wizard, full Settings UI (status, backends, models, peers, routing, discovery, doctor). Embeds the Python agent, no separate <code>uv</code> setup for end users.</td></tr>
+<tr><td><b>Native macOS app</b></td><td>Build from source + install script on macOS 26+ (menubar supervisor, welcome wizard, Settings UI). GitHub DMG returns when notarized. Embeds the Python agent.</td></tr>
 <tr><td><b>Linux &amp; Windows packages (alpha)</b></td><td><code>.deb</code> / <code>.rpm</code> with systemd user unit, or Windows zip + <code>NetllmAgent</code> service, first packaged release for these platforms. Same agent core as macOS. Install from <a href="https://github.com/matthewdcage/llm-swarm-router/releases/latest">GitHub Releases</a>.</td></tr>
 <tr><td><b>Web dashboard (all platforms)</b></td><td><a href="http://127.0.0.1:11400/ui/">http://127.0.0.1:11400/ui/</a>, status, models, peers, discover, copy client env. macOS menubar adds <b>Open Dashboard</b>; Linux/Windows use browser + <code>netllm env</code>.</td></tr>
 <tr><td><b>Zero-touch local discovery</b></td><td>Agent scans on every start, oMLX (<code>:8080</code>+, macOS), Ollama (<code>:11434</code>), LM Studio (<code>:1234</code>), vLLM (<code>:8000</code>). Per-machine overrides in Settings or <code>discovery.provider_urls</code>. Found URLs persist automatically.</td></tr>
@@ -278,17 +287,16 @@ Requirements: macOS 15+, Apple Silicon, [uv](https://docs.astral.sh/uv/), Xcode 
 
 ```bash
 uv sync
+uv pip install venvstacks
 apps/netllm-mac/Scripts/build.sh release
-packaging/scripts/create-dmg.sh    # → dist/llm-swarm-router.dmg
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
+# Optional maintainer DMG (ad-hoc until notarized): packaging/scripts/create-dmg.sh
 ```
 
 **Test like an end user** (build → Applications → launch):
 
 ```bash
-./scripts/emulate-user-install-mac.sh   # build + clean install
-
-# Upgrade from a downloaded release DMG (stops stale agents, verifies /ui/)
-./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
+./scripts/emulate-user-install-mac.sh   # build + macos-app-install.sh --source
 ```
 
 Python layer packaging (venvstacks): [packaging/README.md](packaging/README.md)

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ export ANTHROPIC_API_KEY=netllm-local
 
 Pick a model ID from `./netllm models` (or the app **Settings → Models** tab). Full per-editor steps: [docs/editor-integration.md](docs/editor-integration.md).
 
+**Honcho:** Point deriver/dialectic `base_url` and connector `LLM_OPENAI_COMPATIBLE_BASE_URL` at netllm once; keep your model names; put oMLX/Ollama/LM Studio URLs in `~/.config/netllm/config.toml`. Swarm peers distribute automatically. Details: [docs/honcho-integration.md](docs/honcho-integration.md).
+
 ---
 
 ## What you get

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ export OPENAI_API_KEY=netllm-local
 
 ## Wire your editor
 
+Point any compatible client at netllm **once**. Keep your model IDs; configure oMLX, Ollama, LM Studio, and swarm peers in `~/.config/netllm/config.toml` only (not per-client URL lists). LAN peers distribute automatically after `./netllm peers`.
+
 ```bash
 export OPENAI_BASE_URL=http://127.0.0.1:11400/v1
 export OPENAI_API_KEY=netllm-local
@@ -211,9 +213,7 @@ export ANTHROPIC_BASE_URL=http://127.0.0.1:11400
 export ANTHROPIC_API_KEY=netllm-local
 ```
 
-Pick a model ID from `./netllm models` (or the app **Settings → Models** tab). Full per-editor steps: [docs/editor-integration.md](docs/editor-integration.md).
-
-**Honcho:** Point deriver/dialectic `base_url` and connector `LLM_OPENAI_COMPATIBLE_BASE_URL` at netllm once; keep your model names; put oMLX/Ollama/LM Studio URLs in `~/.config/netllm/config.toml`. Swarm peers distribute automatically. Details: [docs/honcho-integration.md](docs/honcho-integration.md).
+Pick a model ID from `./netllm models` (or the app **Settings → Models** tab). Full client table and per-editor steps: [docs/editor-integration.md](docs/editor-integration.md). Honcho connectors: [docs/honcho-integration.md](docs/honcho-integration.md).
 
 ---
 

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -25,7 +25,7 @@ Parent rail: [../AGENTS.md](../AGENTS.md). Release builds: [../packaging/AGENTS.
 ```bash
 scripts/verify-before-pr.sh          # macOS Swift build
 scripts/verify-before-pr.sh --full   # + menubar e2e when Stage .app exists
-scripts/test-menubar-e2e.sh
+scripts/test-menubar-e2e.sh          # bundled serve -q + 0.0.0.0 listen smoke before DMG
 ```
 
 ## Child DOX Index

--- a/apps/netllm-mac/AGENTS.md
+++ b/apps/netllm-mac/AGENTS.md
@@ -13,8 +13,8 @@ Swift menubar application that supervises the netllm Python agent, exposes setti
 | `Sources/App/` | Entry, delegate, lifecycle |
 | `Sources/Menubar/` | Status item, stats polling |
 | `Sources/Server/` | Process supervisor, control socket |
-| `Sources/Config/` | TOML slices, CLI shim, branding, tokens |
-| `Sources/AppView/` | Settings, welcome, about, glass chrome |
+| `Sources/Config/` | TOML slices, CLI shim, `AgentAPI` HTTP client, branding, tokens |
+| `Sources/AppView/` | Settings (`SettingsViewModel` live poll), welcome, about, glass chrome |
 | `Sources/Updater/` | GitHub Releases check, in-app install |
 | `Sources/Welcome/` | First-run wizard |
 | `Scripts/build.sh` | Release/stage build (venvstacks + Swift); ad-hoc sign unless `CODESIGN_IDENTITY` set |
@@ -28,6 +28,9 @@ Swift menubar application that supervises the netllm Python agent, exposes setti
 - Repo checkout does not update `/Applications/llm-swarm-router.app`; user upgrade: menubar **Updates** or bundled `macos-app-install.sh` (embedded under `Contents/Resources/Scripts/`); `scripts/upgrade-mac-app.sh` is repo-maintainer wrapper only
 - Logs: `~/Library/Application Support/netllm/logs/`
 - **Gatekeeper:** ad-hoc Stage/DMG builds do not launch on macOS 26+; release path is Developer ID + notarize via [packaging/scripts/local-notarized-dmg.sh](../../packaging/scripts/local-notarized-dmg.sh) or CI ([macos-code-signing.md](../../docs/macos-code-signing.md))
+- **Settings live status:** `SettingsViewModel` polls `/health` + `/netllm/v1/status` every 2s while Settings is open; **Restart Agent** waits for `/health` before refreshing stats (avoids stale "waiting for HTTP health" / backends `—`)
+- **LAN swarm QoL:** welcome **Listen on LAN** sets `swarm.subnet_scan = true`; agent probes LAN at startup when enabled. Settings auto-runs `POST /netllm/v1/admin/peers-scan` once per session when agent is healthy (display only; runtime merge is agent-side). Manual **Scan & save** still persists `swarm.peers` when mDNS is blocked.
+- **HTTP client host:** Settings and menubar **Open Dashboard** use `127.0.0.1` (`AppConfig.connectableHost`); web UI opened at `http://<LAN-IP>:11400/ui/` on the same Mac is equivalent after agent admin-host fix ([netllm-agent/AGENTS.md](../../packages/netllm-agent/AGENTS.md))
 
 ## Work Guidance
 

--- a/apps/netllm-mac/Sources/AppView/SettingsViewModel.swift
+++ b/apps/netllm-mac/Sources/AppView/SettingsViewModel.swift
@@ -22,6 +22,10 @@ final class SettingsViewModel {
     var agentLogs: AgentLogsPayload?
     private(set) var uiRevision = 0
 
+    private var livePollTask: Task<Void, Never>?
+    private var autoPeerScanTask: Task<Void, Never>?
+    private var didAutoPeerScan = false
+
     let configStore: ConfigStore
     let cli: CLIRunner
     private(set) var agentBaseURL: URL
@@ -104,10 +108,45 @@ final class SettingsViewModel {
 
     func reloadAll() async {
         await runAction("Reloading…") {
+            didAutoPeerScan = false
             document = try configStore.load()
             updateAgentURL()
             await refreshLiveData()
+            scheduleAutoPeerScanIfNeeded()
             setSuccess("Config and live status refreshed.")
+        }
+    }
+
+    /// Poll agent health while Settings is open so stats update without quit/restart.
+    func startLivePolling() {
+        livePollTask?.cancel()
+        livePollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await self.refreshLiveData()
+                try? await Task.sleep(for: .seconds(2))
+            }
+        }
+    }
+
+    func stopLivePolling() {
+        livePollTask?.cancel()
+        livePollTask = nil
+        autoPeerScanTask?.cancel()
+        autoPeerScanTask = nil
+    }
+
+    /// After Restart Agent, wait until /health responds before refreshing stats.
+    func waitForAgentHealth(maxAttempts: Int = 30) async {
+        updateAgentURL()
+        for _ in 0..<maxAttempts {
+            if Task.isCancelled { return }
+            if await AgentAPI.isReachable(baseURL: agentBaseURL) {
+                agentReachable = true
+                bumpUI()
+                return
+            }
+            try? await Task.sleep(for: .seconds(1))
         }
     }
 
@@ -123,6 +162,7 @@ final class SettingsViewModel {
 
     func refreshLiveData() async {
         updateAgentURL()
+        let wasReachable = agentReachable
         agentReachable = await AgentAPI.isReachable(baseURL: agentBaseURL)
         if agentReachable {
             async let statusTask = AgentAPI.status(baseURL: agentBaseURL)
@@ -135,12 +175,40 @@ final class SettingsViewModel {
                 routedModels = AgentAPI.modelsFromStatus(status)
             }
             syncDiscoverProvidersFromStatus()
+            if !wasReachable {
+                scheduleAutoPeerScanIfNeeded()
+            }
         } else {
             status = nil
             agentVersion = nil
             routedModels = []
         }
         bumpUI()
+    }
+
+    private var swarmDiscoveryEnabled: Bool {
+        document.swarm.mdns
+            || document.swarm.subnet_scan
+            || !document.swarm.peers.isEmpty
+            || document.bindHost == "0.0.0.0"
+    }
+
+    private func scheduleAutoPeerScanIfNeeded() {
+        guard agentReachable, swarmDiscoveryEnabled, !didAutoPeerScan else { return }
+        autoPeerScanTask?.cancel()
+        autoPeerScanTask = Task { [weak self] in
+            await self?.autoDiscoverLanPeers()
+        }
+    }
+
+    /// Background subnet scan for Settings stats (no save; agent merges peers at runtime).
+    private func autoDiscoverLanPeers() async {
+        guard !didAutoPeerScan else { return }
+        didAutoPeerScan = true
+        if let result = await AgentAPI.peersScan(baseURL: agentBaseURL) {
+            lanPeers = result.peers
+            bumpUI()
+        }
     }
 
     /// Agent discovers providers on startup; mirror that in the Settings UI without a manual scan.
@@ -237,25 +305,20 @@ final class SettingsViewModel {
         Task {
             let label = save ? "Scanning LAN and saving peers…" : "Scanning LAN for peers…"
             await runAction(label) {
-                var args = ["peers", "--json", "--subnet-scan"]
-                if save { args.append("--save") }
-                let json = try parseCLIJSON(command: args)
-                guard let peers = json["peers"] as? [[String: Any]] else {
-                    throw ActionError.unexpectedResponse("peers")
-                }
-                let warnings = (json["warnings"] as? [String] ?? []).joined(separator: " ")
-                lanPeers = peers.map { row in
-                    PeerStatus(
-                        agentId: row["agent_id"] as? String ?? "",
-                        listenURL: row["listen_url"] as? String ?? "",
-                        role: row["role"] as? String ?? "peer",
-                        hostname: row["hostname"] as? String ?? ""
-                    )
-                }
-                if save {
-                    document = try configStore.load()
-                    needsRestart = true
-                }
+                try await applyPeersScan(save: save, showManualHints: true)
+            }
+        }
+    }
+
+    private func applyPeersScan(save: Bool, showManualHints: Bool) async throws {
+        if agentReachable, let result = await AgentAPI.peersScan(baseURL: agentBaseURL, save: save) {
+            lanPeers = result.peers
+            let warnings = result.warnings
+            if save {
+                document = try configStore.load()
+                needsRestart = true
+            }
+            if showManualHints {
                 if lanPeers.isEmpty {
                     let hint = warnings.isEmpty
                         ? "mDNS often fails on Wi‑Fi — subnet scan also found none."
@@ -267,12 +330,52 @@ final class SettingsViewModel {
                     var msg = "Found \(lanPeers.count) LAN agent(s): \(names)."
                     if save {
                         msg += " Restart agent to merge remote backends."
-                    } else {
-                        msg += " Use Scan & save, then Restart agent."
+                    } else if connectedPeerCount == 0 {
+                        msg += " Peers connect automatically when subnet scan is enabled."
                     }
                     if !warnings.isEmpty { msg += " \(warnings)" }
                     setSuccess(msg)
                 }
+            }
+            return
+        }
+
+        var args = ["peers", "--json", "--subnet-scan"]
+        if save { args.append("--save") }
+        let json = try parseCLIJSON(command: args)
+        guard let peers = json["peers"] as? [[String: Any]] else {
+            throw ActionError.unexpectedResponse("peers")
+        }
+        let warnings = (json["warnings"] as? [String] ?? []).joined(separator: " ")
+        lanPeers = peers.map { row in
+            PeerStatus(
+                agentId: row["agent_id"] as? String ?? "",
+                listenURL: row["listen_url"] as? String ?? "",
+                role: row["role"] as? String ?? "peer",
+                hostname: row["hostname"] as? String ?? ""
+            )
+        }
+        if save {
+            document = try configStore.load()
+            needsRestart = true
+        }
+        if showManualHints {
+            if lanPeers.isEmpty {
+                let hint = warnings.isEmpty
+                    ? "mDNS often fails on Wi‑Fi — subnet scan also found none."
+                    : warnings
+                setSuccess("Scan complete — no LAN agents found. \(hint)")
+            } else {
+                let names = lanPeers.map { $0.hostname.isEmpty ? $0.listenURL : $0.hostname }
+                    .joined(separator: ", ")
+                var msg = "Found \(lanPeers.count) LAN agent(s): \(names)."
+                if save {
+                    msg += " Restart agent to merge remote backends."
+                } else {
+                    msg += " Use Scan & save, then Restart agent."
+                }
+                if !warnings.isEmpty { msg += " \(warnings)" }
+                setSuccess(msg)
             }
         }
     }

--- a/apps/netllm-mac/Sources/AppView/SettingsWindowView.swift
+++ b/apps/netllm-mac/Sources/AppView/SettingsWindowView.swift
@@ -57,14 +57,22 @@ struct SettingsWindowView: View {
                 }
             }
         }
-        .task { await model.reloadAll() }
+        .task {
+            await model.reloadAll()
+            model.startLivePolling()
+        }
+        .onDisappear { model.stopLivePolling() }
         .onAppear { portText = String(model.document.port) }
     }
 
     private func restartAgent() {
         supervisor.restart()
         onRestartAgent?()
-        Task { await model.refreshLiveData() }
+        Task {
+            await model.waitForAgentHealth()
+            await model.refreshLiveData()
+            model.needsRestart = false
+        }
     }
 
     @ViewBuilder
@@ -320,14 +328,14 @@ struct SettingsWindowView: View {
                 Text("No peers connected to running agent.").foregroundStyle(.secondary)
             }
             sectionHeader("LAN discovery")
-            Text("Scans your subnet (10.0.0.0/24) for agents on :11400. Wi‑Fi often blocks mDNS, so subnet scan is used automatically.")
+            Text("Subnet scan runs automatically when the agent is healthy (enable Subnet scan in Swarm). Wi‑Fi often blocks mDNS; static peers in config still work.")
                 .font(.caption).foregroundStyle(.secondary)
             actionButtons {
                 Button("Scan network") { model.runPeersScan() }
                 Button("Scan & save to config") { model.runPeersScan(save: true) }
             }
             if model.lanPeers.isEmpty && !model.isLoading && model.message == nil && model.errorMessage == nil {
-                Text("No scan yet — click Scan network (takes ~10s on a /24).")
+                Text("Scanning automatically when agent is ready (~10s on a /24).")
                     .font(.caption).foregroundStyle(.secondary)
             } else if model.lanPeers.isEmpty && model.message != nil {
                 Text("Last scan returned no LAN agents.")
@@ -419,7 +427,9 @@ struct SettingsWindowView: View {
         VStack(alignment: .leading, spacing: 12) {
             sectionHeader("Swarm")
             Toggle("mDNS discovery", isOn: $model.document.swarm.mdns)
-            Toggle("Subnet scan", isOn: $model.document.swarm.subnet_scan)
+            Toggle("Subnet scan at startup", isOn: $model.document.swarm.subnet_scan)
+            Text("Probes the LAN for agents on :11400 when the agent starts. Recommended when listening on 0.0.0.0.")
+                .font(.caption).foregroundStyle(.secondary)
             HStack {
                 Text("Heartbeat (s)")
                 TextField("10", value: $model.document.swarm.heartbeat_interval_s, format: .number)

--- a/apps/netllm-mac/Sources/Config/AgentAPI.swift
+++ b/apps/netllm-mac/Sources/Config/AgentAPI.swift
@@ -96,6 +96,34 @@ enum AgentAPI {
         }
     }
 
+    /// Subnet-scan for LAN agents (same as `netllm peers --subnet-scan`).
+    static func peersScan(baseURL: URL, save: Bool = false) async -> (peers: [PeerStatus], warnings: String)? {
+        var components = URLComponents(
+            url: baseURL.appendingPathComponent("/netllm/v1/admin/peers-scan"),
+            resolvingAgainstBaseURL: false
+        )
+        if save {
+            components?.queryItems = [URLQueryItem(name: "save", value: "true")]
+        }
+        guard let url = components?.url else { return nil }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 30
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            let rows = json["peers"] as? [[String: Any]] ?? []
+            let peers = rows.map(parsePeer)
+            let warnings = (json["warnings"] as? [String] ?? []).joined(separator: " ")
+            return (peers, warnings)
+        } catch {
+            return nil
+        }
+    }
+
     private static func parseBackend(_ dict: [String: Any]) -> BackendStatus {
         let health = dict["health"] as? [String: Any] ?? [:]
         let models = health["models"] as? [String] ?? []

--- a/apps/netllm-mac/Sources/Config/AppConfig.swift
+++ b/apps/netllm-mac/Sources/Config/AppConfig.swift
@@ -96,6 +96,7 @@ struct AppConfig: Sendable {
                 "",
                 "[swarm]",
                 "mdns = true",
+                "subnet_scan = false",
                 "",
                 "[routing]",
                 "default_strategy = \"local_first\"",
@@ -108,6 +109,12 @@ struct AppConfig: Sendable {
 
         let listen = lanMode ? "0.0.0.0:\(port)" : "\(bindHost):\(port)"
         lines = mergeTomlValue(lines, key: "listen", value: "\"\(listen)\"", section: "[agent]")
+        lines = mergeTomlValue(
+            lines,
+            key: "subnet_scan",
+            value: lanMode ? "true" : "false",
+            section: "[swarm]"
+        )
         lines = mergeTomlValue(lines, key: "auto_start_on_launch", value: autoStart ? "true" : "false", section: "[ui]")
         try lines.joined(separator: "\n").write(to: path, atomically: true, encoding: .utf8)
     }

--- a/apps/netllm-mac/Sources/Welcome/WelcomeView.swift
+++ b/apps/netllm-mac/Sources/Welcome/WelcomeView.swift
@@ -18,7 +18,7 @@ struct WelcomeView: View {
                 Button("Continue") { step = 1 }
             case 1:
                 Toggle("Listen on LAN (0.0.0.0)", isOn: $lanMode)
-                Text("Enable for swarm peers on your network. Set cluster_token in Settings for untrusted LANs.")
+                Text("Enables swarm on your network and turns on subnet scan at agent startup (Wi‑Fi often blocks mDNS). Set cluster_token in Settings for untrusted LANs.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Toggle("Start agent on launch", isOn: $autoStart)

--- a/config.example.toml
+++ b/config.example.toml
@@ -11,7 +11,7 @@ advertise = true
 # Linux/Windows default (netllm init): ollama, lmstudio, vllm (no omlx)
 providers = ["omlx", "ollama", "lmstudio", "vllm"]
 custom_endpoints = []
-# Per-machine overrides (tried before default port scan). Example Mac mini oMLX on 8088:
+# Per-machine overrides (tried before default port scan). Example desktop node with oMLX on 8088:
 # [discovery.provider_urls]
 # omlx = ["http://127.0.0.1:8088/v1"]
 # ollama = ["http://127.0.0.1:11434/v1"]

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,15 +24,15 @@ Parent rail: [../AGENTS.md](../AGENTS.md).
 - Release tag must match root `pyproject.toml` version
 - Do not commit `.cursor/plans/`, `.cursor/outreach/`, or coordinator drafts here
 - User-facing command examples use placeholders (`/path/to/llm-swarm-router`, `~/Downloads/…`); never maintainer machine paths (`/Volumes/…`, named dev hardware)
-- **macOS Gatekeeper (macOS 26+):** ad-hoc GitHub DMGs are rejected at launch (`no usable signature`); terminal `macos-app-install.sh` copies the bundle but does not bypass Gatekeeper — notarized Developer ID DMG required ([macos-code-signing.md](macos-code-signing.md), [macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch))
-- **macOS DMG upgrade (users):** menubar **Updates**, then bundled `Contents/Resources/Scripts/macos-app-install.sh` (from `/Applications/…` or mounted DMG at `/Volumes/llm-swarm-router/…`). `./scripts/upgrade-mac-app.sh` is **repo-checkout only** — never the sole path in release notes or install guides
+- **macOS Gatekeeper (macOS 26+):** ad-hoc GitHub DMGs are rejected at launch; user-facing install guides lead with **clone tag → build → `macos-app-install.sh --source`** ([macos-install.md](macos-install.md), [macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch)); notarized DMG path documented for when signing ships ([macos-code-signing.md](macos-code-signing.md))
+- **macOS upgrade (users):** build from source + `--source` install on macOS 26+; menubar **Updates** and `--dmg` install when notarized; bundled `macos-app-install.sh` under `Contents/Resources/Scripts/`; `./scripts/upgrade-mac-app.sh` is **repo-checkout only**
 - **Release notes:** macOS install order documented in [ci-and-release.md](ci-and-release.md); canonical example [release-notes/v0.3.0.1.md](release-notes/v0.3.0.1.md)
 
 ## Work Guidance
 
 - New platform behavior: update install + troubleshooting + platform-matrix together
 - SDK bumps: update `sdk-versions.md` in same PR as package dep change
-- Release notes go under `release-notes/` with version in filename; macOS blocks follow v0.3.0.1 pattern (in-app → bundled installer → optional repo script)
+- Release notes go under `release-notes/` with version in filename; macOS blocks follow v0.3.0.1 pattern (in-app → bundled installer → optional repo script); menubar agent-start fixes: [release-notes/v0.3.0.2.md](release-notes/v0.3.0.2.md)
 - macOS signing/notarization changes: update `macos-code-signing.md`, `ci-and-release.md`, and install/troubleshooting Gatekeeper sections together
 
 ## Verification

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -34,6 +34,7 @@ Parent rail: [../AGENTS.md](../AGENTS.md).
 - SDK bumps: update `sdk-versions.md` in same PR as package dep change
 - Release notes go under `release-notes/` with version in filename; macOS blocks follow v0.3.0.1 pattern (in-app → bundled installer → optional repo script); menubar agent-start fixes: [release-notes/v0.3.0.2.md](release-notes/v0.3.0.2.md)
 - macOS signing/notarization changes: update `macos-code-signing.md`, `ci-and-release.md`, and install/troubleshooting Gatekeeper sections together
+- Web dashboard / admin-access behavior: document in `macos-troubleshooting.md` (Swarm or dashboard section) when agent `admin.py` or `static/dashboard.js` contracts change
 
 ## Verification
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -21,6 +21,7 @@ Parent rail: [../AGENTS.md](../AGENTS.md).
 ## Local Contracts
 
 - User docs stay plain and actionable; agent commands use `./netllm` from repo root
+- **Honcho:** [honcho-integration.md](honcho-integration.md) opens with a **Bottom line** (one netllm URL in Honcho, model names unchanged, backends in netllm config, swarm auto-distributes); README and [editor-integration.md](editor-integration.md) link or summarize the same contract
 - Release tag must match root `pyproject.toml` version
 - Do not commit `.cursor/plans/`, `.cursor/outreach/`, or coordinator drafts here
 - User-facing command examples use placeholders (`/path/to/llm-swarm-router`, `~/Downloads/…`); never maintainer machine paths (`/Volumes/…`, named dev hardware)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -21,7 +21,7 @@ Parent rail: [../AGENTS.md](../AGENTS.md).
 ## Local Contracts
 
 - User docs stay plain and actionable; agent commands use `./netllm` from repo root
-- **Honcho:** [honcho-integration.md](honcho-integration.md) opens with a **Bottom line** (one netllm URL in Honcho, model names unchanged, backends in netllm config, swarm auto-distributes); README and [editor-integration.md](editor-integration.md) link or summarize the same contract
+- **Client wiring:** [editor-integration.md](editor-integration.md) **Client configuration (all tools)** is canonical (one netllm URL per client, model IDs unchanged, backends in netllm config); [honcho-integration.md](honcho-integration.md) adds Honcho-only connector sharding
 - Release tag must match root `pyproject.toml` version
 - Do not commit `.cursor/plans/`, `.cursor/outreach/`, or coordinator drafts here
 - User-facing command examples use placeholders (`/path/to/llm-swarm-router`, `~/Downloads/…`); never maintainer machine paths (`/Volumes/…`, named dev hardware)

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Overview: [platform-matrix.md](platform-matrix.md)
 
 | Topic | Doc |
 |-------|-----|
-| Latest release | [v0.3.0.1 release notes](release-notes/v0.3.0.1.md) · [GitHub Releases](https://github.com/matthewdcage/llm-swarm-router/releases) |
+| Latest release | [v0.3.0.2 release notes](release-notes/v0.3.0.2.md) · [GitHub Releases](https://github.com/matthewdcage/llm-swarm-router/releases) |
 | Prior alpha (Linux/Windows) | [v0.2.2 release notes](release-notes/v0.2.2-alpha.md) |
 | Linux/Windows QA checklist | [solutions/linux-windows-alpha-qa.md](solutions/linux-windows-alpha-qa.md) |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,8 @@ Overview: [platform-matrix.md](platform-matrix.md)
 
 | Topic | Doc |
 |-------|-----|
-| Wire Cursor, Claude Code, Codex, Honcho | [editor-integration.md](editor-integration.md) |
-| Honcho (Docker / deriver) | [honcho-integration.md](honcho-integration.md) |
+| Wire Cursor, Claude Code, Codex, Honcho | [editor-integration.md](editor-integration.md) (start at **Client configuration**) |
+| Honcho (Docker / deriver / connectors) | [honcho-integration.md](honcho-integration.md) |
 | Quick diagnostic | `./netllm doctor` from repo root or global install |
 
 ## Developers & agents

--- a/docs/ci-and-release.md
+++ b/docs/ci-and-release.md
@@ -70,9 +70,9 @@ Triggered by publishing a GitHub Release whose tag matches `pyproject.toml` (e.g
 5. `git push origin main`
 6. `gh release create vX.Y.Z --title "..." --notes-file docs/release-notes/vX.Y.Z.md`
 
-**macOS upgrade text in release notes:** prefer menubar **Updates**, then the bundled `macos-app-install.sh` path (no git clone), then optional `cd /path/to/llm-swarm-router && ./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg` for contributors. Do not assume readers have a repo checkout. See [v0.3.0.1 notes](release-notes/v0.3.0.1.md) for the pattern.
+**macOS upgrade text in release notes:** on macOS 26+, lead with **build from source + `macos-app-install.sh --source`** ([macos-install.md](macos-install.md)); menubar **Updates** and `--dmg` paths when notarized. Do not assume drag-to-Applications works. See [v0.3.0.2 notes](release-notes/v0.3.0.2.md).
 
-Release job builds and attaches: `llm-swarm-router.dmg`, `.deb`, `.rpm`, Windows zip, `netllm.yaml`, SHA256 sidecars.
+Release job builds and attaches: `llm-swarm-router.dmg` (ad-hoc until notarized), `.deb`, `.rpm`, Windows zip, `netllm.yaml`, SHA256 sidecars.
 
 **macOS Gatekeeper:** configure Developer ID + notarization secrets per [macos-code-signing.md](macos-code-signing.md). Release workflow signs after menubar tests, notarizes the DMG, then writes SHA256 sidecars. Without secrets, DMGs remain ad-hoc signed — point users at [macos-troubleshooting.md](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch).
 

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -62,7 +62,15 @@ When your setup supports a custom OpenAI-compatible endpoint, use the same base 
 
 ## Honcho
 
-See [honcho-integration.md](honcho-integration.md). Use `http://host.docker.internal:11400/v1` when Honcho runs in Docker and netllm on the host.
+Full guide: [honcho-integration.md](honcho-integration.md).
+
+**Bottom line:** Change Honcho's `base_url` and connector env to netllm once (`http://127.0.0.1:11400/v1`, or `http://host.docker.internal:11400/v1` from Docker). Keep model names as-is. Configure oMLX, Ollama, LM Studio, and swarm peers in `~/.config/netllm/config.toml` only, not in Honcho. Once LAN peers are up, routing is automatic; Honcho does not need per-machine URLs.
+
+```toml
+# Honcho deriver / dialectic overrides (example)
+base_url = "http://host.docker.internal:11400/v1"
+api_key = "netllm-local"
+```
 
 ## LAN / swarm gateway
 

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -17,6 +17,24 @@ export OPENAI_BASE_URL=http://127.0.0.1:11400/v1
 export OPENAI_API_KEY=netllm-local
 ```
 
+## Client configuration (all tools)
+
+Use the same pattern for **Cursor, Claude Code, Codex, Honcho, Continue, Cline, curl, and custom apps**:
+
+| Setting | Value |
+|---------|--------|
+| OpenAI-compatible base URL | `http://127.0.0.1:11400/v1` on the same machine, `http://<gateway-ip>:11400/v1` for a LAN gateway, or `http://host.docker.internal:11400/v1` when the client runs in Docker and netllm on the host |
+| API key | `netllm-local` (placeholder; real keys only for optional cloud failover) |
+| Model ID | Unchanged from your current setup; must match `./netllm models` exactly |
+| Backend URLs (oMLX, Ollama, LM Studio, vLLM) | **`~/.config/netllm/config.toml` only** — discovery, Settings UI, or `[[routing.backends]]`. Do not keep per-machine URL lists in each client. |
+| Multi-machine swarm | Run `./netllm serve --host 0.0.0.0` on each node; clients still use **one** netllm URL. Peers merge automatically (`./netllm peers`). Optional: `./netllm gateway` on one host, then point clients at that agent only. |
+
+**Anthropic Messages API clients** (Claude Code native path, some agents): use `http://127.0.0.1:11400` (no `/v1`) and `ANTHROPIC_API_KEY=netllm-local`.
+
+Verify after wiring: `./netllm test --model <your-model>` (add `--api anthropic` for Messages API).
+
+Per-tool UI steps below; Honcho-specific connector sharding: [honcho-integration.md](honcho-integration.md).
+
 ## Cursor
 
 1. **Cursor Settings** → **Models**
@@ -62,15 +80,16 @@ When your setup supports a custom OpenAI-compatible endpoint, use the same base 
 
 ## Honcho
 
-Full guide: [honcho-integration.md](honcho-integration.md).
-
-**Bottom line:** Change Honcho's `base_url` and connector env to netllm once (`http://127.0.0.1:11400/v1`, or `http://host.docker.internal:11400/v1` from Docker). Keep model names as-is. Configure oMLX, Ollama, LM Studio, and swarm peers in `~/.config/netllm/config.toml` only, not in Honcho. Once LAN peers are up, routing is automatic; Honcho does not need per-machine URLs.
+Full guide: [honcho-integration.md](honcho-integration.md). Follow **Client configuration (all tools)** above, then set Honcho-specific overrides:
 
 ```toml
-# Honcho deriver / dialectic overrides (example)
+# deriver / dialectic (example)
+[deriver.model_config.overrides]
 base_url = "http://host.docker.internal:11400/v1"
 api_key = "netllm-local"
 ```
+
+Connectors: single `LLM_OPENAI_COMPATIBLE_BASE_URL` (not comma-separated URLs) plus `CONNECTOR_LLM_ROUTING_STRATEGY=batch_shard` when running parallel workers. See the Honcho guide for shard headers.
 
 ## LAN / swarm gateway
 

--- a/docs/honcho-integration.md
+++ b/docs/honcho-integration.md
@@ -2,12 +2,12 @@
 
 Use **netllm** as a drop-in OpenAI-compatible router for Honcho instead of embedding multi-endpoint URLs in `config.toml` or connector env vars.
 
-## Bottom line
+Honcho follows the same client rules as every other tool: [editor-integration.md](editor-integration.md#client-configuration-all-tools). Summary for Honcho:
 
-1. Point Honcho at netllm **once**: set `base_url` (deriver/dialectic) and `LLM_OPENAI_COMPATIBLE_BASE_URL` (connectors) to `http://127.0.0.1:11400/v1`, or `http://host.docker.internal:11400/v1` when Honcho runs in Docker and netllm on the host.
-2. **Keep your existing model names** in Honcho config; netllm routes by model ID against its backend catalog (`./netllm models`).
-3. Put all oMLX, Ollama, LM Studio, vLLM, and custom OpenAI-compatible URLs in **`~/.config/netllm/config.toml`** (discovery or `[[routing.backends]]`), not in Honcho. Do not dual-configure Honcho's embedded endpoint pool and netllm at the same time.
-4. With swarm peers visible (`./netllm peers`), distribution across machines is automatic; Honcho never needs per-machine backend URLs. Optionally point Honcho at one **gateway** agent only (`./netllm gateway` on one host).
+1. Set deriver/dialectic `base_url` and connector `LLM_OPENAI_COMPATIBLE_BASE_URL` to netllm once (`http://127.0.0.1:11400/v1`, or `http://host.docker.internal:11400/v1` from Docker).
+2. Keep your existing **model names**; netllm matches them against `./netllm models`.
+3. Configure oMLX, Ollama, LM Studio, vLLM, and swarm peers in **`~/.config/netllm/config.toml`**, not in Honcho. Remove Honcho's embedded endpoint pool when migration is verified (see [Migration policy](#migration-policy)).
+4. With swarm peers visible (`./netllm peers`), routing across machines is automatic; Honcho does not need per-machine backend URLs.
 
 ## Prerequisites
 

--- a/docs/honcho-integration.md
+++ b/docs/honcho-integration.md
@@ -2,6 +2,13 @@
 
 Use **netllm** as a drop-in OpenAI-compatible router for Honcho instead of embedding multi-endpoint URLs in `config.toml` or connector env vars.
 
+## Bottom line
+
+1. Point Honcho at netllm **once**: set `base_url` (deriver/dialectic) and `LLM_OPENAI_COMPATIBLE_BASE_URL` (connectors) to `http://127.0.0.1:11400/v1`, or `http://host.docker.internal:11400/v1` when Honcho runs in Docker and netllm on the host.
+2. **Keep your existing model names** in Honcho config; netllm routes by model ID against its backend catalog (`./netllm models`).
+3. Put all oMLX, Ollama, LM Studio, vLLM, and custom OpenAI-compatible URLs in **`~/.config/netllm/config.toml`** (discovery or `[[routing.backends]]`), not in Honcho. Do not dual-configure Honcho's embedded endpoint pool and netllm at the same time.
+4. With swarm peers visible (`./netllm peers`), distribution across machines is automatic; Honcho never needs per-machine backend URLs. Optionally point Honcho at one **gateway** agent only (`./netllm gateway` on one host).
+
 ## Prerequisites
 
 - netllm agent running on the host: `netllm serve` (default `http://127.0.0.1:11400/v1`)

--- a/docs/macos-code-signing.md
+++ b/docs/macos-code-signing.md
@@ -1,6 +1,6 @@
 # macOS code signing and notarization
 
-Release DMGs are **Developer ID signed and notarized** when GitHub Actions secrets are configured. Without secrets, builds fall back to ad-hoc signing and users may see Gatekeeper prompts ([macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch)).
+Release DMGs are **Developer ID signed and notarized** when GitHub Actions secrets are configured. **Until notarization ships**, CI attaches ad-hoc DMGs and user docs recommend **build from source + `macos-app-install.sh --source`** on macOS 26+ ([macos-install.md](macos-install.md), [macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch)).
 
 ## One-time setup
 

--- a/docs/macos-install.md
+++ b/docs/macos-install.md
@@ -5,49 +5,61 @@ existing Python agent on port **11400**, it does not replace oMLX inference on p
 
 **Troubleshooting:** [macos-troubleshooting.md](macos-troubleshooting.md) · **All platforms:** [platform-matrix.md](platform-matrix.md)
 
+> **GitHub DMG status (2026-06):** Release DMGs are **ad-hoc signed** until Apple Developer notarization is enabled. On **macOS 26 (Tahoe)+**, Gatekeeper blocks ad-hoc menubar apps (`no usable signature`). Until notarized DMGs ship, use **build from source + install script** below (recommended) or **CLI-only** `./netllm serve`.
+
 ## Install channels
 
-### DMG (recommended for desktop users)
+### Build from source + install script (recommended on macOS 26+)
 
-1. Download `llm-swarm-router.dmg` from [GitHub Releases](https://github.com/matthewdcage/llm-swarm-router/releases/latest).
-2. Open the DMG and drag **llm-swarm-router** to **Applications** (click **Replace** when upgrading).
-3. **Quit** any running menubar instance before replacing (About → Quit), or use the clean upgrade script below.
-4. Launch from Applications, the llm-swarm-router bee logo appears in the menu bar (switches for light/dark menu bar).
-5. Complete the welcome wizard (config path, LAN mode, auto-start).
+Works on Tahoe without Gatekeeper blocks. Uses the same installer CI validates before release.
 
-If macOS blocks drag-to-Applications (*cannot verify free from malware*), use the **terminal installer** below or see [Gatekeeper troubleshooting](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch).
-
-### Upgrade from a release DMG (clean, recommended)
-
-Avoid `/ui/` 404 and port conflicts after upgrade: stop stale agents, replace the bundle, verify the dashboard.
-
-From a repo checkout (after `git clone`):
+**Requirements:** macOS 15+, Apple Silicon, [uv](https://docs.astral.sh/uv/), git, Xcode command-line tools (`xcode-select --install`).
 
 ```bash
-cd /path/to/llm-swarm-router
-./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
+git clone https://github.com/matthewdcage/llm-swarm-router.git
+cd llm-swarm-router
+git checkout v0.3.0.2   # or latest tag from GitHub Releases
+
+uv sync
+uv pip install venvstacks
+apps/netllm-mac/Scripts/build.sh release
+
+packaging/scripts/macos-app-install.sh \
+  --source apps/netllm-mac/build/Stage/llm-swarm-router.app
 ```
 
-Without a clone, use the installer bundled inside the app (v0.2.3.1+ DMG) or on the mounted DMG volume:
+The installer quits any running menubar app, stops orphaned agents on `:11400`, copies to `/Applications/llm-swarm-router.app`, relaunches, and verifies `GET /ui/` returns HTTP 200.
+
+**Upgrade:** pull/checkout the new tag, rebuild, run the same `macos-app-install.sh --source …` command.
+
+**Verify:**
 
 ```bash
-# Upgrade (app already in /Applications)
-INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
-chmod +x "$INSTALLER"
-"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
-
-# First install (open DMG first, then run from the volume)
-open ~/Downloads/llm-swarm-router.dmg
-INSTALLER="/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
-chmod +x "$INSTALLER" "/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/Resources/Scripts/mount-dmg.sh"
-"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+defaults read /Applications/llm-swarm-router.app/Contents/Info CFBundleShortVersionString
+curl -sf http://127.0.0.1:11400/health
 ```
-
-The installer quits the menubar app, stops Homebrew `netllm` if it was running, frees the agent port, replaces `/Applications/llm-swarm-router.app`, launches the new app, and checks `GET /ui/` returns HTTP 200.
 
 The app installs a CLI shim at `~/.config/netllm/bin/netllm` for terminal control.
 
+### CLI only (no menubar, no Gatekeeper)
+
+Agent + web dashboard without the Swift menubar app:
+
+```bash
+git clone https://github.com/matthewdcage/llm-swarm-router.git
+cd llm-swarm-router
+git checkout v0.3.0.2   # or latest tag
+
+uv sync
+./netllm init
+./netllm serve
+```
+
+Dashboard: http://127.0.0.1:11400/ui/
+
 ### Homebrew
+
+CLI agent background service (not the menubar app):
 
 ```bash
 brew tap matthewdcage/netllm https://github.com/matthewdcage/llm-swarm-router
@@ -57,12 +69,30 @@ brew services start netllm   # background agent
 
 Logs: `$(brew --prefix)/var/log/netllm.log`
 
-### Developer / source (unchanged)
+### GitHub DMG (when notarized)
+
+Once [Developer ID notarization](macos-code-signing.md) is enabled in CI, the release DMG will return as the drag-to-Applications path:
+
+1. Download `llm-swarm-router.dmg` from [GitHub Releases](https://github.com/matthewdcage/llm-swarm-router/releases/latest).
+2. Install with the bundled terminal installer (not drag-only on macOS 26):
 
 ```bash
-uv sync
-./netllm init
-./netllm serve
+INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
+chmod +x "$INSTALLER"
+"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+```
+
+**Today:** ad-hoc DMGs may fail Gatekeeper on macOS 26 — prefer **build from source** above. See [Gatekeeper troubleshooting](macos-troubleshooting.md#gatekeeper-blocks-install-or-launch).
+
+### Repo maintainer upgrade helper
+
+From a git checkout only:
+
+```bash
+cd /path/to/llm-swarm-router
+./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
+# or after local build:
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
 ```
 
 ## Menubar actions
@@ -76,16 +106,18 @@ uv sync
 | Open oMLX Admin | `http://127.0.0.1:8080/admin` when oMLX is installed |
 | Open Dashboard | Local web UI at `/ui/` (same on Linux/Windows) |
 | Copy Client Env | OpenAI + Anthropic env vars for editors |
-| Check for Updates… | Poll GitHub for stable releases; download/install when app is in `/Applications/` |
+| Check for Updates… | Poll GitHub for stable releases (downloads ad-hoc DMG until notarized — may not install on macOS 26+) |
 | Settings… (⌘,) | Full `config.toml` editor + live status, backends, models, peers, doctor/test/gateway |
 
 ## In-app updates (Applications install)
 
-When **llm-swarm-router** is installed under `/Applications/` (not a Stage/dev build), the menubar app can check, download, and install updates automatically:
+When **llm-swarm-router** is under `/Applications/` (not a Stage/dev build):
 
 1. **Menubar → Updates → Check for Updates…** or wait for the hourly background check.
 2. When an update is available, choose **Download Update** (verifies size + SHA256 sidecar when published).
 3. Choose **Install Update…** — the agent stops, the app quits, and the bundled `macos-app-install.sh` replaces the app and relaunches it.
+
+**macOS 26+ note:** in-app update installs the GitHub release DMG. Until that DMG is notarized, prefer **build from source + install script** for upgrades.
 
 Disable automatic checks in **Settings → UI → Check for updates automatically** or in `config.toml`:
 
@@ -95,7 +127,6 @@ check_for_updates_automatically = false
 ```
 
 The web dashboard at `/ui/` also shows version info and download links (via agent proxy to GitHub — no browser CORS). Homebrew installs should use `brew upgrade netllm` instead of in-app DMG install.
-
 
 Settings tabs mirror CLI scope: **Overview**, **Backends** (`discover`), **Models**, **Peers** (`peers`), **Agent/Discovery/Swarm/Routing/UI** config sections, **Doctor & Test** tools. Saves via `netllm config import`; reads via `netllm config export`.
 
@@ -123,24 +154,25 @@ Source files live in `assets/` (see `assets/README.md`):
 `build.sh` runs `Scripts/build-icons.sh` to produce `AppIcon.icns` and scaled menubar PNGs.
 Verify with `scripts/test-brand-icons.sh` (also run as part of `test-menubar-e2e.sh`).
 
-## Test install like an end user (recommended for maintainers)
+## Test install like an end user (maintainers)
 
 ```bash
 ./scripts/emulate-user-install-mac.sh
 ```
 
-That builds a release DMG, runs the same clean install path as `upgrade-mac-app.sh` (stop stale processes → replace bundle → verify `/ui/`), and launches from Applications.
+That builds a release Stage app, runs `macos-app-install.sh --source`, and launches from Applications.
 
-Manual equivalent: quit menubar app → open `dist/llm-swarm-router.dmg` → drag to Applications (**Replace**) → launch (right-click **Open** once if Gatekeeper prompts).
-
-## Build from source (developers only)
+## Build from source (developers)
 
 ```bash
 uv sync
+uv pip install venvstacks
 apps/netllm-mac/Scripts/build.sh release
-packaging/scripts/create-dmg.sh
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
 scripts/test-menubar-e2e.sh
 ```
+
+Optional DMG for maintainers (ad-hoc until notarized): `packaging/scripts/create-dmg.sh`
 
 See [packaging/README.md](../packaging/README.md) for venvstacks export details.
 
@@ -157,6 +189,6 @@ Wire editors to netllm, see [editor-integration.md](editor-integration.md). Issu
 | Component | Path |
 |-----------|------|
 | Menubar app (Swift) | [`apps/netllm-mac/`](../apps/netllm-mac/) |
-| Python bundling + DMG | [`packaging/`](../packaging/): see [packaging/README.md](../packaging/README.md) |
+| Python bundling + release scripts | [`packaging/`](../packaging/): see [packaging/README.md](../packaging/README.md) |
 | CLI lifecycle (app socket, Homebrew) | [`packages/netllm-cli/src/netllm_cli/lifecycle/darwin.py`](../packages/netllm-cli/src/netllm_cli/lifecycle/darwin.py) |
 | Shared agent core | [`packages/netllm-agent/`](../packages/netllm-agent/) |

--- a/docs/macos-troubleshooting.md
+++ b/docs/macos-troubleshooting.md
@@ -18,14 +18,14 @@ Dashboard: http://127.0.0.1:11400/ui/ · menubar **Open Dashboard** or **Copy Cl
 Usually an **old agent still owns the port** after a drag-to-Applications upgrade (the running process was not quit before replace).
 
 ```bash
-# DMG-only install (no git clone): bundled installer in the app
-INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
-chmod +x "$INSTALLER"
-"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+# Recommended upgrade (macOS 26+): rebuild and install from source
+cd /path/to/llm-swarm-router && git checkout v0.3.0.2
+uv sync && uv pip install venvstacks
+apps/netllm-mac/Scripts/build.sh release
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
 
-# Or from a repo checkout:
-cd /path/to/llm-swarm-router
-./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
+# Or from a repo checkout with a downloaded DMG (after notarization):
+# ./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
 ```
 
 Or manually: menubar **Quit** → `brew services stop netllm` (if used) → confirm `lsof -i :11400` is empty → relaunch from Applications.
@@ -46,23 +46,37 @@ From a repo checkout, prefer `./netllm` if PATH is uncertain.
 
 Release DMGs are **ad-hoc signed** until [Developer ID notarization](macos-code-signing.md) is enabled in CI. macOS may show *cannot verify free from malware* when you drag to **Applications**, or on first launch.
 
-**macOS 26 (Tahoe) and later:** clearing quarantine or using the terminal installer is **not enough** for ad-hoc builds. Gatekeeper reports `no usable signature` and blocks launch (dialog with only **Done**). You need a **notarized Developer ID** DMG, or use the source CLI path below.
+**macOS 26 (Tahoe) and later:** ad-hoc menubar apps are blocked (`no usable signature`). Clearing quarantine or mounting the DMG does **not** fix this. Use **build from source + install script** (recommended):
 
-**Recommended:** use the bundled terminal installer (fixes copy + port cleanup; does not bypass Gatekeeper on Tahoe for ad-hoc builds):
+```bash
+git clone https://github.com/matthewdcage/llm-swarm-router.git
+cd llm-swarm-router && git checkout v0.3.0.2   # or latest tag
+uv sync && uv pip install venvstacks
+apps/netllm-mac/Scripts/build.sh release
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
+```
+
+**CLI only (no Gatekeeper issue with menubar):**
+
+```bash
+cd /path/to/llm-swarm-router
+uv sync && ./netllm init && ./netllm serve
+# Dashboard: http://127.0.0.1:11400/ui/
+```
+
+### After notarized DMGs ship
+
+Use the bundled terminal installer (not drag-only):
 
 **Upgrade** (app already installed):
 
 ```bash
-# Eject stale DMG mounts first if install says mount failed
-hdiutil detach "/Volumes/llm-swarm-router" -quiet 2>/dev/null || true
-hdiutil detach "/Volumes/llm-swarm-router 1" -quiet 2>/dev/null || true
-
 INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
 chmod +x "$INSTALLER"
 "$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
 ```
 
-**First install** (no app in Applications yet):
+**First install** from mounted DMG:
 
 ```bash
 open ~/Downloads/llm-swarm-router.dmg
@@ -71,19 +85,11 @@ chmod +x "$INSTALLER" "/Volumes/llm-swarm-router/llm-swarm-router.app/Contents/R
 "$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
 ```
 
-If mount fails, install from the mounted volume without re-mounting:
+From a repo checkout:
 
 ```bash
-open ~/Downloads/llm-swarm-router.dmg
-"$INSTALLER" --source "/Volumes/llm-swarm-router/llm-swarm-router.app"
-```
-
-**Run without the menubar app (works today on ad-hoc / Gatekeeper-blocked Macs):**
-
-```bash
-cd /path/to/llm-swarm-router   # git clone
-uv sync && ./netllm init && ./netllm serve
-# Dashboard: http://127.0.0.1:11400/ui/
+cd /path/to/llm-swarm-router
+./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
 ```
 
 **Maintainer: build a notarized DMG locally** (after Developer ID cert is in Keychain):
@@ -115,7 +121,7 @@ Maintainers: enable notarized releases per [macos-code-signing.md](macos-code-si
 | Symptom | Fix |
 |---------|-----|
 | `curl` to `/health` fails | Menubar → **Start Agent**, or `netllm start` |
-| Port 11400 in use | Expected while the menubar app runs the agent. Settings → **Restart Agent** or `netllm restart`: not a second `netllm serve`. After upgrade, run the bundled `macos-app-install.sh` or [repo upgrade script](macos-install.md#upgrade-from-a-release-dmg-clean-recommended) if an old process still holds the port |
+| Port 11400 in use | Expected while the menubar app runs the agent. Settings → **Restart Agent** or `netllm restart`: not a second `netllm serve`. After upgrade, run [build + install script](macos-install.md#build-from-source--install-script-recommended-on-macos-26) or bundled `macos-app-install.sh` if an old process still holds the port |
 | DMG app won’t launch | Right-click **llm-swarm-router** in Applications → **Open** once (Gatekeeper) |
 | Homebrew agent down | `brew services restart netllm` · logs: `$(brew --prefix)/var/log/netllm.log` |
 

--- a/docs/macos-troubleshooting.md
+++ b/docs/macos-troubleshooting.md
@@ -160,8 +160,10 @@ DMG/menubar installs: `netllm doctor` does not require a global CLI on PATH.
 | Symptom | Fix |
 |---------|-----|
 | `netllm peers` empty | Use `netllm serve --host 0.0.0.0` (or enable LAN in welcome wizard). Set `swarm.cluster_token` on untrusted networks |
-| mDNS browse fails | Source installs: `uv sync` (zeroconf). Fallback: `netllm peers --subnet-scan --save` or static `swarm.peers` |
+| mDNS browse fails | Enable **Subnet scan at startup** in menubar Settings → Swarm (or `subnet_scan = true` in config). Fallback: `netllm peers --subnet-scan --save` or static `swarm.peers` |
 | Guest Wi‑Fi | mDNS often blocked: use static peers |
+
+**Web dashboard:** Prefer **Open Dashboard** from the menubar (`http://127.0.0.1:11400/ui/`). If you open `http://<LAN-IP>:11400/ui/` on the same Mac, admin tabs should work; from another machine on the LAN, status/models are read-only unless you set `swarm.cluster_token` and pass `Authorization: Bearer <token>`.
 
 **Verify:** `netllm peers` and `netllm models --lan`.
 

--- a/docs/platform-matrix.md
+++ b/docs/platform-matrix.md
@@ -18,7 +18,7 @@ Cross-platform: [editor-integration.md](editor-integration.md) · Agent help: `.
 
 | Tier | Platforms | Expectation |
 |------|-----------|-------------|
-| **Stable** | macOS | DMG menubar app on every published GitHub Release |
+| **Stable** | macOS | Menubar app via **build + install script** on macOS 26+; notarized GitHub DMG when signing is enabled |
 | **Alpha** | Linux, Windows | First deb/rpm/zip packages on each Release; breaking changes and install UX still settling: see release notes |
 | **Core** | All | HTTP API contract at `:11400`: additive changes only |
 
@@ -26,7 +26,7 @@ Cross-platform: [editor-integration.md](editor-integration.md) · Agent help: `.
 
 | Platform | Recommended install | Background agent | `netllm start/stop/restart` |
 |----------|---------------------|------------------|----------------------------|
-| **macOS** | [DMG](https://github.com/matthewdcage/llm-swarm-router/releases) → Applications | Menubar app supervises agent | App control socket or Homebrew `brew services` |
+| **macOS** | [Build from source](macos-install.md#build-from-source--install-script-recommended-on-macos-26) + `macos-app-install.sh --source` | Menubar app supervises agent | App control socket or Homebrew `brew services` |
 | **macOS** | Homebrew `brew install netllm` | `brew services start netllm` | Homebrew |
 | **Linux** | `.deb` / `.rpm` from Releases | systemd user unit `netllm` | `linux-systemd` when package installed |
 | **Windows** | `netllm-*-windows-x64.zip` | `NetllmAgent` Windows service | `windows-service` after `install-service.ps1` |
@@ -56,15 +56,15 @@ Agent lifespan runs provider discovery on start and persists URLs to config (all
 
 ## Release assets (one GitHub Release page)
 
-Latest: [v0.2.3.5](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.5) (macOS update UX + agent port recovery) · [v0.2.3.4](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.4) (lifecycle gates) · [All releases](https://github.com/matthewdcage/llm-swarm-router/releases)
+Latest: [v0.3.0.2](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.3.0.2) (menubar agent start + LAN listen) · [All releases](https://github.com/matthewdcage/llm-swarm-router/releases)
 
-| Asset | Platform |
-|-------|----------|
-| `llm-swarm-router.dmg` | macOS (stable) |
-| `netllm_*_amd64.deb` | Linux (alpha) |
-| `netllm-*.rpm` | Linux (alpha) |
-| `netllm-*-windows-x64.zip` | Windows (alpha) |
-| `netllm.yaml` | Winget manifest snippet (SHA256 + URL for winget-pkgs PR) |
+| Asset | Platform | Notes |
+|-------|----------|-------|
+| `llm-swarm-router.dmg` | macOS | Attached to releases; **ad-hoc until notarized** — prefer [source build + install script](macos-install.md#build-from-source--install-script-recommended-on-macos-26) on macOS 26+ |
+| `netllm_*_amd64.deb` | Linux | Alpha |
+| `netllm-*.rpm` | Linux | Alpha |
+| `netllm-*-windows-x64.zip` | Windows | Alpha |
+| `netllm.yaml` | Winget | Manifest snippet for winget-pkgs PR |
 
 Built by [.github/workflows/release.yml](../.github/workflows/release.yml) on `release: published` (macOS DMG, Linux deb/rpm, Windows zip + winget manifest).
 

--- a/docs/release-notes/v0.2.3.4.md
+++ b/docs/release-notes/v0.2.3.4.md
@@ -23,7 +23,7 @@ Patch release fixing menubar quit/orphan agent bugs on port 11400, hardening doc
 
 ### Install / upgrade
 
-- **macOS:** [v0.2.3.4](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.4) — menubar **Updates** or `scripts/upgrade-mac-app.sh`
+- **macOS:** [v0.2.3.4](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.4) — menubar **Updates**, bundled `macos-app-install.sh`, or [macos install guide](../macos-install.md)
 - **Source:** `git pull && uv sync`
 
 ### Previous release

--- a/docs/release-notes/v0.2.3.5.md
+++ b/docs/release-notes/v0.2.3.5.md
@@ -16,7 +16,7 @@ Patch release fixing stuck in-app updates, blank Settings on launch, and the men
 
 ### Install / upgrade
 
-- **macOS:** [v0.2.3.5](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.5) — menubar **Updates** or `scripts/upgrade-mac-app.sh`
+- **macOS:** [v0.2.3.5](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.5) — menubar **Updates**, bundled `macos-app-install.sh`, or [macos install guide](../macos-install.md)
 - **Source:** `git pull && uv sync`
 
 ### Previous release

--- a/docs/release-notes/v0.2.3.6.md
+++ b/docs/release-notes/v0.2.3.6.md
@@ -33,7 +33,7 @@ tail -30 ~/Library/Application\ Support/netllm/logs/app.log
 
 ### Install / upgrade
 
-- **macOS:** [v0.2.3.6](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.6) — menubar **Updates** or `scripts/upgrade-mac-app.sh`
+- **macOS:** [v0.2.3.6](https://github.com/matthewdcage/llm-swarm-router/releases/tag/v0.2.3.6) — menubar **Updates**, bundled `macos-app-install.sh`, or [macos install guide](../macos-install.md)
 - **Source:** `git pull && uv sync`
 
 ### Previous release

--- a/docs/release-notes/v0.3.0.2.md
+++ b/docs/release-notes/v0.3.0.2.md
@@ -39,6 +39,10 @@ Full guide: [macos-install.md](../macos-install.md) · Gatekeeper: [macos-troubl
 
 Menubar **Updates → Install**, or bundled `macos-app-install.sh --dmg ~/Downloads/llm-swarm-router.dmg` — see [macos-install.md](../macos-install.md).
 
+### Next release
+
+- [v0.3.0.3 notes](v0.3.0.3.md): Settings live poll + dashboard admin on same-host LAN IP
+
 ### Previous release
 
 - [v0.3.0.1 notes](v0.3.0.1.md): in-app update download fix

--- a/docs/release-notes/v0.3.0.2.md
+++ b/docs/release-notes/v0.3.0.2.md
@@ -6,11 +6,11 @@ Patch release fixing menubar **Agent: starting…** / **Agent: failed — exited
 
 - **Bundled agent crash:** `netllm serve -q` with LAN listen printed startup warnings via `console.print(..., file=sys.stderr)`, which Rich 13+ rejects — menubar supervises with `-q`, so the agent never reached `/health`
 - **CI regression gate:** `tests/test_serve_quiet_lan.py` plus menubar e2e **quiet + 0.0.0.0** smoke on the Stage `.app` before DMG attach
-- **Release signing path:** Developer ID sign + notarize hooks in `release.yml` when GitHub secrets are set ([macos-code-signing.md](../macos-code-signing.md)); ad-hoc DMGs still require Gatekeeper workarounds on macOS 26 until secrets are configured
+- **Release signing path:** Developer ID sign + notarize hooks in `release.yml` when GitHub secrets are set ([macos-code-signing.md](../macos-code-signing.md)); ad-hoc GitHub DMGs remain blocked by Gatekeeper on macOS 26 until notarization ships
 
 ### Notes
 
-- Always download the DMG from the [latest GitHub Release](https://github.com/matthewdcage/llm-swarm-router/releases/latest) — stale `~/Downloads/llm-swarm-router.dmg` files may be older builds (e.g. 0.2.3.1 while the app offers **Update available (v0.3.0.x)**).
+- **macOS 26+:** prefer **build from source + install script** (below), not the GitHub DMG, until notarized releases are published
 - Verify installed version: `defaults read /Applications/llm-swarm-router.app/Contents/Info CFBundleShortVersionString`
 
 ### Diagnose agent start failures
@@ -21,26 +21,23 @@ tail -40 ~/Library/Application\ Support/netllm/logs/agent.log
 curl -sf http://127.0.0.1:11400/health
 ```
 
-### Install / upgrade
-
-- **macOS (in-app):** menubar **Updates → Install** after this release is published.
-
-- **macOS (DMG, no git clone):**
+### Install / upgrade (recommended on macOS 26+)
 
 ```bash
-INSTALLER="/Applications/llm-swarm-router.app/Contents/Resources/Scripts/macos-app-install.sh"
-chmod +x "$INSTALLER"
-"$INSTALLER" --dmg ~/Downloads/llm-swarm-router.dmg
+git clone https://github.com/matthewdcage/llm-swarm-router.git
+cd llm-swarm-router && git checkout v0.3.0.2
+uv sync && uv pip install venvstacks
+apps/netllm-mac/Scripts/build.sh release
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
 ```
 
-First install or Gatekeeper blocks drag-to-Applications: see [macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](../macos-troubleshooting.md#gatekeeper-blocks-install-or-launch).
+**CLI only (no menubar):** `uv sync && ./netllm init && ./netllm serve` — http://127.0.0.1:11400/ui/
 
-- **macOS (repo checkout):**
+Full guide: [macos-install.md](../macos-install.md) · Gatekeeper: [macos-troubleshooting.md#gatekeeper-blocks-install-or-launch](../macos-troubleshooting.md#gatekeeper-blocks-install-or-launch)
 
-```bash
-cd /path/to/llm-swarm-router
-./scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
-```
+### After notarized DMGs ship
+
+Menubar **Updates → Install**, or bundled `macos-app-install.sh --dmg ~/Downloads/llm-swarm-router.dmg` — see [macos-install.md](../macos-install.md).
 
 ### Previous release
 

--- a/docs/release-notes/v0.3.0.3.md
+++ b/docs/release-notes/v0.3.0.3.md
@@ -1,0 +1,33 @@
+## 0.3.0.3: macOS swarm Settings QoL + web dashboard admin
+
+Patch release improving LAN swarm discoverability in the menubar Settings app and fixing the web dashboard when opened via a LAN IP on the same Mac.
+
+### Fixes
+
+- **Settings live status:** polls `/health` and `/netllm/v1/status` every 2s while Settings is open; **Restart Agent** waits for `/health` before refreshing (no more stale backends `—` until app quit)
+- **LAN peer discovery QoL:** welcome **Listen on LAN** enables `swarm.subnet_scan`; Settings auto-runs subnet peer scan when the agent is healthy
+- **Web dashboard admin:** `http://<LAN-IP>:11400/ui/` on the same host works like `127.0.0.1` (`local_admin_client_hosts`); doctor/config failures no longer mark the whole dashboard unreachable
+- **macOS install docs:** source build + install script primary until notarized GitHub DMGs ship (macOS 26+ Gatekeeper)
+
+### Notes
+
+- **macOS 26+:** prefer **build from source + install script** (below), not the GitHub DMG, until notarized releases are published
+- Remote machines on the LAN: dashboard status/models are read-only unless `swarm.cluster_token` is set
+
+### Install / upgrade (recommended on macOS 26+)
+
+```bash
+git clone https://github.com/matthewdcage/llm-swarm-router.git
+cd llm-swarm-router && git checkout v0.3.0.3
+uv sync && uv pip install venvstacks
+apps/netllm-mac/Scripts/build.sh release
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
+```
+
+**CLI only (no menubar):** `uv sync && ./netllm init && ./netllm serve` — http://127.0.0.1:11400/ui/
+
+Full guide: [macos-install.md](../macos-install.md) · Swarm: [macos-troubleshooting.md#swarm--lan-peers](../macos-troubleshooting.md#swarm--lan-peers)
+
+### Previous release
+
+- [v0.3.0.2 notes](v0.3.0.2.md): menubar agent start on LAN listen

--- a/docs/solutions/macos-release-readiness.md
+++ b/docs/solutions/macos-release-readiness.md
@@ -137,7 +137,7 @@ bash packaging/scripts/create-dmg.sh
 ### Gate 4 — User-path rehearsal
 
 ```bash
-./scripts/emulate-user-install-mac.sh   # DMG → /Applications → launch
+./scripts/emulate-user-install-mac.sh   # Stage → macos-app-install.sh --source → /Applications
 ```
 
 Then manual (5 min):
@@ -154,7 +154,8 @@ Then manual (5 min):
 **Upgrade path (if prior build installed):**
 
 ```bash
-./scripts/upgrade-mac-app.sh dist/llm-swarm-router.dmg
+packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
+# After notarization: ./scripts/upgrade-mac-app.sh dist/llm-swarm-router.dmg
 ```
 
 ---
@@ -186,7 +187,7 @@ After GitHub Release `published` (workflow attaches artifacts):
 |-------|-----|
 | Release workflow green | Actions → Release workflow |
 | Assets present | DMG, `.sha256`, deb, rpm, zip, winget yaml |
-| Download DMG from Releases page | Install on second machine (e.g. Mac mini) |
+| Download DMG from Releases page | Install on a second machine (clean field test) |
 | In-app update OR clean install | Version matches tag; Gate 4 subset on real hardware |
 | `GET /netllm/v1/update/check` | Returns new version for older clients |
 
@@ -233,7 +234,7 @@ Wait for `.github/workflows/release.yml` → Gate 6.
 
 ### Phase E — Field verify
 
-Mac mini: install from Releases DMG → Gate 4 subset → confirm update notification from `0.2.3.3` or older.
+Field machine: install from Releases DMG → Gate 4 subset → confirm update notification from `0.2.3.3` or older.
 
 ---
 

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,50 @@
+# packages — Python uv workspace
+
+## Purpose
+
+Source of truth for netllm Python code. Six workspace members under `src/` layout; version-locked via root `pyproject.toml` and `uv.lock`.
+
+## Ownership
+
+| Package | Role |
+|---------|------|
+| `netllm-core` | Routing, health cache, config, Anthropic bridge |
+| `netllm-discovery` | Local provider scan, swarm registry, mDNS |
+| `netllm-agent` | FastAPI daemon: `/v1/*`, `/netllm/v1/*`, `/metrics`, `/ui/` |
+| `netllm-cli` | Typer CLI (`./netllm` wrapper) |
+| `netllm-sdk-openai` | OpenAI SDK upstream adapter (isolated vendor dep) |
+| `netllm-sdk-anthropic` | Anthropic SDK upstream adapter (isolated vendor dep) |
+
+Parent rail: [../AGENTS.md](../AGENTS.md).
+
+## Local Contracts
+
+- `netllm-core` must never import `openai` or `anthropic`; vendor SDKs live only in `netllm-sdk-*`
+- Workspace deps use `[tool.uv.sources]` with `workspace = true`
+- Bump one SDK package per PR; follow [../docs/sdk-versions.md](../docs/sdk-versions.md)
+- Python 3.11+, ruff line length 88, basedpyright `standard`
+
+## Work Guidance
+
+- Match existing module layout: `packages/<name>/src/<name>/`
+- CLI patterns follow `netllm-cli` (Typer + Rich)
+- Agent HTTP surface changes need tests under `tests/` and possibly `netllm-agent` static dashboard updates
+
+## Verification
+
+```bash
+./scripts/ci.sh lint
+./scripts/ci.sh test
+./scripts/ci.sh sdk   # after SDK bumps
+```
+
+## Child DOX Index
+
+| Path | Contract |
+|------|----------|
+| [`netllm-core/AGENTS.md`](netllm-core/AGENTS.md) | Routing, config, health, bridge |
+| [`netllm-discovery/AGENTS.md`](netllm-discovery/AGENTS.md) | Discovery and swarm |
+| [`netllm-agent/AGENTS.md`](netllm-agent/AGENTS.md) | FastAPI agent and dashboard |
+| [`netllm-cli/AGENTS.md`](netllm-cli/AGENTS.md) | Typer CLI and lifecycle |
+| [`netllm-sdk-openai/AGENTS.md`](netllm-sdk-openai/AGENTS.md) | OpenAI SDK adapter |
+| [`netllm-sdk-anthropic/AGENTS.md`](netllm-sdk-anthropic/AGENTS.md) | Anthropic SDK adapter |

--- a/packages/netllm-agent/AGENTS.md
+++ b/packages/netllm-agent/AGENTS.md
@@ -1,0 +1,37 @@
+# netllm-agent
+
+Parent: [../AGENTS.md](../AGENTS.md).
+
+## Purpose
+
+FastAPI agent daemon: OpenAI-compatible `/v1/*`, Anthropic `/v1/messages`, admin `/netllm/v1/*`, Prometheus `/metrics`, web dashboard `/ui/`.
+
+## Ownership
+
+Key modules: `app.py`, `service.py`, `admin.py`, `metrics.py`, `shard.py`. Static UI: `static/` (HTML, JS, CSS, tokens).
+
+## Local Contracts
+
+- Default bind: `127.0.0.1:11400`; do not run menubar app and `./netllm serve` together (same port)
+- Dashboard tokens: edit `apps/netllm-mac/design-tokens.json`, run `scripts/generate-dashboard-tokens.py` (CI `--check`)
+- In-app update API: `GET /netllm/v1/update/check` (macOS menubar proxies this)
+- Depends on all other workspace packages except `netllm-cli`
+
+## Work Guidance
+
+- HTTP handlers stay thin; routing logic delegates to `netllm-core`
+- Streaming and shard paths are performance-sensitive — add integration tests in `tests/`
+- Dashboard changes should match macOS menubar design tokens when applicable
+
+## Verification
+
+```bash
+./netllm serve
+./netllm test
+./netllm test --api anthropic
+curl -s http://127.0.0.1:11400/ui/
+```
+
+## Child DOX Index
+
+None — UI assets live under `src/netllm_agent/static/`.

--- a/packages/netllm-agent/AGENTS.md
+++ b/packages/netllm-agent/AGENTS.md
@@ -15,6 +15,8 @@ Key modules: `app.py`, `service.py`, `admin.py`, `metrics.py`, `shard.py`. Stati
 - Default bind: `127.0.0.1:11400`; do not run menubar app and `./netllm serve` together (same port)
 - Dashboard tokens: edit `apps/netllm-mac/design-tokens.json`, run `scripts/generate-dashboard-tokens.py` (CI `--check`)
 - In-app update API: `GET /netllm/v1/update/check` (macOS menubar proxies this)
+- **Admin routes** (`admin.py`): config save, doctor, version, logs, discover, peers-scan — allowed from **this host** (`local_admin_client_hosts()` in `netllm-core`) or `Authorization: Bearer <cluster_token>`; remote LAN clients get read-only status/models unless token is set
+- **Web dashboard** (`static/dashboard.js`): status/models load without admin; doctor/config failures degrade gracefully (warn banner, not fatal)
 - Depends on all other workspace packages except `netllm-cli`
 
 ## Work Guidance

--- a/packages/netllm-agent/pyproject.toml
+++ b/packages/netllm-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-agent"
-version = "0.3.0.2"
+version = "0.3.0.3"
 description = "FastAPI agent daemon for netllm swarm routing"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-agent/src/netllm_agent/admin.py
+++ b/packages/netllm-agent/src/netllm_agent/admin.py
@@ -7,18 +7,17 @@ from typing import Any
 
 from fastapi import HTTPException, Request
 from netllm_core.models import NetllmConfig, save_config
+from netllm_core.platform import local_admin_client_hosts
 
 from netllm_agent.service import AgentService
 
 _CONFIG_SECTIONS = frozenset({"agent", "discovery", "swarm", "routing", "ui"})
 
-_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", "testclient"})
-
 
 def require_admin_access(request: Request, cfg: NetllmConfig) -> None:
-    """Allow admin routes from loopback or with a valid cluster token."""
+    """Allow admin routes from this host or with a valid cluster token."""
     client_host = (request.client.host if request.client else "").lower()
-    if client_host in _LOOPBACK_HOSTS:
+    if client_host in local_admin_client_hosts():
         return
     token = (cfg.swarm.cluster_token or "").strip()
     if token:
@@ -27,7 +26,7 @@ def require_admin_access(request: Request, cfg: NetllmConfig) -> None:
             return
     raise HTTPException(
         status_code=403,
-        detail="Admin routes require a loopback client or Bearer cluster token",
+        detail="Admin routes require a local client or Bearer cluster token",
     )
 
 

--- a/packages/netllm-agent/src/netllm_agent/static/dashboard.js
+++ b/packages/netllm-agent/src/netllm_agent/static/dashboard.js
@@ -28,6 +28,7 @@ const state = {
   updatePollTimer: null,
   logsPollTimer: null,
   logs: null,
+  adminWarned: false,
 };
 
 function showToast(msg) {
@@ -63,7 +64,16 @@ async function api(path, options = {}) {
   const res = await fetch(path, options);
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(text || `${res.status} ${res.statusText}`);
+    let message = text || `${res.status} ${res.statusText}`;
+    try {
+      const json = JSON.parse(text);
+      if (json && typeof json.detail === "string") {
+        message = json.detail;
+      }
+    } catch {
+      /* keep raw text */
+    }
+    throw new Error(message);
   }
   if (res.status === 204) return null;
   const ct = res.headers.get("content-type") || "";
@@ -104,17 +114,23 @@ async function loadCore() {
   const status = await api("/netllm/v1/status");
   state.status = status;
   updateOmlxAdminLink();
-  const [models, doctor, env] = await Promise.all([
+  const [models, env] = await Promise.all([
     api("/v1/models"),
-    api("/netllm/v1/doctor"),
     api("/netllm/v1/client-env"),
   ]);
   state.models = models.data || [];
-  state.doctor = doctor;
   const vars = env.vars || env;
   state.envText = Object.entries(vars)
     .map(([k, v]) => `export ${k}=${v}`)
     .join("\n");
+  try {
+    state.doctor = await api("/netllm/v1/doctor");
+  } catch (e) {
+    state.doctor = { ok: false, issues: [], error: e.message };
+    warnAdminLimited(
+      "Doctor unavailable (admin API). Use http://127.0.0.1:11400/ui/ on this Mac or set a cluster token."
+    );
+  }
   try {
     const config = await api("/netllm/v1/config");
     if (!state.dirty) {
@@ -122,15 +138,20 @@ async function loadCore() {
       state.configDraft = cloneConfig(config);
     }
   } catch (e) {
-    setBanner(
-      "Config editor unavailable (admin API). Editable tabs need loopback access.",
-      "warn"
+    warnAdminLimited(
+      "Config editor unavailable (admin API). Use http://127.0.0.1:11400/ui/ on this Mac or set a cluster token."
     );
     if (!state.configDraft) {
       state.configDraft = emptyConfigDraft();
     }
   }
   updateStatusLine();
+}
+
+function warnAdminLimited(message) {
+  if (state.adminWarned) return;
+  state.adminWarned = true;
+  setBanner(message, "warn");
 }
 
 function emptyConfigDraft() {

--- a/packages/netllm-cli/AGENTS.md
+++ b/packages/netllm-cli/AGENTS.md
@@ -1,0 +1,35 @@
+# netllm-cli
+
+Parent: [../AGENTS.md](../AGENTS.md).
+
+## Purpose
+
+Typer CLI entry point for init, serve, lifecycle (start/stop/restart), doctor, models, peers, gateway, and config editing. Repo root `./netllm` wraps `uv run`.
+
+## Ownership
+
+Key modules: `main.py`, `ui.py`, `install.py`, `install_detect.py`, `config_json.py`. Platform lifecycle: `lifecycle/darwin.py`, `linux.py`, `windows.py`, `common.py`.
+
+## Local Contracts
+
+- Prefer `./netllm` from repo root in docs; global `netllm` after `./netllm install`
+- `doctor` must pass before declaring setup complete
+- Background agent: macOS menubar/Homebrew, Linux systemd user unit, Windows service (see platform docs)
+- **`serve -q` warnings:** use `print_warnings()` from `ui.py` only — never `console.print(..., file=...)` (Rich 13+ rejects `file=`; menubar supervises with `-q`, so startup warnings must not crash before uvicorn)
+
+## Work Guidance
+
+- Match Typer/Rich patterns already in `main.py`
+- Lifecycle changes must align with [../../packaging/AGENTS.md](../../packaging/AGENTS.md) install artifacts
+
+## Verification
+
+```bash
+./netllm doctor
+./netllm status
+./scripts/ci.sh test
+```
+
+## Child DOX Index
+
+None — lifecycle subfolder is part of this package.

--- a/packages/netllm-cli/pyproject.toml
+++ b/packages/netllm-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-cli"
-version = "0.3.0.2"
+version = "0.3.0.3"
 description = "CLI for netllm network LLM router"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-core/AGENTS.md
+++ b/packages/netllm-core/AGENTS.md
@@ -8,7 +8,7 @@ Shared routing, backend health cache, configuration I/O, model catalog types, an
 
 ## Ownership
 
-Key modules: `config.py`, `routing_policy.py`, `pool.py`, `health.py`, `models.py`, `anthropic_bridge.py`, `batch.py`, `update.py`.
+Key modules: `config.py`, `routing_policy.py`, `pool.py`, `health.py`, `models.py`, `anthropic_bridge.py`, `batch.py`, `update.py`, `platform.py`.
 
 ## Local Contracts
 
@@ -19,7 +19,8 @@ Key modules: `config.py`, `routing_policy.py`, `pool.py`, `health.py`, `models.p
 ## Work Guidance
 
 - Keep pydantic models in `models.py`; avoid circular imports with agent/discovery
-- Platform helpers in `platform.py` and `install_detect.py` are shared with CLI
+- Platform helpers in `platform.py` and `install_detect.py` are shared with CLI and agent
+- `platform.local_admin_client_hosts()` — loopback plus this machine's interface IPs; used by agent admin gate so `http://<LAN-IP>:11400/ui/` on the same host works like `127.0.0.1`
 
 ## Verification
 

--- a/packages/netllm-core/AGENTS.md
+++ b/packages/netllm-core/AGENTS.md
@@ -1,0 +1,32 @@
+# netllm-core
+
+Parent: [../AGENTS.md](../AGENTS.md).
+
+## Purpose
+
+Shared routing, backend health cache, configuration I/O, model catalog types, and Anthropic Messages bridge logic. No FastAPI, no vendor SDK imports.
+
+## Ownership
+
+Key modules: `config.py`, `routing_policy.py`, `pool.py`, `health.py`, `models.py`, `anthropic_bridge.py`, `batch.py`, `update.py`.
+
+## Local Contracts
+
+- Config path: `~/.config/netllm/config.toml` (see root `config.example.toml`)
+- `anthropic_bridge.py` translates Messages API ↔ OpenAI-compatible backends; SDK calls stay in `netllm-sdk-anthropic`
+- Routing strategies and backend health drive agent and CLI behavior
+
+## Work Guidance
+
+- Keep pydantic models in `models.py`; avoid circular imports with agent/discovery
+- Platform helpers in `platform.py` and `install_detect.py` are shared with CLI
+
+## Verification
+
+```bash
+./scripts/ci.sh test   # tests/ cover routing and bridge
+```
+
+## Child DOX Index
+
+None — flat `src/netllm_core/` package.

--- a/packages/netllm-core/pyproject.toml
+++ b/packages/netllm-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-core"
-version = "0.3.0.2"
+version = "0.3.0.3"
 description = "Core routing, health, and config for netllm"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-core/src/netllm_core/platform.py
+++ b/packages/netllm-core/src/netllm_core/platform.py
@@ -20,6 +20,30 @@ def default_hostname() -> str:
     return socket.gethostname()
 
 
+_local_admin_hosts: frozenset[str] | None = None
+
+
+def local_admin_client_hosts() -> frozenset[str]:
+    """Hosts that may call loopback-gated admin routes from this machine."""
+    global _local_admin_hosts
+    if _local_admin_hosts is not None:
+        return _local_admin_hosts
+    hosts: set[str] = {"127.0.0.1", "::1", "localhost", "testclient"}
+    try:
+        for info in socket.getaddrinfo(socket.gethostname(), None):
+            hosts.add(info[4][0].lower())
+    except OSError:
+        pass
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect(("8.8.8.8", 80))
+            hosts.add(sock.getsockname()[0].lower())
+    except OSError:
+        pass
+    _local_admin_hosts = frozenset(hosts)
+    return _local_admin_hosts
+
+
 def default_log_dir() -> Path:
     if is_darwin():
         return Path.home() / "Library" / "Application Support" / "netllm" / "logs"

--- a/packages/netllm-core/src/netllm_core/version.py
+++ b/packages/netllm-core/src/netllm_core/version.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 
-_FALLBACK_VERSION = "0.3.0.2"
+_FALLBACK_VERSION = "0.3.0.3"
 
 
 def get_version() -> str:

--- a/packages/netllm-discovery/AGENTS.md
+++ b/packages/netllm-discovery/AGENTS.md
@@ -1,0 +1,35 @@
+# netllm-discovery
+
+Parent: [../AGENTS.md](../AGENTS.md).
+
+## Purpose
+
+Local LLM provider discovery (oMLX, Ollama, LM Studio, vLLM), LAN peer registry, and optional mDNS swarm advertisement/browse.
+
+## Ownership
+
+Key modules: `local.py`, `swarm.py`, `mdns.py`, `lan.py`, `runtime.py`, `process_util.py`.
+
+## Local Contracts
+
+- Default probe ports: oMLX `:8080`, Ollama `:11434`, LM Studio `:1234`, vLLM `:8000`
+- Custom ports via `[discovery].custom_endpoints` or `[[routing.backends]]` in config
+- mDNS requires `zeroconf` from `uv sync`; LAN swarm needs agent `serve --host 0.0.0.0`
+- Set `swarm.cluster_token` on untrusted networks
+
+## Work Guidance
+
+- Discovery results feed `netllm-core` routing; keep scan logic side-effect free where possible
+- Optional `mdns` extra on `netllm-agent` for zeroconf
+
+## Verification
+
+```bash
+./netllm discover
+./netllm peers      # with agent on 0.0.0.0
+./scripts/ci.sh test
+```
+
+## Child DOX Index
+
+None — flat `src/netllm_discovery/` package.

--- a/packages/netllm-discovery/pyproject.toml
+++ b/packages/netllm-discovery/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-discovery"
-version = "0.3.0.2"
+version = "0.3.0.3"
 description = "Local and swarm discovery for netllm agents"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-sdk-anthropic/AGENTS.md
+++ b/packages/netllm-sdk-anthropic/AGENTS.md
@@ -1,0 +1,32 @@
+# netllm-sdk-anthropic
+
+Parent: [../AGENTS.md](../AGENTS.md).
+
+## Purpose
+
+Isolated Anthropic Python SDK adapter. Only package that imports `anthropic`; upstream version pinned in `pyproject.toml` and [../../docs/sdk-versions.md](../../docs/sdk-versions.md).
+
+## Ownership
+
+Key module: `client.py`. Contract tests: `tests/test_client_contract.py`.
+
+## Local Contracts
+
+- One SDK bump per PR: edit dep → `uv sync` → update sdk-versions doc → `./scripts/ci.sh sdk`
+- Bridge translation lives in `netllm-core/anthropic_bridge.py`, not here
+
+## Work Guidance
+
+- Keep surface minimal — expose what bridge and agent need for Messages API
+- Do not leak Anthropic types into `netllm-core`
+
+## Verification
+
+```bash
+./scripts/ci.sh sdk
+./netllm test --api anthropic
+```
+
+## Child DOX Index
+
+None.

--- a/packages/netllm-sdk-anthropic/pyproject.toml
+++ b/packages/netllm-sdk-anthropic/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-sdk-anthropic"
-version = "0.3.0.2"
+version = "0.3.0.3"
 description = "Anthropic SDK adapter for netllm upstream calls"
 requires-python = ">=3.11"
 dependencies = [

--- a/packages/netllm-sdk-openai/AGENTS.md
+++ b/packages/netllm-sdk-openai/AGENTS.md
@@ -1,0 +1,32 @@
+# netllm-sdk-openai
+
+Parent: [../AGENTS.md](../AGENTS.md).
+
+## Purpose
+
+Isolated OpenAI Python SDK adapter. Only package that imports `openai`; upstream version pinned in `pyproject.toml` and [../../docs/sdk-versions.md](../../docs/sdk-versions.md).
+
+## Ownership
+
+Key module: `client.py`. Contract tests: `tests/test_openai_upstream_contract.py`.
+
+## Local Contracts
+
+- One SDK bump per PR: edit dep → `uv sync` → update sdk-versions doc → `./scripts/ci.sh sdk`
+- Adapter changes follow upstream changelog; see sdk-versions.md change layers
+
+## Work Guidance
+
+- Keep surface minimal — expose what `netllm-core` and `netllm-agent` need
+- Do not leak OpenAI types into `netllm-core`
+
+## Verification
+
+```bash
+./scripts/ci.sh sdk
+./scripts/ci.sh test
+```
+
+## Child DOX Index
+
+None.

--- a/packages/netllm-sdk-openai/pyproject.toml
+++ b/packages/netllm-sdk-openai/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm-sdk-openai"
-version = "0.3.0.2"
+version = "0.3.0.3"
 description = "OpenAI SDK adapter for netllm upstream calls"
 requires-python = ">=3.11"
 dependencies = [

--- a/packaging/AGENTS.md
+++ b/packaging/AGENTS.md
@@ -44,6 +44,7 @@ Index: [README.md](README.md). macOS app bundle: [../apps/netllm-mac/Scripts/bui
 
 - Bump all workspace package versions + `uv lock` before `gh release create`
 - macOS notarized release: configure GitHub secrets per [macos-code-signing.md](../docs/macos-code-signing.md) before tagging; verify with `local-notarized-dmg.sh` locally when cert is in Keychain
+- Maintainer local Apple credentials: gitignored repo-root `.env` (`set -a && source .env && set +a` before `local-notarized-dmg.sh`); never commit — `.env` is in `.gitignore`
 - Packaging smoke: `./scripts/ci.sh packaging`
 - macOS packaging PRs may touch both `packaging/` and `apps/netllm-mac/`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netllm"
-version = "0.3.0.2"
+version = "0.3.0.3"
 description = "Network LLM router — swarm agents with OpenAI-compatible gateway"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/emulate-user-install-mac.sh
+++ b/scripts/emulate-user-install-mac.sh
@@ -1,26 +1,28 @@
 #!/usr/bin/env bash
-# Build and install like an end user: DMG → Applications → launch (not build/Stage).
-# Uses macos-app-install.sh for clean upgrades (stops stale agents before replace).
+# Build and install like an end user: Stage app → Applications → launch.
+# Uses macos-app-install.sh --source (Gatekeeper-safe on macOS 26+; ad-hoc DMGs fail).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 INSTALLER="$ROOT/packaging/scripts/macos-app-install.sh"
-DMG="$ROOT/dist/llm-swarm-router.dmg"
+STAGE_APP="$ROOT/apps/netllm-mac/build/Stage/llm-swarm-router.app"
 
 echo "==> Native install rehearsal for llm-swarm-router"
 echo
 
-echo "==> Building release app + DMG"
+echo "==> Building release Stage app"
 "$ROOT/apps/netllm-mac/Scripts/build.sh" release
-"$ROOT/packaging/scripts/create-dmg.sh"
+
+[[ -d "$STAGE_APP" ]] || { echo "Stage app missing: $STAGE_APP" >&2; exit 1; }
 
 chmod +x "$INSTALLER"
-"$INSTALLER" --dmg "$DMG"
+"$INSTALLER" --source "$STAGE_APP"
 
 cat <<EOF
 To repeat this flow later:
   $ROOT/scripts/emulate-user-install-mac.sh
 
-To upgrade from a downloaded release DMG (no build):
-  $ROOT/scripts/upgrade-mac-app.sh ~/Downloads/llm-swarm-router.dmg
+Optional maintainer DMG (ad-hoc until notarized):
+  $ROOT/packaging/scripts/create-dmg.sh
+  $ROOT/scripts/upgrade-mac-app.sh $ROOT/dist/llm-swarm-router.dmg
 EOF

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,42 @@
+# tests — cross-package integration tests
+
+## Purpose
+
+pytest suite exercising routing, agent HTTP surfaces, Anthropic bridge, CLI, discovery, and bundled install scripts across workspace packages.
+
+## Ownership
+
+- Root `tests/` — integration and contract tests
+- Package-local tests: `packages/netllm-sdk-*/tests/` (SDK upstream contracts)
+
+Parent rail: [../AGENTS.md](../AGENTS.md).
+
+## Local Contracts
+
+- Runner: pytest with asyncio mode auto (root config)
+- Fixtures: `tests/fixtures/` (e.g. Anthropic message payloads)
+- Add tests for real behavior; avoid trivial assertions
+- macOS install scripts: `tests/test_bundled_install_scripts.sh`
+- Menubar agent start (quiet + LAN listen): `tests/test_serve_quiet_lan.py` — regression for bundled `serve -q` with `0.0.0.0` listen reaching uvicorn
+
+## Work Guidance
+
+- Agent or routing changes should extend `tests/` before merge
+- SDK bumps must pass `./scripts/ci.sh sdk` and contract tests in sdk packages
+- Menubar e2e lives in `scripts/test-menubar-e2e.sh` (not pytest); includes bundled **quiet + 0.0.0.0 listen** smoke on Stage `.app` before DMG attach
+
+## Verification
+
+```bash
+./scripts/ci.sh test
+./scripts/ci.sh              # lint + test
+scripts/verify-before-pr.sh
+```
+
+## Child DOX Index
+
+| Path | Contract |
+|------|----------|
+| [`fixtures/`](fixtures/) | Shared test payloads |
+
+Fixtures are data only; no AGENTS.md.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -18,6 +18,7 @@ Parent rail: [../AGENTS.md](../AGENTS.md).
 - Add tests for real behavior; avoid trivial assertions
 - macOS install scripts: `tests/test_bundled_install_scripts.sh`
 - Menubar agent start (quiet + LAN listen): `tests/test_serve_quiet_lan.py` — regression for bundled `serve -q` with `0.0.0.0` listen reaching uvicorn
+- Admin access: `tests/test_agent.py` — remote client 403; same-host LAN IP allowed via `local_admin_client_hosts`
 
 ## Work Guidance
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -216,7 +216,7 @@ def test_admin_config_save_round_trip() -> None:
             assert summary["routing"]["default_strategy"] == "round_robin"
 
 
-def test_admin_config_requires_loopback() -> None:
+def test_admin_config_rejects_remote_client() -> None:
     from unittest.mock import MagicMock
 
     from fastapi import HTTPException
@@ -229,6 +229,22 @@ def test_admin_config_requires_loopback() -> None:
     with pytest.raises(HTTPException) as exc:
         require_admin_access(request, cfg)
     assert exc.value.status_code == 403
+
+
+@patch(
+    "netllm_agent.admin.local_admin_client_hosts",
+    return_value=frozenset({"127.0.0.1", "10.0.0.9"}),
+)
+def test_admin_allows_same_host_lan_ip(_mock_hosts: object) -> None:
+    from unittest.mock import MagicMock
+
+    from netllm_agent.admin import require_admin_access
+
+    cfg = NetllmConfig()
+    request = MagicMock()
+    request.client.host = "10.0.0.9"
+    request.headers.get.return_value = ""
+    require_admin_access(request, cfg)
 
 
 @patch("netllm_discovery.lan.subnet_scan_agents", new_callable=AsyncMock)

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ wheels = [
 
 [[package]]
 name = "netllm"
-version = "0.3.0.2"
+version = "0.3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "netllm-cli" },
@@ -625,7 +625,7 @@ dev = [
 
 [[package]]
 name = "netllm-agent"
-version = "0.3.0.2"
+version = "0.3.0.3"
 source = { editable = "packages/netllm-agent" }
 dependencies = [
     { name = "fastapi" },
@@ -653,7 +653,7 @@ provides-extras = ["mdns"]
 
 [[package]]
 name = "netllm-cli"
-version = "0.3.0.2"
+version = "0.3.0.3"
 source = { editable = "packages/netllm-cli" }
 dependencies = [
     { name = "httpx" },
@@ -676,7 +676,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-core"
-version = "0.3.0.2"
+version = "0.3.0.3"
 source = { editable = "packages/netllm-core" }
 dependencies = [
     { name = "httpx" },
@@ -695,7 +695,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-discovery"
-version = "0.3.0.2"
+version = "0.3.0.3"
 source = { editable = "packages/netllm-discovery" }
 dependencies = [
     { name = "httpx" },
@@ -713,7 +713,7 @@ provides-extras = ["mdns"]
 
 [[package]]
 name = "netllm-sdk-anthropic"
-version = "0.3.0.2"
+version = "0.3.0.3"
 source = { editable = "packages/netllm-sdk-anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -728,7 +728,7 @@ requires-dist = [
 
 [[package]]
 name = "netllm-sdk-openai"
-version = "0.3.0.2"
+version = "0.3.0.3"
 source = { editable = "packages/netllm-sdk-openai" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Repoints **all user-facing macOS install docs** to **clone release tag → build → `macos-app-install.sh --source`** while GitHub DMGs remain ad-hoc (Gatekeeper blocks on macOS 26+)
- Updates `netllm-setup` skill (all synced copies), README, platform matrix, troubleshooting, release notes, CI/release guidance, and `emulate-user-install-mac.sh`
- Adds DOX `AGENTS.md` tree entries for packages/tests/.agents
- Gitignores maintainer `.env` (signing secrets stay local)

Tracking issue: **#16** — close when Developer ID notarization ships and DMG-first docs can return.

## Why

Apple Developer membership is still **Pending** on the new signing account; `MACOS_CERTIFICATE_P12` is not uploaded. Release DMGs attach to GitHub but are not Gatekeeper-safe on Tahoe.

## Temporary install path (macOS 26+)

```bash
git clone https://github.com/matthewdcage/llm-swarm-router.git
cd llm-swarm-router && git checkout v0.3.0.2
uv sync && uv pip install venvstacks
apps/netllm-mac/Scripts/build.sh release
packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app
```

## Test plan

- [x] `uv run pytest tests/test_serve_quiet_lan.py`
- [x] `packaging/scripts/macos-app-install.sh --source apps/netllm-mac/build/Stage/llm-swarm-router.app` → `/Applications/llm-swarm-router.app` v0.3.0.2, `/health` OK, `/ui/` HTTP 200
- [ ] Review doc links after merge (macos-install.md anchors)

## Not in this PR

- `.env` (gitignored maintainer secrets)
- `.cursor/agents/` coordinator subagents (local/untracked)
- Notarized DMG release (blocked on #16)

Refs #16