### PR TITLE
fix(swarm): loop-guard agent hops, no transitive echo, e2e two-agent harness

### DIFF
--- a/packages/netllm-agent/AGENTS.md
+++ b/packages/netllm-agent/AGENTS.md
@@ -17,6 +17,7 @@ Key modules: `app.py`, `service.py`, `admin.py`, `metrics.py`, `shard.py`. Stati
 - In-app update API: `GET /netllm/v1/update/check` (macOS menubar proxies this)
 - **Admin routes** (`admin.py`): config save, doctor, version, logs, discover, peers-scan — allowed from **this host** (`local_admin_client_hosts()` in `netllm-core`) or `Authorization: Bearer <cluster_token>`; remote LAN clients get read-only status/models unless token is set
 - **Web dashboard** (`static/dashboard.js`): status/models load without admin; doctor/config failures degrade gracefully (warn banner, not fatal)
+- **Loop guard:** every forward to a `peer:` backend sets `x-netllm-local-only: 1` (`AgentService._peer_forward_headers`) so peers serve locally and never re-forward; status/catalog handlers force-probe **local** backends only (peer rows stay fresh via heartbeats — probing them recurses)
 - Depends on all other workspace packages except `netllm-cli`
 
 ## Work Guidance

--- a/packages/netllm-agent/src/netllm_agent/app.py
+++ b/packages/netllm-agent/src/netllm_agent/app.py
@@ -104,7 +104,9 @@ def create_app(
     async def netllm_status() -> dict[str, Any]:
         await service.refresh_local_backends()
         for backend in service.pool.backends:
-            if backend.enabled:
+            # Local rows only — probing peer agents from a status handler
+            # recurses when the peer's status handler probes us back.
+            if backend.enabled and backend.local:
                 service.pool.is_healthy(backend, force_refresh=True)
         return await service.status_payload_enriched()
 

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -162,7 +162,11 @@ class AgentService:
         for b in self.pool.backends:
             if not b.enabled:
                 continue
-            self.pool.is_healthy(b, force_refresh=True)
+            # Force-probe local providers only. Peer-agent rows are kept
+            # fresh by heartbeats; probing them from a catalog handler
+            # recurses (the peer's handler would probe us back).
+            if b.local:
+                self.pool.is_healthy(b, force_refresh=True)
             for mid in b.health.models:
                 if mid not in seen:
                     seen[mid] = {
@@ -183,6 +187,18 @@ class AgentService:
         hdrs = AgentService._normalize_headers(headers)
         raw = hdrs.get(LOCAL_ONLY_HEADER, "")
         return raw.strip().lower() in ("1", "true", "yes")
+
+    @staticmethod
+    def _peer_forward_headers(backend: Backend) -> dict[str, str] | None:
+        """Loop guard: agent-hop forwards must terminate at the peer.
+
+        Without this header a peer running a distributing strategy
+        (round_robin, least_load, ...) could bounce the request back,
+        ping-ponging it across the mesh.
+        """
+        if backend.id.startswith("peer:"):
+            return {LOCAL_ONLY_HEADER: "1"}
+        return None
 
     def _resolved_routing(
         self,
@@ -313,6 +329,7 @@ class AgentService:
                 client = OpenAIUpstream(
                     backend.base_url,
                     api_key=backend.api_key or "netllm-local",
+                    default_headers=self._peer_forward_headers(backend),
                 )
                 result = await client.chat_completion(payload)
                 latency = time.monotonic() - t0
@@ -383,6 +400,7 @@ class AgentService:
                 client = OpenAIUpstream(
                     backend.base_url,
                     api_key=backend.api_key or "netllm-local",
+                    default_headers=self._peer_forward_headers(backend),
                 )
                 async for chunk in self._stream_with_metrics(
                     client, payload, backend, model, shard
@@ -684,6 +702,7 @@ class AgentService:
         client = OpenAIUpstream(
             backend.base_url,
             api_key=backend.api_key or "netllm-local",
+            default_headers=self._peer_forward_headers(backend),
         )
         result = await client.chat_completion(oai_payload)
         return openai_to_anthropic_response(result, model=model)
@@ -714,6 +733,7 @@ class AgentService:
         client = OpenAIUpstream(
             backend.base_url,
             api_key=backend.api_key or "netllm-local",
+            default_headers=self._peer_forward_headers(backend),
         )
         async for chunk in translate_openai_stream_to_anthropic(
             client.chat_completion_stream(oai_payload),

--- a/packages/netllm-discovery/AGENTS.md
+++ b/packages/netllm-discovery/AGENTS.md
@@ -17,6 +17,7 @@ Key modules: `local.py`, `swarm.py`, `mdns.py`, `lan.py`, `runtime.py`, `process
 - mDNS requires `zeroconf` from `uv sync`; LAN swarm needs agent `serve --host 0.0.0.0`
 - Set `swarm.cluster_token` on untrusted networks
 - **Agent-hop routing:** `SwarmRegistry.peer_agent_backends()` emits one `Backend` per peer at `{listen_url}/v1`; never merge peer loopback oMLX URLs into a gateway pool
+- **No transitive echo:** `_peer_backend_models()` unions only a peer's `local=true` rows — peers advertise models they serve directly, never their own remote `peer:` rows
 - `lan.filter_own_peer_urls()` strips this host's agent URL from `swarm.peers` on save/scan
 
 ## Work Guidance

--- a/packages/netllm-discovery/src/netllm_discovery/swarm.py
+++ b/packages/netllm-discovery/src/netllm_discovery/swarm.py
@@ -52,11 +52,18 @@ class SwarmRegistry:
             del self.peers[pid]
 
     def _peer_backend_models(self, peer: PeerRecord) -> list[str]:
-        """Union model IDs from peer backends (incl. local loopback rows)."""
+        """Union model IDs the peer serves directly (local rows only).
+
+        Remote rows in a peer's status are its own view of *other*
+        agents; advertising those here would echo backends transitively
+        around the mesh, inflate catalogs, and invite multi-hop chains.
+        """
         models: set[str] = set()
         for raw in peer.backends:
             try:
                 b = Backend.model_validate(raw)
+                if not b.local:
+                    continue
                 models.update(b.health.models)
             except Exception:
                 logger.debug("skip invalid peer backend: %s", raw)

--- a/packages/netllm-sdk-openai/src/netllm_sdk_openai/client.py
+++ b/packages/netllm-sdk-openai/src/netllm_sdk_openai/client.py
@@ -27,17 +27,23 @@ class OpenAIUpstream:
         *,
         connect_timeout: float = 5.0,
         read_timeout: float = 120.0,
+        default_headers: dict[str, str] | None = None,
     ) -> None:
         timeout = httpx_timeout(connect_timeout, read_timeout)
+        extra: dict[str, Any] = {}
+        if default_headers:
+            extra["default_headers"] = default_headers
         self._async = AsyncOpenAI(
             base_url=base_url.rstrip("/"),
             api_key=api_key or "netllm-local",
             timeout=timeout,
+            **extra,
         )
         self._sync = OpenAI(
             base_url=base_url.rstrip("/"),
             api_key=api_key or "netllm-local",
             timeout=timeout,
+            **extra,
         )
         self.base_url = base_url.rstrip("/")
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -565,3 +565,111 @@ def test_wants_local_only_header() -> None:
     assert AgentService._wants_local_only({"x-netllm-local-only": "true"})
     assert not AgentService._wants_local_only({})
     assert not AgentService._wants_local_only({"x-netllm-local-only": "0"})
+
+
+def test_peer_forward_headers_loop_guard() -> None:
+    from netllm_agent.service import AgentService
+    from netllm_core.models import LOCAL_ONLY_HEADER
+
+    peer = Backend(
+        id="peer:remote-agent",
+        base_url="http://192.168.1.11:11400/v1",
+        provider="custom",
+        local=False,
+    )
+    local = Backend(
+        id="omlx:http://127.0.0.1:8080/v1",
+        base_url="http://127.0.0.1:8080/v1",
+        provider="omlx",
+        local=True,
+    )
+    assert AgentService._peer_forward_headers(peer) == {LOCAL_ONLY_HEADER: "1"}
+    assert AgentService._peer_forward_headers(local) is None
+
+
+@patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)
+@patch("netllm_core.pool.probe_openai_compat_sync")
+@patch("netllm_sdk_openai.client.AsyncOpenAI")
+def test_peer_hop_sets_local_only_default_header(
+    mock_openai_cls: object,
+    mock_probe: object,
+    mock_scan: AsyncMock,
+) -> None:
+    """Forwards to a peer agent must carry x-netllm-local-only so the peer
+    cannot bounce the request back into the mesh."""
+    from unittest.mock import MagicMock
+
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    cfg.routing.default_strategy = "round_robin"
+    cfg.routing.allow_remote = True
+
+    mock_scan.return_value = []
+    mock_probe.return_value = {
+        "status": "online",
+        "models": ["shared-model"],
+        "model_count": 1,
+    }
+
+    headers_by_base: dict[str, object] = {}
+    mock_client = MagicMock()
+
+    def track_openai_client(*_args: object, **kwargs: object) -> MagicMock:
+        base = str(kwargs.get("base_url", "")).rstrip("/")
+        if base:
+            headers_by_base[base] = kwargs.get("default_headers")
+        return mock_client
+
+    mock_openai_cls.side_effect = track_openai_client
+
+    async def fake_create(**kwargs: object) -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "cmpl-test",
+            "object": "chat.completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "model": kwargs.get("model", "shared-model"),
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        return mock_response
+
+    mock_client.chat.completions.create = fake_create
+
+    app = create_app(cfg)
+    with TestClient(app) as client:
+        client.post(
+            "/netllm/v1/heartbeat",
+            json={
+                "agent_id": "peer-remote",
+                "listen_url": "http://192.168.1.11:11400",
+                "role": "peer",
+                "hostname": "mac-mini",
+                "backends": [
+                    Backend(
+                        id="b1",
+                        base_url="http://127.0.0.1:8080/v1",
+                        provider="omlx",
+                        local=True,
+                        health=BackendHealth(status="online", models=["shared-model"]),
+                    ).model_dump(mode="json")
+                ],
+            },
+        )
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "shared-model",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        assert resp.status_code == 200
+
+    peer_headers = headers_by_base.get("http://192.168.1.11:11400/v1")
+    assert peer_headers == {"x-netllm-local-only": "1"}

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -27,12 +27,72 @@ EXPECTED_HTTP_ROUTES = {
     "/netllm/v1/config",
     "/netllm/v1/client-env",
     "/netllm/v1/admin/discover",
+    "/netllm/v1/heartbeat",
+    "/netllm/v1/peers",
+    "/netllm/v1/backends",
 }
+
+# Strategies that existing user configs may reference; removing any is breaking.
+LEGACY_ROUTING_STRATEGIES = (
+    "failover",
+    "round_robin",
+    "local_first",
+    "least_load",
+    "latency_weighted",
+    "batch_shard",
+)
 
 
 def test_default_listen_address() -> None:
     cfg = NetllmConfig()
     assert cfg.agent.listen == "127.0.0.1:11400"
+
+
+def test_default_config_behavior_unchanged() -> None:
+    """Existing installs keep single-machine semantics: loopback bind,
+    local_first routing, no cluster token, peer role, mDNS on."""
+    cfg = NetllmConfig()
+    assert cfg.routing.default_strategy == "local_first"
+    assert cfg.routing.allow_remote is True
+    assert cfg.swarm.cluster_token == ""
+    assert cfg.agent.role == "peer"
+    assert cfg.agent.advertise is True
+    assert cfg.swarm.mdns is True
+    assert cfg.swarm.subnet_scan is False
+
+
+def test_legacy_routing_strategies_still_accepted() -> None:
+    from netllm_core.models import RoutingConfig
+
+    for strategy in LEGACY_ROUTING_STRATEGIES:
+        cfg = RoutingConfig(default_strategy=strategy)
+        assert cfg.default_strategy == strategy
+
+
+def test_init_non_tty_writes_single_machine_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`netllm init` without a TTY must never prompt and must keep the
+    current single-machine defaults (loopback listen, local_first)."""
+    from typer.testing import CliRunner
+
+    import netllm_cli.main as cli_main
+
+    async def _no_providers(cfg: NetllmConfig) -> list[dict[str, str]]:
+        return []
+
+    monkeypatch.setattr(cli_main, "scan_local_providers", _no_providers)
+    cfg_path = tmp_path / "config.toml"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_main.app,
+        ["init", "--config", str(cfg_path), "--no-global-cli"],
+    )
+    assert result.exit_code == 0, result.output
+    cfg = load_config(cfg_path)
+    assert cfg.agent.listen == "127.0.0.1:11400"
+    assert cfg.routing.default_strategy == "local_first"
+    assert cfg.swarm.cluster_token == ""
 
 
 def test_config_example_roundtrip(tmp_path: Path) -> None:
@@ -178,6 +238,39 @@ def test_heartbeat_payload_contract() -> None:
             },
         )
     assert resp.status_code == 204
+
+
+def test_heartbeat_accepts_legacy_v03_backend_rows() -> None:
+    """Old peers (v0.3.x) send backend rows without any newer optional
+    fields — mixed-version swarms must keep working."""
+    from fastapi.testclient import TestClient
+    from netllm_agent.app import create_app
+    from netllm_core.models import NetllmConfig
+
+    legacy_backend = {
+        "id": "omlx:http://127.0.0.1:8080/v1",
+        "base_url": "http://127.0.0.1:8080/v1",
+        "provider": "omlx",
+        "local": True,
+        "health": {"status": "online", "models": ["mlx-model"]},
+    }
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    with TestClient(create_app(cfg)) as client:
+        resp = client.post(
+            "/netllm/v1/heartbeat",
+            json={
+                "agent_id": "old-peer",
+                "listen_url": "http://192.168.1.51:11400",
+                "role": "peer",
+                "hostname": "legacy",
+                "backends": [legacy_backend],
+            },
+        )
+        assert resp.status_code == 204
+        peers = client.get("/netllm/v1/peers").json()["peers"]
+    assert any(p["agent_id"] == "old-peer" for p in peers)
 
 
 def test_ui_route_serves_dashboard() -> None:

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -250,7 +250,6 @@ def test_heartbeat_accepts_legacy_v03_backend_rows() -> None:
         "id": "omlx:http://127.0.0.1:8080/v1",
         "base_url": "http://127.0.0.1:8080/v1",
         "provider": "omlx",
-        "local": True,
         "health": {"status": "online", "models": ["mlx-model"]},
     }
     cfg = NetllmConfig()

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -74,9 +74,8 @@ def test_init_non_tty_writes_single_machine_defaults(
 ) -> None:
     """`netllm init` without a TTY must never prompt and must keep the
     current single-machine defaults (loopback listen, local_first)."""
-    from typer.testing import CliRunner
-
     import netllm_cli.main as cli_main
+    from typer.testing import CliRunner
 
     async def _no_providers(cfg: NetllmConfig) -> list[dict[str, str]]:
         return []

--- a/tests/test_e2e_two_agents.py
+++ b/tests/test_e2e_two_agents.py
@@ -38,7 +38,11 @@ def _free_port() -> int:
 
 
 class ServerThread:
-    """Run an ASGI app under uvicorn in a daemon thread."""
+    """Run an ASGI app under uvicorn in a daemon thread.
+
+    Pass port 0 to let the OS pick a free port (race-free); the bound
+    port is available as ``self.port`` after ``start()``.
+    """
 
     def __init__(self, app: Any, port: int) -> None:
         self.port = port
@@ -55,6 +59,11 @@ class ServerThread:
             if time.monotonic() > deadline:
                 raise TimeoutError(f"uvicorn on :{self.port} did not start")
             time.sleep(0.05)
+        if self.port == 0:
+            for server in self.server.servers:
+                for sock in server.sockets:
+                    self.port = sock.getsockname()[1]
+                    break
 
     def stop(self) -> None:
         self.server.should_exit = True
@@ -136,22 +145,28 @@ def two_agent_mesh() -> Iterator[dict[str, Any]]:
     agent_a: dict[str, Any] = {"chat_inbound": 0, "local_only_headers": []}
     agent_b: dict[str, Any] = {"chat_inbound": 0, "local_only_headers": []}
 
-    pa_port, pb_port = _free_port(), _free_port()
-    aa_port, ab_port = _free_port(), _free_port()
-
-    servers = [
-        ServerThread(make_mock_provider("A", provider_a), pa_port),
-        ServerThread(make_mock_provider("B", provider_b), pb_port),
-        ServerThread(make_agent(pa_port, aa_port, agent_a), aa_port),
-        ServerThread(make_agent(pb_port, ab_port, agent_b), ab_port),
-    ]
     # Loopback peers are rejected in production; allow them for the harness.
     with patch(
         "netllm_discovery.swarm.is_lan_reachable_agent_url",
         lambda url: bool(url),
     ):
-        for server in servers:
-            server.start()
+        # Providers bind port 0 (OS-assigned, race-free). Agents need
+        # their port in config before binding, so they use _free_port().
+        provider_srv_a = ServerThread(make_mock_provider("A", provider_a), 0)
+        provider_srv_b = ServerThread(make_mock_provider("B", provider_b), 0)
+        provider_srv_a.start()
+        provider_srv_b.start()
+
+        aa_port, ab_port = _free_port(), _free_port()
+        agent_srv_a = ServerThread(
+            make_agent(provider_srv_a.port, aa_port, agent_a), aa_port
+        )
+        agent_srv_b = ServerThread(
+            make_agent(provider_srv_b.port, ab_port, agent_b), ab_port
+        )
+        agent_srv_a.start()
+        agent_srv_b.start()
+        servers = [provider_srv_a, provider_srv_b, agent_srv_a, agent_srv_b]
 
         base_a = f"http://127.0.0.1:{aa_port}"
         base_b = f"http://127.0.0.1:{ab_port}"

--- a/tests/test_e2e_two_agents.py
+++ b/tests/test_e2e_two_agents.py
@@ -1,0 +1,228 @@
+"""End-to-end two-agent acceptance harness.
+
+Standing acceptance test for the swarm promise: two real netllm agents
+(uvicorn, real HTTP) each with their own mock OpenAI provider, registered
+as peers of each other. Verifies that
+
+- one endpoint exposes the combined model catalog,
+- round_robin spreads same-model requests across both machines,
+- agent-hop forwards carry ``x-netllm-local-only`` so a distributing peer
+  never ping-pongs the request back into the mesh.
+
+Loopback note: real swarms reject loopback peer URLs; the harness patches
+``is_lan_reachable_agent_url`` so two agents on 127.0.0.1 can mesh in CI.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from collections.abc import Iterator
+from typing import Any
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI, Request
+from netllm_agent.app import create_app
+from netllm_core.models import BackendOverride, NetllmConfig
+
+MODEL = "shared-model"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class ServerThread:
+    """Run an ASGI app under uvicorn in a daemon thread."""
+
+    def __init__(self, app: Any, port: int) -> None:
+        self.port = port
+        config = uvicorn.Config(
+            app, host="127.0.0.1", port=port, log_level="error", lifespan="on"
+        )
+        self.server = uvicorn.Server(config)
+        self.thread = threading.Thread(target=self.server.run, daemon=True)
+
+    def start(self) -> None:
+        self.thread.start()
+        deadline = time.monotonic() + 15.0
+        while not self.server.started:
+            if time.monotonic() > deadline:
+                raise TimeoutError(f"uvicorn on :{self.port} did not start")
+            time.sleep(0.05)
+
+    def stop(self) -> None:
+        self.server.should_exit = True
+        self.thread.join(timeout=10.0)
+
+
+def make_mock_provider(name: str, record: dict[str, Any]) -> FastAPI:
+    """Minimal OpenAI-compatible inference server that records hits.
+
+    Discovery runs a 1-token diagnose probe (max_tokens=1 + stream key)
+    against override backends; those are counted as probes, not serves.
+    """
+    app = FastAPI()
+
+    @app.get("/v1/models")
+    def models() -> dict[str, Any]:
+        return {"object": "list", "data": [{"id": MODEL, "object": "model"}]}
+
+    @app.post("/v1/chat/completions")
+    async def chat(request: Request) -> dict[str, Any]:
+        payload = await request.json()
+        if payload.get("max_tokens") == 1 and "stream" in payload:
+            record["probe_hits"] += 1
+        else:
+            record["hits"] += 1
+        return {
+            "id": f"cmpl-{name}-{record['hits']}",
+            "object": "chat.completion",
+            "created": 0,
+            "model": payload.get("model", MODEL),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": f"served-by:{name}"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+    return app
+
+
+def make_agent(provider_port: int, agent_port: int, record: dict[str, Any]) -> FastAPI:
+    cfg = NetllmConfig()
+    cfg.agent.listen = f"127.0.0.1:{agent_port}"
+    cfg.agent.advertise = False
+    cfg.swarm.mdns = False
+    cfg.discovery.providers = []
+    cfg.routing.default_strategy = "round_robin"
+    cfg.routing.allow_remote = True
+    cfg.routing.backends = [
+        BackendOverride(
+            base_url=f"http://127.0.0.1:{provider_port}/v1",
+            provider="custom",
+            local=True,
+        )
+    ]
+    app = create_app(cfg)
+
+    @app.middleware("http")
+    async def inbound_recorder(request: Request, call_next: Any) -> Any:
+        if request.url.path == "/v1/chat/completions":
+            record["chat_inbound"] += 1
+            record["local_only_headers"].append(
+                request.headers.get("x-netllm-local-only")
+            )
+        return await call_next(request)
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def two_agent_mesh() -> Iterator[dict[str, Any]]:
+    from unittest.mock import patch
+
+    provider_a: dict[str, Any] = {"hits": 0, "probe_hits": 0}
+    provider_b: dict[str, Any] = {"hits": 0, "probe_hits": 0}
+    agent_a: dict[str, Any] = {"chat_inbound": 0, "local_only_headers": []}
+    agent_b: dict[str, Any] = {"chat_inbound": 0, "local_only_headers": []}
+
+    pa_port, pb_port = _free_port(), _free_port()
+    aa_port, ab_port = _free_port(), _free_port()
+
+    servers = [
+        ServerThread(make_mock_provider("A", provider_a), pa_port),
+        ServerThread(make_mock_provider("B", provider_b), pb_port),
+        ServerThread(make_agent(pa_port, aa_port, agent_a), aa_port),
+        ServerThread(make_agent(pb_port, ab_port, agent_b), ab_port),
+    ]
+    # Loopback peers are rejected in production; allow them for the harness.
+    with patch(
+        "netllm_discovery.swarm.is_lan_reachable_agent_url",
+        lambda url: bool(url),
+    ):
+        for server in servers:
+            server.start()
+
+        base_a = f"http://127.0.0.1:{aa_port}"
+        base_b = f"http://127.0.0.1:{ab_port}"
+        with httpx.Client(timeout=30.0) as client:
+            status_a = client.get(f"{base_a}/netllm/v1/status").json()
+            status_b = client.get(f"{base_b}/netllm/v1/status").json()
+            # Cross-register peers (mDNS is off in the harness).
+            client.post(f"{base_a}/netllm/v1/heartbeat", json=status_b)
+            client.post(f"{base_b}/netllm/v1/heartbeat", json=status_a)
+
+        yield {
+            "base_a": base_a,
+            "base_b": base_b,
+            "provider_a": provider_a,
+            "provider_b": provider_b,
+            "agent_a": agent_a,
+            "agent_b": agent_b,
+        }
+
+        for server in servers:
+            server.stop()
+
+
+def test_combined_catalog_via_single_endpoint(two_agent_mesh: dict[str, Any]) -> None:
+    with httpx.Client(timeout=30.0) as client:
+        data = client.get(f"{two_agent_mesh['base_a']}/v1/models").json()
+    model_ids = {m["id"] for m in data["data"]}
+    assert MODEL in model_ids
+
+    with httpx.Client(timeout=30.0) as client:
+        status = client.get(f"{two_agent_mesh['base_a']}/netllm/v1/status").json()
+    peer_rows = [b for b in status["backends"] if b["id"].startswith("peer:")]
+    assert len(peer_rows) == 1
+    assert MODEL in peer_rows[0]["health"]["models"]
+
+
+def test_round_robin_spreads_load_without_ping_pong(
+    two_agent_mesh: dict[str, Any],
+) -> None:
+    provider_a = two_agent_mesh["provider_a"]
+    provider_b = two_agent_mesh["provider_b"]
+    agent_a = two_agent_mesh["agent_a"]
+    agent_b = two_agent_mesh["agent_b"]
+    base_a = two_agent_mesh["base_a"]
+
+    start_a, start_b = provider_a["hits"], provider_b["hits"]
+    inbound_a_start = agent_a["chat_inbound"]
+    total = 4
+
+    with httpx.Client(timeout=60.0) as client:
+        for _ in range(total):
+            resp = client.post(
+                f"{base_a}/v1/chat/completions",
+                json={
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            assert resp.status_code == 200, resp.text
+
+    served_a = provider_a["hits"] - start_a
+    served_b = provider_b["hits"] - start_b
+
+    # Load spread: both machines did inference, nothing double-served.
+    assert served_a + served_b == total
+    assert served_a > 0
+    assert served_b > 0
+
+    # Loop safety: agent B is also round_robin and knows agent A as a
+    # peer, yet must never bounce a hop back (A only sees the test client).
+    assert agent_a["chat_inbound"] - inbound_a_start == total
+    hop_headers = [h for h in agent_b["local_only_headers"] if h is not None]
+    assert hop_headers, "agent B never saw a forwarded hop"
+    assert all(h == "1" for h in hop_headers)

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -127,3 +127,33 @@ def test_peer_agent_backends_unions_models_from_peer_backends() -> None:
     backends = registry.peer_agent_backends()
     assert len(backends) == 1
     assert set(backends[0].health.models) == {"model-a", "model-b"}
+
+
+def test_peer_agent_backends_ignore_peer_remote_rows() -> None:
+    """A peer's own remote (peer:) rows must not echo transitively."""
+    registry = SwarmRegistry(NetllmConfig())
+    registry.register_peer(
+        PeerRecord(
+            agent_id="peer-gateway",
+            listen_url="http://10.0.0.32:11400",
+            backends=[
+                Backend(
+                    id="local-omlx",
+                    base_url="http://127.0.0.1:8080/v1",
+                    provider="omlx",
+                    local=True,
+                    health=BackendHealth(models=["served-here"]),
+                ).model_dump(mode="json"),
+                Backend(
+                    id="peer:other-agent",
+                    base_url="http://10.0.0.99:11400/v1",
+                    provider="custom",
+                    local=False,
+                    health=BackendHealth(models=["served-elsewhere"]),
+                ).model_dump(mode="json"),
+            ],
+        )
+    )
+    backends = registry.peer_agent_backends()
+    assert len(backends) == 1
+    assert backends[0].health.models == ["served-here"]


### PR DESCRIPTION
## Summary

PR 1 of the v0.4.0 "deliver the swarm promise" series.

- Forwards to peer agents now carry `x-netllm-local-only: 1` (all four upstream paths: chat, chat stream, Anthropic bridge, bridge stream) so a peer running `round_robin`/`least_load` can never bounce a request back into the mesh
- `_peer_backend_models()` unions only a peer's `local=true` rows — stops transitive backend echo and catalog inflation across heartbeats
- Status and model-catalog handlers force-probe local backends only, fixing recursive cross-agent probe storms (agent A probing B made B probe A back)
- `OpenAIUpstream` gains optional `default_headers` (additive)
- New `tests/test_e2e_two_agents.py`: real two-agent uvicorn harness — the standing acceptance test for combined catalogs and same-model load spreading without ping-pong
- Contract baseline in `tests/test_contract.py`: pins single-machine defaults, legacy strategy literals, non-TTY `netllm init`, the `/netllm/v1` route surface, and v0.3.x heartbeat compatibility

## Test plan

- [x] `./scripts/ci.sh` (lint + 188 tests) green locally
- [x] e2e harness: 4 requests via agent A -> served 2/2 across both providers, agent B saw only header-guarded hops, agent A received zero bounce-backs