### PR TITLE
feat(routing): local_spillover strategy with mesh-aware load

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -26,9 +26,12 @@ heartbeat_interval_s = 10.0
 
 [routing]
 # local_first: single machine. round_robin: spread same model across LAN peer agents.
+# local_spillover: serve locally while idle, spill to least-loaded peer when busy.
 default_strategy = "local_first"
 allow_remote = true
 require_same_model_for_shard = true
+# local_spillover only: stay local below this many concurrent requests.
+spillover_max_local_in_flight = 2
 
 # Optional routing policies (first match wins). Cloud paths require allow_cloud = true.
 # [[routing.policies]]

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -54,7 +54,12 @@ class AgentService:
 
     def __init__(self, config: NetllmConfig) -> None:
         self.config = config
-        self.pool = RouterPool(allow_remote=config.routing.allow_remote)
+        self.pool = RouterPool(
+            allow_remote=config.routing.allow_remote,
+            spillover_max_local_in_flight=(
+                config.routing.spillover_max_local_in_flight
+            ),
+        )
         self.swarm = SwarmRegistry(config)
         self._mdns_advertiser = None
         self._mdns_browser = None
@@ -322,7 +327,7 @@ class AgentService:
             )
             if backend is None:
                 break
-            backend.in_flight += 1
+            self.pool.acquire(backend)
             BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(backend.in_flight)
             t0 = time.monotonic()
             try:
@@ -354,7 +359,7 @@ class AgentService:
                     exc,
                 )
             finally:
-                backend.in_flight = max(0, backend.in_flight - 1)
+                self.pool.release(backend)
                 BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(
                     backend.in_flight
                 )
@@ -394,7 +399,7 @@ class AgentService:
             )
             if backend is None:
                 break
-            backend.in_flight += 1
+            self.pool.acquire(backend)
             BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(backend.in_flight)
             try:
                 client = OpenAIUpstream(
@@ -416,7 +421,7 @@ class AgentService:
                     exc,
                 )
             finally:
-                backend.in_flight = max(0, backend.in_flight - 1)
+                self.pool.release(backend)
                 BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(
                     backend.in_flight
                 )
@@ -494,9 +499,8 @@ class AgentService:
             ]
         )
 
-    @staticmethod
     def _order_message_candidates(
-        candidates: list[Backend], routing: ResolvedRouting
+        self, candidates: list[Backend], routing: ResolvedRouting
     ) -> list[Backend]:
         ordered = candidates
         if routing.prefer_provider:
@@ -504,11 +508,20 @@ class AgentService:
             if preferred:
                 others = [b for b in ordered if b.provider != routing.prefer_provider]
                 ordered = preferred + others
-        if routing.strategy == "local_first":
+        if routing.strategy in ("local_first", "local_spillover"):
             local = [b for b in ordered if b.local]
             remote = [b for b in ordered if not b.local]
             if local:
                 ordered = local + remote
+            if routing.strategy == "local_spillover" and local and remote:
+                best_local = min(local, key=lambda b: b.in_flight)
+                best_remote = min(remote, key=lambda b: b.in_flight)
+                threshold = self.pool.spillover_max_local_in_flight
+                if (
+                    best_local.in_flight >= threshold
+                    and best_remote.in_flight < best_local.in_flight
+                ):
+                    ordered = remote + local
         return ordered
 
     def _message_backend_candidates(
@@ -576,7 +589,7 @@ class AgentService:
             backend = candidates[attempt - 1] if attempt <= len(candidates) else None
             if backend is None:
                 break
-            backend.in_flight += 1
+            self.pool.acquire(backend)
             BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(backend.in_flight)
             t0 = time.monotonic()
             try:
@@ -604,7 +617,7 @@ class AgentService:
                     exc,
                 )
             finally:
-                backend.in_flight = max(0, backend.in_flight - 1)
+                self.pool.release(backend)
                 BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(
                     backend.in_flight
                 )
@@ -645,7 +658,7 @@ class AgentService:
             backend = candidates[attempt - 1] if attempt <= len(candidates) else None
             if backend is None:
                 break
-            backend.in_flight += 1
+            self.pool.acquire(backend)
             BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(backend.in_flight)
             try:
                 async for chunk in self._messages_stream_on_backend(
@@ -663,7 +676,7 @@ class AgentService:
                     exc,
                 )
             finally:
-                backend.in_flight = max(0, backend.in_flight - 1)
+                self.pool.release(backend)
                 BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(
                     backend.in_flight
                 )

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -514,14 +514,17 @@ class AgentService:
             if local:
                 ordered = local + remote
             if routing.strategy == "local_spillover" and local and remote:
-                best_local = min(local, key=lambda b: b.in_flight)
-                best_remote = min(remote, key=lambda b: b.in_flight)
+                # Stable load sort keeps prefer_provider order on ties.
+                local_sorted = sorted(local, key=lambda b: b.in_flight)
+                remote_sorted = sorted(remote, key=lambda b: b.in_flight)
                 threshold = self.pool.spillover_max_local_in_flight
                 if (
-                    best_local.in_flight >= threshold
-                    and best_remote.in_flight < best_local.in_flight
+                    local_sorted[0].in_flight >= threshold
+                    and remote_sorted[0].in_flight < local_sorted[0].in_flight
                 ):
-                    ordered = remote + local
+                    ordered = remote_sorted + local_sorted
+                else:
+                    ordered = local_sorted + remote_sorted
         return ordered
 
     def _message_backend_candidates(

--- a/packages/netllm-core/AGENTS.md
+++ b/packages/netllm-core/AGENTS.md
@@ -15,6 +15,7 @@ Key modules: `config.py`, `routing_policy.py`, `pool.py`, `health.py`, `models.p
 - Config path: `~/.config/netllm/config.toml` (see root `config.example.toml`)
 - `anthropic_bridge.py` translates Messages API ↔ OpenAI-compatible backends; SDK calls stay in `netllm-sdk-anthropic`
 - Routing strategies and backend health drive agent and CLI behavior
+- **`local_spillover`** (swarm default from guided init): serve locally below `routing.spillover_max_local_in_flight` concurrent requests, spill to the least-loaded peer above it; peer load = heartbeat-reported local rows + own active hops (`RouterPool._own_peer_hops` ledger — use `pool.acquire()`/`pool.release()`, never mutate `in_flight` directly)
 
 ## Work Guidance
 

--- a/packages/netllm-core/src/netllm_core/models.py
+++ b/packages/netllm-core/src/netllm_core/models.py
@@ -28,6 +28,7 @@ RoutingStrategy = Literal[
     "least_load",
     "latency_weighted",
     "batch_shard",
+    "local_spillover",
 ]
 
 AgentRole = Literal["peer", "gateway"]
@@ -101,6 +102,9 @@ class RoutingConfig(BaseModel):
     default_strategy: RoutingStrategy = "local_first"
     allow_remote: bool = True
     require_same_model_for_shard: bool = True
+    # local_spillover: serve locally below this many concurrent requests,
+    # spill to the least-loaded LAN peer at or above it.
+    spillover_max_local_in_flight: int = 2
     backends: list[BackendOverride] = Field(default_factory=list)
     policies: list[RoutingPolicy] = Field(default_factory=list)
 

--- a/packages/netllm-core/src/netllm_core/pool.py
+++ b/packages/netllm-core/src/netllm_core/pool.py
@@ -68,11 +68,21 @@ class BatchDedupLedger:
 class RouterPool:
     """Manages backends with health cache and routing selection."""
 
-    def __init__(self, *, allow_remote: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        allow_remote: bool = True,
+        spillover_max_local_in_flight: int = 2,
+    ) -> None:
         self._backends: list[Backend] = []
         self._health_cache: dict[str, _HealthEntry] = {}
         self._round_robin_idx = 0
         self.allow_remote = allow_remote
+        self.spillover_max_local_in_flight = max(1, spillover_max_local_in_flight)
+        # Our own active forwards per peer agent URL. Peer rows are
+        # rebuilt from heartbeats on every refresh, so this ledger keeps
+        # in-flight hop counts from being wiped between heartbeats.
+        self._own_peer_hops: dict[str, int] = {}
 
     @property
     def backends(self) -> list[Backend]:
@@ -84,12 +94,31 @@ class RouterPool:
     def merge_backends(self, new_backends: list[Backend]) -> None:
         by_url = {b.base_url: b for b in self._backends}
         for b in new_backends:
-            if b.base_url in by_url:
-                existing = by_url[b.base_url]
+            existing = by_url.get(b.base_url)
+            if b.id.startswith("peer:"):
+                # Peer rows arrive with heartbeat-reported load; add our
+                # own in-flight hops so load is visible between heartbeats.
+                b.in_flight += self._own_peer_hops.get(b.base_url, 0)
+            elif existing is not None:
                 b.in_flight = existing.in_flight
+            if existing is not None:
                 b.latency_ema_ms = existing.latency_ema_ms
             by_url[b.base_url] = b
         self._backends = list(by_url.values())
+
+    def acquire(self, backend: Backend) -> None:
+        """Count a request as in flight on this backend."""
+        backend.in_flight += 1
+        if backend.id.startswith("peer:"):
+            hops = self._own_peer_hops
+            hops[backend.base_url] = hops.get(backend.base_url, 0) + 1
+
+    def release(self, backend: Backend) -> None:
+        """Mark a request complete on this backend."""
+        backend.in_flight = max(0, backend.in_flight - 1)
+        if backend.id.startswith("peer:"):
+            hops = self._own_peer_hops
+            hops[backend.base_url] = max(0, hops.get(backend.base_url, 0) - 1)
 
     def mark_failure(self, backend: Backend) -> None:
         key = backend.cache_key()
@@ -222,11 +251,33 @@ class RouterPool:
                 return pool[idx]
             return pool[0]
 
+        if strategy == "local_spillover":
+            return self._select_local_spillover(all_candidates)
+
         if strategy == "batch_shard" and shard_key:
             idx = shard_index(shard_key, len(all_candidates))
             return all_candidates[idx]
 
         return all_candidates[0]
+
+    def _select_local_spillover(self, candidates: list[Backend]) -> Backend | None:
+        """Serve locally while under the in-flight threshold; above it,
+        spill to a LAN peer only when the peer is genuinely less loaded."""
+        local_pool = [b for b in candidates if b.local]
+        remote_pool = [b for b in candidates if not b.local]
+        if not local_pool:
+            if not remote_pool:
+                return None
+            return min(remote_pool, key=lambda b: b.in_flight)
+        best_local = min(local_pool, key=lambda b: b.in_flight)
+        if best_local.in_flight < self.spillover_max_local_in_flight:
+            return best_local
+        if not remote_pool:
+            return best_local
+        best_remote = min(remote_pool, key=lambda b: b.in_flight)
+        if best_remote.in_flight < best_local.in_flight:
+            return best_remote
+        return best_local
 
     def plan_batch_shard(
         self,

--- a/packages/netllm-discovery/src/netllm_discovery/swarm.py
+++ b/packages/netllm-discovery/src/netllm_discovery/swarm.py
@@ -51,23 +51,34 @@ class SwarmRegistry:
         for pid in self.stale_peers(max_age_s):
             del self.peers[pid]
 
-    def _peer_backend_models(self, peer: PeerRecord) -> list[str]:
-        """Union model IDs the peer serves directly (local rows only).
+    def _peer_local_rows(self, peer: PeerRecord) -> list[Backend]:
+        """Validated `local=true` rows from a peer's heartbeat payload.
 
         Remote rows in a peer's status are its own view of *other*
-        agents; advertising those here would echo backends transitively
+        agents; using those here would echo backends transitively
         around the mesh, inflate catalogs, and invite multi-hop chains.
         """
-        models: set[str] = set()
+        rows: list[Backend] = []
         for raw in peer.backends:
             try:
                 b = Backend.model_validate(raw)
-                if not b.local:
-                    continue
-                models.update(b.health.models)
             except Exception:
                 logger.debug("skip invalid peer backend: %s", raw)
+                continue
+            if b.local:
+                rows.append(b)
+        return rows
+
+    def _peer_backend_models(self, peer: PeerRecord) -> list[str]:
+        """Union model IDs the peer serves directly (local rows only)."""
+        models: set[str] = set()
+        for b in self._peer_local_rows(peer):
+            models.update(b.health.models)
         return sorted(models)
+
+    def _peer_in_flight(self, peer: PeerRecord) -> int:
+        """Heartbeat-reported concurrent load on the peer's own providers."""
+        return sum(max(0, b.in_flight) for b in self._peer_local_rows(peer))
 
     def peer_agent_backends(self) -> list[Backend]:
         """One routable backend per peer: the peer's agent OpenAI surface (/v1)."""
@@ -89,6 +100,7 @@ class SwarmRegistry:
                     local=False,
                     agent_id=peer.agent_id,
                     health=BackendHealth(models=models),
+                    in_flight=self._peer_in_flight(peer),
                 )
             )
         return out

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -597,16 +597,12 @@ def test_order_message_candidates_spillover_sorts_by_load() -> None:
         local=False,
         in_flight=0,
     )
-    ordered = service._order_message_candidates(
-        [busy_peer, local, idle_peer], routing
-    )
+    ordered = service._order_message_candidates([busy_peer, local, idle_peer], routing)
     # Saturated local with a less-loaded peer: least-loaded remote first.
     assert [b.id for b in ordered] == ["peer:idle", "peer:busy", "local"]
 
     local.in_flight = 0
-    ordered = service._order_message_candidates(
-        [busy_peer, local, idle_peer], routing
-    )
+    ordered = service._order_message_candidates([busy_peer, local, idle_peer], routing)
     assert ordered[0].id == "local"
 
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -567,6 +567,49 @@ def test_wants_local_only_header() -> None:
     assert not AgentService._wants_local_only({"x-netllm-local-only": "0"})
 
 
+def test_order_message_candidates_spillover_sorts_by_load() -> None:
+    from netllm_agent.service import AgentService
+    from netllm_core.routing_policy import ResolvedRouting
+
+    cfg = NetllmConfig()
+    cfg.routing.spillover_max_local_in_flight = 2
+    service = AgentService(cfg)
+    routing = ResolvedRouting(
+        strategy="local_spillover",
+        local_only=False,
+        allow_cloud_inject=False,
+        prefer_provider=None,
+    )
+    local = Backend(
+        id="local", base_url="http://127.0.0.1:8080/v1", local=True, in_flight=3
+    )
+    busy_peer = Backend(
+        id="peer:busy",
+        base_url="http://192.168.1.11:11400/v1",
+        provider="custom",
+        local=False,
+        in_flight=9,
+    )
+    idle_peer = Backend(
+        id="peer:idle",
+        base_url="http://192.168.1.12:11400/v1",
+        provider="custom",
+        local=False,
+        in_flight=0,
+    )
+    ordered = service._order_message_candidates(
+        [busy_peer, local, idle_peer], routing
+    )
+    # Saturated local with a less-loaded peer: least-loaded remote first.
+    assert [b.id for b in ordered] == ["peer:idle", "peer:busy", "local"]
+
+    local.in_flight = 0
+    ordered = service._order_message_candidates(
+        [busy_peer, local, idle_peer], routing
+    )
+    assert ordered[0].id == "local"
+
+
 def test_peer_forward_headers_loop_guard() -> None:
     from netllm_agent.service import AgentService
     from netllm_core.models import LOCAL_ONLY_HEADER

--- a/tests/test_e2e_two_agents.py
+++ b/tests/test_e2e_two_agents.py
@@ -259,23 +259,32 @@ def test_local_spillover_idle_agent_serves_locally() -> None:
     agent_a: dict[str, Any] = {"chat_inbound": 0, "local_only_headers": []}
     agent_b: dict[str, Any] = {"chat_inbound": 0, "local_only_headers": []}
 
-    pa_port, pb_port = _free_port(), _free_port()
-    aa_port, ab_port = _free_port(), _free_port()
-    servers = [
-        ServerThread(make_mock_provider("A", provider_a), pa_port),
-        ServerThread(make_mock_provider("B", provider_b), pb_port),
-        ServerThread(
-            make_agent(pa_port, aa_port, agent_a, strategy="local_spillover"), aa_port
-        ),
-        ServerThread(
-            make_agent(pb_port, ab_port, agent_b, strategy="local_spillover"), ab_port
-        ),
-    ]
     with patch(
         "netllm_discovery.swarm.is_lan_reachable_agent_url",
         lambda url: bool(url),
     ):
-        for server in servers:
+        provider_srv_a = ServerThread(make_mock_provider("A", provider_a), 0)
+        provider_srv_b = ServerThread(make_mock_provider("B", provider_b), 0)
+        provider_srv_a.start()
+        provider_srv_b.start()
+        aa_port, ab_port = _free_port(), _free_port()
+        servers = [
+            provider_srv_a,
+            provider_srv_b,
+            ServerThread(
+                make_agent(
+                    provider_srv_a.port, aa_port, agent_a, strategy="local_spillover"
+                ),
+                aa_port,
+            ),
+            ServerThread(
+                make_agent(
+                    provider_srv_b.port, ab_port, agent_b, strategy="local_spillover"
+                ),
+                ab_port,
+            ),
+        ]
+        for server in servers[2:]:
             server.start()
         try:
             base_a = f"http://127.0.0.1:{aa_port}"

--- a/tests/test_e2e_two_agents.py
+++ b/tests/test_e2e_two_agents.py
@@ -107,13 +107,19 @@ def make_mock_provider(name: str, record: dict[str, Any]) -> FastAPI:
     return app
 
 
-def make_agent(provider_port: int, agent_port: int, record: dict[str, Any]) -> FastAPI:
+def make_agent(
+    provider_port: int,
+    agent_port: int,
+    record: dict[str, Any],
+    *,
+    strategy: str = "round_robin",
+) -> FastAPI:
     cfg = NetllmConfig()
     cfg.agent.listen = f"127.0.0.1:{agent_port}"
     cfg.agent.advertise = False
     cfg.swarm.mdns = False
     cfg.discovery.providers = []
-    cfg.routing.default_strategy = "round_robin"
+    cfg.routing.default_strategy = strategy  # type: ignore[assignment]
     cfg.routing.allow_remote = True
     cfg.routing.backends = [
         BackendOverride(
@@ -241,3 +247,59 @@ def test_round_robin_spreads_load_without_ping_pong(
     hop_headers = [h for h in agent_b["local_only_headers"] if h is not None]
     assert hop_headers, "agent B never saw a forwarded hop"
     assert all(h == "1" for h in hop_headers)
+
+
+def test_local_spillover_idle_agent_serves_locally() -> None:
+    """With local_spillover and a serial (idle) workload, requests never
+    leave the machine even though a peer is registered."""
+    from unittest.mock import patch
+
+    provider_a: dict[str, Any] = {"hits": 0, "probe_hits": 0}
+    provider_b: dict[str, Any] = {"hits": 0, "probe_hits": 0}
+    agent_a: dict[str, Any] = {"chat_inbound": 0, "local_only_headers": []}
+    agent_b: dict[str, Any] = {"chat_inbound": 0, "local_only_headers": []}
+
+    pa_port, pb_port = _free_port(), _free_port()
+    aa_port, ab_port = _free_port(), _free_port()
+    servers = [
+        ServerThread(make_mock_provider("A", provider_a), pa_port),
+        ServerThread(make_mock_provider("B", provider_b), pb_port),
+        ServerThread(
+            make_agent(pa_port, aa_port, agent_a, strategy="local_spillover"), aa_port
+        ),
+        ServerThread(
+            make_agent(pb_port, ab_port, agent_b, strategy="local_spillover"), ab_port
+        ),
+    ]
+    with patch(
+        "netllm_discovery.swarm.is_lan_reachable_agent_url",
+        lambda url: bool(url),
+    ):
+        for server in servers:
+            server.start()
+        try:
+            base_a = f"http://127.0.0.1:{aa_port}"
+            base_b = f"http://127.0.0.1:{ab_port}"
+            with httpx.Client(timeout=30.0) as client:
+                status_a = client.get(f"{base_a}/netllm/v1/status").json()
+                status_b = client.get(f"{base_b}/netllm/v1/status").json()
+                client.post(f"{base_a}/netllm/v1/heartbeat", json=status_b)
+                client.post(f"{base_b}/netllm/v1/heartbeat", json=status_a)
+
+                start_b = provider_b["hits"]
+                for _ in range(3):
+                    resp = client.post(
+                        f"{base_a}/v1/chat/completions",
+                        json={
+                            "model": MODEL,
+                            "messages": [{"role": "user", "content": "hi"}],
+                        },
+                    )
+                    assert resp.status_code == 200
+                    body = resp.json()
+                    assert body["choices"][0]["message"]["content"] == "served-by:A"
+            assert provider_b["hits"] == start_b
+            assert agent_b["chat_inbound"] == 0
+        finally:
+            for server in servers:
+                server.stop()

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -169,3 +169,153 @@ def test_least_load_selects_lowest_in_flight(_mock: object) -> None:
     selected = pool.select_backend("m", "least_load")
     assert selected is not None
     assert selected.base_url == "http://b/v1"
+
+
+def _spillover_pool(local_in_flight: int, remote_in_flight: int) -> RouterPool:
+    pool = RouterPool(spillover_max_local_in_flight=2)
+    pool.set_backends(
+        [
+            Backend(
+                id="local",
+                base_url="http://127.0.0.1:8080/v1",
+                local=True,
+                in_flight=local_in_flight,
+                health=BackendHealth(models=["m"], status="online"),
+            ),
+            Backend(
+                id="peer:remote",
+                base_url="http://192.168.1.11:11400/v1",
+                provider="custom",
+                local=False,
+                in_flight=remote_in_flight,
+                health=BackendHealth(models=["m"], status="online"),
+            ),
+        ]
+    )
+    return pool
+
+
+@patch("netllm_core.pool.probe_openai_compat_sync", return_value=_MOCK_ONLINE)
+def test_local_spillover_idle_local_never_hops(_mock: object) -> None:
+    pool = _spillover_pool(local_in_flight=0, remote_in_flight=0)
+    selected = pool.select_backend("m", "local_spillover")
+    assert selected is not None
+    assert selected.local is True
+
+
+@patch("netllm_core.pool.probe_openai_compat_sync", return_value=_MOCK_ONLINE)
+def test_local_spillover_saturated_local_spills_to_idle_peer(_mock: object) -> None:
+    pool = _spillover_pool(local_in_flight=2, remote_in_flight=0)
+    selected = pool.select_backend("m", "local_spillover")
+    assert selected is not None
+    assert selected.local is False
+    assert selected.base_url == "http://192.168.1.11:11400/v1"
+
+
+@patch("netllm_core.pool.probe_openai_compat_sync", return_value=_MOCK_ONLINE)
+def test_local_spillover_stays_local_when_peer_equally_busy(_mock: object) -> None:
+    pool = _spillover_pool(local_in_flight=3, remote_in_flight=3)
+    selected = pool.select_backend("m", "local_spillover")
+    assert selected is not None
+    assert selected.local is True
+
+
+@patch("netllm_core.pool.probe_openai_compat_sync", return_value=_MOCK_ONLINE)
+def test_local_spillover_no_remote_stays_local_when_saturated(_mock: object) -> None:
+    pool = RouterPool(spillover_max_local_in_flight=2)
+    pool.set_backends(
+        [
+            Backend(
+                id="local",
+                base_url="http://127.0.0.1:8080/v1",
+                local=True,
+                in_flight=9,
+                health=BackendHealth(models=["m"], status="online"),
+            )
+        ]
+    )
+    selected = pool.select_backend("m", "local_spillover")
+    assert selected is not None
+    assert selected.local is True
+
+
+@patch("netllm_core.pool.probe_openai_compat_sync", return_value=_MOCK_ONLINE)
+def test_local_spillover_remote_only_uses_least_loaded(_mock: object) -> None:
+    pool = RouterPool(spillover_max_local_in_flight=2)
+    pool.set_backends(
+        [
+            Backend(
+                id="peer:a",
+                base_url="http://192.168.1.11:11400/v1",
+                provider="custom",
+                local=False,
+                in_flight=4,
+                health=BackendHealth(models=["m"], status="online"),
+            ),
+            Backend(
+                id="peer:b",
+                base_url="http://192.168.1.12:11400/v1",
+                provider="custom",
+                local=False,
+                in_flight=1,
+                health=BackendHealth(models=["m"], status="online"),
+            ),
+        ]
+    )
+    selected = pool.select_backend("m", "local_spillover")
+    assert selected is not None
+    assert selected.base_url == "http://192.168.1.12:11400/v1"
+
+
+def test_merge_backends_adds_own_hops_to_peer_rows() -> None:
+    """Peer rows are rebuilt from heartbeats every refresh; our active
+    forwards must survive the rebuild and stale peer load must not stick."""
+    pool = RouterPool()
+    peer = Backend(
+        id="peer:remote",
+        base_url="http://192.168.1.11:11400/v1",
+        provider="custom",
+        local=False,
+        in_flight=0,
+    )
+    pool.set_backends([peer])
+    pool.acquire(peer)
+    pool.acquire(peer)
+    assert peer.in_flight == 2
+
+    def fresh_row(reported: int) -> Backend:
+        return Backend(
+            id="peer:remote",
+            base_url="http://192.168.1.11:11400/v1",
+            provider="custom",
+            local=False,
+            in_flight=reported,
+        )
+
+    # Heartbeat reports 1 busy slot; our 2 active hops are added on top.
+    pool.merge_backends([fresh_row(1)])
+    assert pool.backends[0].in_flight == 3
+    # Hops complete; the next heartbeat-reported value stands alone (no ratchet).
+    pool.release(pool.backends[0])
+    pool.release(pool.backends[0])
+    pool.merge_backends([fresh_row(0)])
+    assert pool.backends[0].in_flight == 0
+
+
+def test_merge_backends_preserves_local_in_flight() -> None:
+    pool = RouterPool()
+    existing = Backend(
+        id="omlx:x", base_url="http://127.0.0.1:8080/v1", local=True, in_flight=2
+    )
+    pool.set_backends([existing])
+    pool.merge_backends(
+        [
+            Backend(
+                id="omlx:x",
+                base_url="http://127.0.0.1:8080/v1",
+                local=True,
+                in_flight=0,
+            )
+        ]
+    )
+    assert pool.backends[0].in_flight == 2

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -157,3 +157,44 @@ def test_peer_agent_backends_ignore_peer_remote_rows() -> None:
     backends = registry.peer_agent_backends()
     assert len(backends) == 1
     assert backends[0].health.models == ["served-here"]
+
+
+def test_peer_agent_backends_seed_in_flight_from_local_rows() -> None:
+    """Heartbeat-reported peer load feeds local_spillover decisions."""
+    registry = SwarmRegistry(NetllmConfig())
+    registry.register_peer(
+        PeerRecord(
+            agent_id="peer-busy",
+            listen_url="http://10.0.0.32:11400",
+            backends=[
+                Backend(
+                    id="local-omlx",
+                    base_url="http://127.0.0.1:8080/v1",
+                    provider="omlx",
+                    local=True,
+                    in_flight=2,
+                    health=BackendHealth(models=["m"]),
+                ).model_dump(mode="json"),
+                Backend(
+                    id="local-ollama",
+                    base_url="http://127.0.0.1:11434/v1",
+                    provider="ollama",
+                    local=True,
+                    in_flight=1,
+                    health=BackendHealth(models=["m"]),
+                ).model_dump(mode="json"),
+                Backend(
+                    id="peer:other",
+                    base_url="http://10.0.0.99:11400/v1",
+                    provider="custom",
+                    local=False,
+                    in_flight=7,
+                    health=BackendHealth(models=["m"]),
+                ).model_dump(mode="json"),
+            ],
+        )
+    )
+    backends = registry.peer_agent_backends()
+    assert len(backends) == 1
+    # Sum of local rows only (2 + 1); the peer's own remote hops are not ours.
+    assert backends[0].in_flight == 3


### PR DESCRIPTION
## Summary

PR 2 of the v0.4.0 "deliver the swarm promise" series (follows #20).

- New `local_spillover` routing strategy: serve locally below `routing.spillover_max_local_in_flight` concurrent requests (default 2), spill to the least-loaded LAN peer above it, never hop when the peer is just as busy
- Peer load is mesh-aware: heartbeat-reported local rows seed `peer:` backend `in_flight`, and a `RouterPool` own-hops ledger (`acquire`/`release`) keeps our active forwards visible between heartbeats without stale values ratcheting
- Anthropic Messages path orders candidates with the same spillover rule
- `local_first` stays the global default — guided swarm init (PR 3) opts in
- Additive only: new strategy literal + one new optional config field (contract tests pin legacy strategies and defaults)

## Test plan

- [x] `./scripts/ci.sh` green (197 tests)
- [x] Unit: idle local never hops, saturated local spills to idle peer, stays local when peer equally busy, remote-only picks least loaded, merge keeps own hops without ratchet
- [x] e2e: spillover mesh with serial workload serves 100% locally while a peer is registered