### PR TITLE
feat(cli): guided swarm init, netllm join, and swarm-token pairing

### DIFF
--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -134,6 +134,7 @@ class AgentService:
             "backends": [b.model_dump(mode="json") for b in self.pool.backends],
             "peers": self.swarm.all_peer_urls(),
             "routing_strategy": self.config.routing.default_strategy,
+            "cluster_token_set": bool(self.config.swarm.cluster_token),
         }
         if omlx_admin:
             payload["omlx_admin_url"] = omlx_admin

--- a/packages/netllm-cli/src/netllm_cli/main.py
+++ b/packages/netllm-cli/src/netllm_cli/main.py
@@ -129,9 +129,19 @@ def _resolve_init_swarm_mode(*, swarm: bool, single: bool) -> bool:
     return False
 
 
+def _listen_port_of(listen: str) -> str:
+    """Port from a host:port listen string (last-colon split, IPv6-safe)."""
+    if "]" in listen:  # bracketed IPv6: [::1]:11400
+        port = listen.rpartition("]:")[2]
+    elif listen.count(":") == 1:  # host:port
+        port = listen.rpartition(":")[2]
+    else:  # bare host or bare IPv6 — no port present
+        port = ""
+    return port if port.isdigit() else "11400"
+
+
 def _apply_swarm_mode(cfg: NetllmConfig) -> None:
-    host, _, port = cfg.agent.listen.partition(":")
-    cfg.agent.listen = f"0.0.0.0:{port or '11400'}"
+    cfg.agent.listen = f"0.0.0.0:{_listen_port_of(cfg.agent.listen)}"
     cfg.swarm.cluster_token = secrets.token_urlsafe(24)
     cfg.routing.default_strategy = "local_spillover"
 
@@ -344,10 +354,12 @@ def discover(
 
 
 def _normalize_agent_url(url: str) -> str:
+    from urllib.parse import urlparse
+
     base = url.strip().rstrip("/")
     if not base.startswith("http"):
         base = f"http://{base}"
-    if ":" not in base.split("//", 1)[1]:
+    if urlparse(base).port is None:
         base = f"{base}:11400"
     return base
 
@@ -391,6 +403,16 @@ def _validate_join_token(base: str, token: str, agent_id: str) -> None:
             hints=[
                 "Show the token on the other machine: [cyan]netllm swarm-token[/]",
                 "Copy the full join command printed by [cyan]netllm init --swarm[/]",
+            ],
+        )
+        raise typer.Exit(1)
+    if resp.status_code not in (200, 204):
+        print_error(
+            "Swarm handshake failed",
+            f"Heartbeat probe returned HTTP {resp.status_code}.",
+            hints=[
+                "Check the other agent's logs",
+                "Verify both machines run a compatible netllm version",
             ],
         )
         raise typer.Exit(1)
@@ -461,8 +483,7 @@ def join(
 
 
 def _apply_swarm_join_listen(cfg: NetllmConfig) -> None:
-    host, _, port = cfg.agent.listen.partition(":")
-    cfg.agent.listen = f"0.0.0.0:{port or '11400'}"
+    cfg.agent.listen = f"0.0.0.0:{_listen_port_of(cfg.agent.listen)}"
 
 
 @app.command("swarm-token")

--- a/packages/netllm-cli/src/netllm_cli/main.py
+++ b/packages/netllm-cli/src/netllm_cli/main.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import secrets
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any
@@ -105,6 +107,55 @@ def _require_config(cfg_path: Path) -> NetllmConfig:
     return load_config(cfg_path)
 
 
+def _resolve_init_swarm_mode(*, swarm: bool, single: bool) -> bool:
+    """One guided question on a TTY; non-TTY stays single-machine."""
+    if swarm and single:
+        print_error(
+            "Conflicting flags",
+            "--swarm and --single are mutually exclusive.",
+        )
+        raise typer.Exit(1)
+    if swarm:
+        return True
+    if single:
+        return False
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        console.print(
+            "\n[bold]Single machine, or LAN swarm?[/]\n"
+            "  [dim]Swarm mode binds the agent to your LAN, generates a\n"
+            "  cluster token, and spreads same-model load across machines.[/]"
+        )
+        return typer.confirm("Set up a LAN swarm (mesh with other machines)?")
+    return False
+
+
+def _apply_swarm_mode(cfg: NetllmConfig) -> None:
+    host, _, port = cfg.agent.listen.partition(":")
+    cfg.agent.listen = f"0.0.0.0:{port or '11400'}"
+    cfg.swarm.cluster_token = secrets.token_urlsafe(24)
+    cfg.routing.default_strategy = "local_spillover"
+
+
+def _join_command_for(cfg: NetllmConfig) -> str:
+    from netllm_discovery.lan import agent_url_from_listen
+
+    lan_url = agent_url_from_listen(cfg.agent.listen)
+    return f"netllm join {lan_url} --token {cfg.swarm.cluster_token}"
+
+
+def _print_swarm_summary(cfg: NetllmConfig) -> None:
+    console.print(
+        Panel(
+            "[bold]Run on every other machine:[/]\n"
+            f"  [cyan]{_join_command_for(cfg)}[/]\n\n"
+            "[dim]Token saved in config (swarm.cluster_token) — show it any "
+            "time with[/] [cyan]netllm swarm-token[/]",
+            title="LAN swarm enabled",
+            border_style="green",
+        )
+    )
+
+
 @app.command()
 def init(
     config: Path | None = typer.Option(None, "--config", help="Config file path"),
@@ -113,6 +164,17 @@ def init(
         True,
         "--global-cli/--no-global-cli",
         help="Install `netllm` globally via uv and update shell PATH",
+    ),
+    swarm: bool = typer.Option(
+        False,
+        "--swarm",
+        help="LAN swarm mode: bind 0.0.0.0, generate cluster token, "
+        "spread load with local_spillover",
+    ),
+    single: bool = typer.Option(
+        False,
+        "--single",
+        help="Single-machine mode (loopback bind, local-only routing)",
     ),
 ) -> None:
     """Write default config, scan local providers, optionally install global CLI."""
@@ -128,16 +190,22 @@ def init(
             hints=[
                 "Scan providers: [cyan]netllm discover[/]",
                 "Overwrite: [cyan]netllm init --force[/]",
+                "Join a swarm without re-init: [cyan]netllm join URL --token T[/]",
                 "Edit config: [cyan]netllm config-edit[/]",
             ],
         )
         raise typer.Exit(0)
 
+    swarm_mode = _resolve_init_swarm_mode(swarm=swarm, single=single)
     cfg = NetllmConfig()
+    if swarm_mode:
+        _apply_swarm_mode(cfg)
     save_config(cfg, cfg_path)
     base = listen_url(cfg.agent.listen)
 
     print_heading("netllm initialized", f"Config written to {cfg_path}")
+    if swarm_mode:
+        _print_swarm_summary(cfg)
 
     results = asyncio.run(scan_local_providers(cfg))
     online = [r for r in results if r.get("status") == "online"]
@@ -166,18 +234,32 @@ def init(
             ],
         )
 
-    print_next_steps(
-        [
-            (suggested_cli("serve"), "Start the router (this terminal)"),
-            (
-                suggested_cli("serve --host 0.0.0.0"),
-                "LAN + swarm — other machines can reach this agent",
-            ),
-            (f"export OPENAI_BASE_URL={base}/v1", "Point OpenAI clients at netllm"),
-            (suggested_cli("status"), "New terminal — backends, peers, health"),
-            (suggested_cli("models"), "List all routed models"),
-        ]
-    )
+    if swarm_mode:
+        print_next_steps(
+            [
+                (suggested_cli("serve"), "Start the router (binds your LAN)"),
+                (_join_command_for(cfg), "Run on every other machine"),
+                (
+                    f"export OPENAI_BASE_URL={base}/v1",
+                    "Point OpenAI clients at netllm",
+                ),
+                (suggested_cli("peers"), "Verify machines found each other"),
+                (suggested_cli("models"), "Combined model catalog"),
+            ]
+        )
+    else:
+        print_next_steps(
+            [
+                (suggested_cli("serve"), "Start the router (this terminal)"),
+                (
+                    suggested_cli("init --force --swarm"),
+                    "LAN swarm — mesh with other machines (token + LAN bind)",
+                ),
+                (f"export OPENAI_BASE_URL={base}/v1", "Point OpenAI clients at netllm"),
+                (suggested_cli("status"), "New terminal — backends, peers, health"),
+                (suggested_cli("models"), "List all routed models"),
+            ]
+        )
 
 
 @app.command()
@@ -259,6 +341,165 @@ def discover(
         print_warnings(hints)
     if online == 0:
         raise typer.Exit(1)
+
+
+def _normalize_agent_url(url: str) -> str:
+    base = url.strip().rstrip("/")
+    if not base.startswith("http"):
+        base = f"http://{base}"
+    if ":" not in base.split("//", 1)[1]:
+        base = f"{base}:11400"
+    return base
+
+
+def _fetch_join_status(base: str) -> dict[str, Any]:
+    """GET the target agent's status; raises typer.Exit on failure."""
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.get(f"{base}/netllm/v1/status")
+            resp.raise_for_status()
+            return resp.json()
+    except Exception as exc:
+        message, hints = agent_unreachable_message(base, exc)
+        print_error("Swarm agent unreachable", message, hints=hints)
+        raise typer.Exit(1) from exc
+
+
+def _validate_join_token(base: str, token: str, agent_id: str) -> None:
+    """POST a heartbeat with the token — 401 means the token is wrong."""
+    payload = {
+        "agent_id": agent_id,
+        "listen_url": "",
+        "role": "peer",
+        "hostname": "joining",
+        "backends": [],
+    }
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(
+                f"{base}/netllm/v1/heartbeat", json=payload, headers=headers
+            )
+    except Exception as exc:
+        message, hints = agent_unreachable_message(base, exc)
+        print_error("Swarm agent unreachable", message, hints=hints)
+        raise typer.Exit(1) from exc
+    if resp.status_code == 401:
+        print_error(
+            "Invalid cluster token",
+            "The other agent rejected this token.",
+            hints=[
+                "Show the token on the other machine: [cyan]netllm swarm-token[/]",
+                "Copy the full join command printed by [cyan]netllm init --swarm[/]",
+            ],
+        )
+        raise typer.Exit(1)
+
+
+@app.command()
+def join(
+    url: str = typer.Argument(
+        ...,
+        help="Any agent already in the swarm, e.g. http://192.168.1.20:11400",
+    ),
+    token: str = typer.Option(
+        "",
+        "--token",
+        help="Cluster token from `netllm init --swarm` / `netllm swarm-token` "
+        "on the other machine",
+    ),
+    config: Path | None = typer.Option(None, "--config", help="Config file path"),
+) -> None:
+    """Join this machine to an existing LAN swarm."""
+    from netllm_discovery.lan import filter_own_peer_urls
+
+    cfg_path = _config_path_option(config)
+    cfg = load_config(cfg_path)
+
+    base = _normalize_agent_url(url)
+    status = _fetch_join_status(base)
+    if token and not status.get("cluster_token_set", False):
+        print_error(
+            "Token mismatch",
+            "You passed --token but the other agent has no cluster token set "
+            "— its heartbeats would be rejected by this machine.",
+            hints=[
+                "On the other machine: [cyan]netllm swarm-token --rotate[/], "
+                "then re-run join with that token",
+                "Or join an open swarm without [cyan]--token[/]",
+            ],
+        )
+        raise typer.Exit(1)
+    _validate_join_token(base, token, cfg.agent.agent_id)
+
+    cfg.swarm.cluster_token = token
+    _apply_swarm_join_listen(cfg)
+    cfg.routing.default_strategy = "local_spillover"
+    kept, rejected = filter_own_peer_urls([*cfg.swarm.peers, base], cfg.agent.listen)
+    if rejected:
+        print_error(
+            "Cannot join yourself",
+            f"[cyan]{base}[/] is this machine's own agent URL.",
+            hints=["Run join with the *other* machine's URL"],
+        )
+        raise typer.Exit(1)
+    cfg.swarm.peers = list(dict.fromkeys(kept))
+    save_config(cfg, cfg_path)
+
+    hostname = status.get("hostname") or status.get("agent_id") or base
+    print_heading(
+        "Joined swarm",
+        f"Peer: {hostname} @ {base} — config updated at {cfg_path}",
+    )
+    print_next_steps(
+        [
+            (suggested_cli("serve"), "Start the agent (binds your LAN)"),
+            (suggested_cli("peers"), "Verify the mesh sees both machines"),
+            (suggested_cli("models"), "Combined model catalog"),
+        ]
+    )
+
+
+def _apply_swarm_join_listen(cfg: NetllmConfig) -> None:
+    host, _, port = cfg.agent.listen.partition(":")
+    cfg.agent.listen = f"0.0.0.0:{port or '11400'}"
+
+
+@app.command("swarm-token")
+def swarm_token(
+    config: Path | None = typer.Option(None, "--config", help="Config file path"),
+    rotate: bool = typer.Option(
+        False, "--rotate", help="Generate and save a new cluster token"
+    ),
+) -> None:
+    """Show (or rotate) the cluster token other machines use to join."""
+    cfg_path = _config_path_option(config)
+    cfg = _require_config(cfg_path)
+
+    if rotate:
+        cfg.swarm.cluster_token = secrets.token_urlsafe(24)
+        save_config(cfg, cfg_path)
+        console.print("[green]New cluster token saved.[/]")
+        print_warnings(
+            [
+                "Update every other machine: re-run "
+                f"[cyan]{_join_command_for(cfg)}[/] there.",
+            ]
+        )
+
+    if not cfg.swarm.cluster_token:
+        print_error(
+            "No cluster token set",
+            "This machine has no swarm token yet.",
+            hints=[
+                "Create one: [cyan]netllm swarm-token --rotate[/]",
+                "Or re-init for swarm: [cyan]netllm init --force --swarm[/]",
+            ],
+        )
+        raise typer.Exit(1)
+
+    console.print(f"[bold]Cluster token:[/] [cyan]{cfg.swarm.cluster_token}[/]")
+    console.print(f"[bold]Join command:[/] [cyan]{_join_command_for(cfg)}[/]")
 
 
 @app.command()

--- a/tests/test_cli_swarm_init.py
+++ b/tests/test_cli_swarm_init.py
@@ -1,0 +1,202 @@
+"""Guided swarm init, join, and swarm-token CLI tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import netllm_cli.main as cli_main
+import pytest
+from netllm_core.models import NetllmConfig, load_config, save_config
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _no_provider_scan(monkeypatch: pytest.MonkeyPatch):
+    async def _empty(cfg: NetllmConfig) -> list[dict[str, Any]]:
+        return []
+
+    monkeypatch.setattr(cli_main, "scan_local_providers", _empty)
+
+
+def _init(tmp_path: Path, *args: str):
+    cfg_path = tmp_path / "config.toml"
+    result = runner.invoke(
+        cli_main.app,
+        ["init", "--config", str(cfg_path), "--no-global-cli", *args],
+    )
+    return result, cfg_path
+
+
+def test_init_swarm_configures_mesh(tmp_path: Path) -> None:
+    result, cfg_path = _init(tmp_path, "--swarm")
+    assert result.exit_code == 0, result.output
+    cfg = load_config(cfg_path)
+    assert cfg.agent.listen == "0.0.0.0:11400"
+    assert len(cfg.swarm.cluster_token) >= 24
+    assert cfg.routing.default_strategy == "local_spillover"
+    assert "netllm join" in result.output
+
+
+def test_init_single_keeps_defaults(tmp_path: Path) -> None:
+    result, cfg_path = _init(tmp_path, "--single")
+    assert result.exit_code == 0, result.output
+    cfg = load_config(cfg_path)
+    assert cfg.agent.listen == "127.0.0.1:11400"
+    assert cfg.swarm.cluster_token == ""
+    assert cfg.routing.default_strategy == "local_first"
+
+
+def test_init_swarm_and_single_conflict(tmp_path: Path) -> None:
+    result, _ = _init(tmp_path, "--swarm", "--single")
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output
+
+
+def test_join_writes_swarm_config(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml"
+    save_config(NetllmConfig(), cfg_path)
+
+    fake_status = {
+        "agent_id": "gw-1",
+        "hostname": "studio",
+        "listen_url": "http://192.168.1.20:11400",
+        "cluster_token_set": True,
+    }
+    with (
+        patch.object(cli_main, "_fetch_join_status", return_value=fake_status),
+        patch.object(cli_main, "_validate_join_token") as mock_validate,
+    ):
+        result = runner.invoke(
+            cli_main.app,
+            [
+                "join",
+                "http://192.168.1.20:11400",
+                "--token",
+                "secret-token",
+                "--config",
+                str(cfg_path),
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    mock_validate.assert_called_once()
+    cfg = load_config(cfg_path)
+    assert cfg.agent.listen == "0.0.0.0:11400"
+    assert cfg.swarm.cluster_token == "secret-token"
+    assert cfg.routing.default_strategy == "local_spillover"
+    assert "http://192.168.1.20:11400" in cfg.swarm.peers
+
+
+def test_join_rejects_token_against_open_swarm(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml"
+    save_config(NetllmConfig(), cfg_path)
+    fake_status = {"agent_id": "gw-1", "cluster_token_set": False}
+    with patch.object(cli_main, "_fetch_join_status", return_value=fake_status):
+        result = runner.invoke(
+            cli_main.app,
+            [
+                "join",
+                "192.168.1.20",
+                "--token",
+                "secret-token",
+                "--config",
+                str(cfg_path),
+            ],
+        )
+    assert result.exit_code == 1
+    assert "no cluster token" in result.output
+
+
+def test_join_rejects_own_url(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml"
+    cfg = NetllmConfig()
+    cfg.agent.listen = "0.0.0.0:11400"
+    save_config(cfg, cfg_path)
+    fake_status = {"agent_id": "self", "cluster_token_set": True}
+    with (
+        patch.object(cli_main, "_fetch_join_status", return_value=fake_status),
+        patch.object(cli_main, "_validate_join_token"),
+        patch(
+            "netllm_discovery.lan.local_lan_ip",
+            return_value="192.168.1.5",
+        ),
+    ):
+        result = runner.invoke(
+            cli_main.app,
+            [
+                "join",
+                "http://192.168.1.5:11400",
+                "--token",
+                "tok",
+                "--config",
+                str(cfg_path),
+            ],
+        )
+    assert result.exit_code == 1
+    assert "own agent URL" in result.output
+
+
+def test_normalize_agent_url() -> None:
+    norm = cli_main._normalize_agent_url
+    assert norm("192.168.1.20") == "http://192.168.1.20:11400"
+    assert norm("http://192.168.1.20:11400/") == "http://192.168.1.20:11400"
+    assert norm("studio.local:11400") == "http://studio.local:11400"
+
+
+def test_swarm_token_show_and_rotate(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.toml"
+    save_config(NetllmConfig(), cfg_path)
+
+    result = runner.invoke(cli_main.app, ["swarm-token", "--config", str(cfg_path)])
+    assert result.exit_code == 1
+    assert "No cluster token" in result.output
+
+    result = runner.invoke(
+        cli_main.app, ["swarm-token", "--rotate", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    token = load_config(cfg_path).swarm.cluster_token
+    assert len(token) >= 24
+    assert token in result.output
+
+
+def test_heartbeat_requires_token_when_set() -> None:
+    from fastapi.testclient import TestClient
+    from netllm_agent.app import create_app
+
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    cfg.swarm.cluster_token = "secret"
+    payload = {
+        "agent_id": "peer-x",
+        "listen_url": "http://192.168.1.9:11400",
+        "role": "peer",
+        "hostname": "x",
+        "backends": [],
+    }
+    with TestClient(create_app(cfg)) as client:
+        denied = client.post("/netllm/v1/heartbeat", json=payload)
+        allowed = client.post(
+            "/netllm/v1/heartbeat",
+            json=payload,
+            headers={"Authorization": "Bearer secret"},
+        )
+    assert denied.status_code == 401
+    assert allowed.status_code == 204
+
+
+def test_status_reports_cluster_token_presence() -> None:
+    from fastapi.testclient import TestClient
+    from netllm_agent.app import create_app
+
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    cfg.swarm.cluster_token = "secret"
+    with TestClient(create_app(cfg)) as client:
+        data = client.get("/netllm/v1/status").json()
+    assert data["cluster_token_set"] is True

--- a/tests/test_cli_swarm_init.py
+++ b/tests/test_cli_swarm_init.py
@@ -144,6 +144,42 @@ def test_normalize_agent_url() -> None:
     assert norm("192.168.1.20") == "http://192.168.1.20:11400"
     assert norm("http://192.168.1.20:11400/") == "http://192.168.1.20:11400"
     assert norm("studio.local:11400") == "http://studio.local:11400"
+    assert norm("http://[fe80::1]") == "http://[fe80::1]:11400"
+    assert norm("http://[fe80::1]:11400") == "http://[fe80::1]:11400"
+
+
+def test_listen_port_of_handles_ipv6_and_bare_hosts() -> None:
+    port_of = cli_main._listen_port_of
+    assert port_of("127.0.0.1:11400") == "11400"
+    assert port_of("0.0.0.0:12000") == "12000"
+    assert port_of("[::1]:11400") == "11400"
+    assert port_of("::1") == "11400"
+    assert port_of("localhost") == "11400"
+
+
+def test_validate_join_token_rejects_server_error() -> None:
+    class FakeResp:
+        status_code = 500
+
+    class FakeClient:
+        def __init__(self, *a: object, **k: object) -> None:
+            pass
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *a: object) -> None:
+            return None
+
+        def post(self, *a: object, **k: object) -> FakeResp:
+            return FakeResp()
+
+    import pytest as _pytest
+    import typer as _typer
+
+    with patch.object(cli_main.httpx, "Client", FakeClient):
+        with _pytest.raises(_typer.Exit):
+            cli_main._validate_join_token("http://192.168.1.20:11400", "tok", "me")
 
 
 def test_swarm_token_show_and_rotate(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

PR 3 of the v0.4.0 "deliver the swarm promise" series (follows #20, #21). Closes the headline audit gap: two machines mesh from `netllm init` without hand-editing config.

- `netllm init` gains `--swarm` / `--single`; on a TTY with neither flag it asks one question. Swarm mode binds `0.0.0.0:11400`, auto-generates `swarm.cluster_token`, selects `local_spillover`, and prints the exact `netllm join` command for the other machines
- New `netllm join <url> --token <t>`: normalizes the URL, verifies the agent is reachable, validates the token via a 401-aware heartbeat probe, detects open-swarm/token mismatches (status now reports `cluster_token_set`), rejects self-joins, then writes LAN bind + token + static peer + spillover
- New `netllm swarm-token [--rotate]` for pairing UX
- Non-breaking: non-TTY `init` behavior unchanged (pinned by contract test); existing configs untouched

## Test plan

- [x] `./scripts/ci.sh` green (208 tests)
- [x] init flag matrix (swarm / single / conflict), join happy path + open-swarm mismatch + self-join rejection, URL normalization, token show/rotate, heartbeat 401 enforcement