### PR TITLE
feat(discovery): surface unreachable peers, auto subnet fallback, firewall doctor

### DIFF
--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -67,6 +67,8 @@ class AgentService:
         self._request_count = 0
         self._batch_ledger = BatchRequestLedger()
         self.startup_warnings: list[str] = []
+        # Hold references so background tasks are not garbage collected.
+        self._background_tasks: set[asyncio.Task[None]] = set()
 
     async def refresh_local_backends(
         self,
@@ -857,11 +859,16 @@ class AgentService:
 
         self.swarm.start_gossip(lambda: self.status_payload())
         if self.config.swarm.subnet_scan:
-            asyncio.create_task(self._discover_subnet_peers())
+            self._spawn_background(self._discover_subnet_peers())
         elif self._should_auto_subnet_fallback():
-            asyncio.create_task(self._mdns_fallback_subnet_scan())
+            self._spawn_background(self._mdns_fallback_subnet_scan())
         self.startup_warnings = warnings
         return warnings
+
+    def _spawn_background(self, coro: Any) -> None:
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     def _should_auto_subnet_fallback(self) -> bool:
         """One-shot subnet scan when mDNS is on but may be blocked.

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import time
@@ -786,8 +787,6 @@ class AgentService:
 
     def start_background(self) -> list[str]:
         warnings: list[str] = []
-        import asyncio
-
         loop = asyncio.get_running_loop()
 
         if self.config.agent.advertise and self.config.swarm.mdns:
@@ -804,6 +803,15 @@ class AgentService:
                 async def on_peer(url: str, props: dict[str, str]) -> None:
                     agent_id = props.get("agent_id", url)
                     if agent_id == self.config.agent.agent_id:
+                        return
+                    if props.get("reachable") == "false":
+                        # Loopback-bound peer — fetching its advertised URL
+                        # would hit our own agent. Surfaced by `netllm peers`.
+                        logger.info(
+                            "mDNS peer %s is loopback-bound (unreachable); "
+                            "it must serve with --host 0.0.0.0 to join",
+                            agent_id,
+                        )
                         return
                     record = await self.swarm.fetch_peer(url)
                     if record:
@@ -850,8 +858,33 @@ class AgentService:
         self.swarm.start_gossip(lambda: self.status_payload())
         if self.config.swarm.subnet_scan:
             asyncio.create_task(self._discover_subnet_peers())
+        elif self._should_auto_subnet_fallback():
+            asyncio.create_task(self._mdns_fallback_subnet_scan())
         self.startup_warnings = warnings
         return warnings
+
+    def _should_auto_subnet_fallback(self) -> bool:
+        """One-shot subnet scan when mDNS is on but may be blocked.
+
+        Only for LAN binds: loopback-bound agents cannot mesh anyway, and
+        default single-machine installs should never probe the subnet.
+        """
+        from netllm_discovery.lan import is_loopback_url
+
+        if not (self.config.swarm.mdns and self.config.agent.advertise):
+            return False
+        return not is_loopback_url(self.swarm.local_agent_url())
+
+    async def _mdns_fallback_subnet_scan(self, delay_s: float = 10.0) -> None:
+        await asyncio.sleep(delay_s)
+        if self.swarm.peers:
+            return
+        logger.info(
+            "mDNS found no peers after %.0fs — running one-time subnet "
+            "scan fallback (disable by adding static swarm.peers)",
+            delay_s,
+        )
+        await self._discover_subnet_peers()
 
     async def _discover_subnet_peers(self) -> None:
         from netllm_discovery.lan import discover_lan_agents

--- a/packages/netllm-cli/src/netllm_cli/main.py
+++ b/packages/netllm-cli/src/netllm_cli/main.py
@@ -742,6 +742,18 @@ def peers(
     if warnings:
         print_warnings(warnings)
 
+    if not peers_found and unreachable:
+        print_error(
+            "Agents found, none reachable",
+            f"{len(unreachable)} agent(s) are loopback-bound and cannot "
+            "accept LAN traffic (see notes above).",
+            hints=[
+                "On each unreachable machine: "
+                "[cyan]netllm init --force --swarm[/] or "
+                "[cyan]netllm serve --host 0.0.0.0[/]",
+            ],
+        )
+        raise typer.Exit(1)
     if not peers_found:
         print_error(
             "No peers found",

--- a/packages/netllm-cli/src/netllm_cli/main.py
+++ b/packages/netllm-cli/src/netllm_cli/main.py
@@ -43,6 +43,7 @@ from netllm_cli.ui import (
     console,
     default_provider_port_hint,
     enabled_provider_summary,
+    firewall_hints,
     inference_status_style,
     listen_url,
     listen_urls,
@@ -712,8 +713,26 @@ def peers(
         )
     )
 
+    unreachable = [p for p in peers_found if p.get("unreachable")]
+    peers_found = [p for p in peers_found if not p.get("unreachable")]
+    for p in unreachable:
+        who = p.get("agent_id") or p.get("listen_url", "?")
+        warnings.append(
+            f"Found agent [bold]{who}[/] but it is bound to loopback — "
+            f"on that machine run [cyan]netllm serve --host 0.0.0.0[/] "
+            f"(or [cyan]netllm init --force --swarm[/])"
+        )
+
     if as_json:
-        typer.echo(json.dumps({"peers": peers_found, "warnings": warnings}))
+        typer.echo(
+            json.dumps(
+                {
+                    "peers": peers_found,
+                    "unreachable": unreachable,
+                    "warnings": warnings,
+                }
+            )
+        )
         return
 
     print_heading(
@@ -733,7 +752,8 @@ def peers(
                 "Enable advertise: [cyan]agent.advertise = true[/] in config",
                 "Guest Wi‑Fi often blocks mDNS — try [cyan]--subnet-scan[/]",
                 "Manual: add URLs under [cyan]swarm.peers[/] in config.toml",
-            ],
+            ]
+            + firewall_hints(),
         )
         raise typer.Exit(1)
 
@@ -1399,6 +1419,17 @@ def doctor(
                         (
                             "mDNS advertise may have failed",
                             f"Try netllm serve --replace. {mdns_platform_hint()}",
+                        )
+                    )
+                if not found and not cfg.agent.listen.startswith("127."):
+                    fw = " · ".join(
+                        h.replace("[cyan]", "").replace("[/]", "")
+                        for h in firewall_hints()
+                    )
+                    issues.append(
+                        (
+                            "mDNS silent — multicast may be blocked",
+                            f"Check firewall (UDP 5353 in/out, TCP 11400 in). {fw}",
                         )
                     )
             except RuntimeError:

--- a/packages/netllm-cli/src/netllm_cli/ui.py
+++ b/packages/netllm-cli/src/netllm_cli/ui.py
@@ -49,6 +49,28 @@ def mdns_platform_hint() -> str:
     return "Guest Wi-Fi may block mDNS; use swarm.peers or --subnet-scan"
 
 
+def firewall_hints() -> list[str]:
+    """Per-platform firewall commands for mDNS (UDP 5353) + agent (TCP 11400)."""
+    if sys.platform == "linux":
+        return [
+            "firewalld: [cyan]sudo firewall-cmd --permanent --add-service=mdns "
+            "&& sudo firewall-cmd --permanent --add-port=11400/tcp "
+            "&& sudo firewall-cmd --reload[/]",
+            "ufw: [cyan]sudo ufw allow 5353/udp && sudo ufw allow 11400/tcp[/]",
+        ]
+    if sys.platform == "win32":
+        return [
+            'mDNS in: [cyan]netsh advfirewall firewall add rule name="netllm mDNS" '
+            "dir=in protocol=UDP localport=5353 action=allow[/]",
+            'agent in: [cyan]netsh advfirewall firewall add rule name="netllm agent" '
+            "dir=in protocol=TCP localport=11400 action=allow[/]",
+        ]
+    return [
+        "macOS firewall: System Settings → Network → Firewall — "
+        "allow incoming connections for python/netllm",
+    ]
+
+
 def _listen_host_port(listen: str) -> tuple[str, str]:
     if listen.startswith("http"):
         from urllib.parse import urlparse

--- a/packages/netllm-discovery/src/netllm_discovery/lan.py
+++ b/packages/netllm-discovery/src/netllm_discovery/lan.py
@@ -255,6 +255,7 @@ async def discover_lan_agents(
                         "agent_id": props.get("agent_id", ""),
                         "role": props.get("role", "peer"),
                         "source": "mdns",
+                        "unreachable": props.get("reachable") == "false",
                         "_props": props,
                     }
         except RuntimeError as exc:
@@ -279,6 +280,12 @@ async def discover_lan_agents(
         enriched: list[dict[str, Any]] = []
         for entry in by_url.values():
             url = entry.get("listen_url", "")
+            if entry.get("unreachable"):
+                # Loopback-bound peer: its advertised URL is not routable
+                # from this host (fetching it would hit our own agent).
+                # Keep the row so callers can explain the rebind fix.
+                enriched.append(entry)
+                continue
             if entry.get("backends") is not None and entry.get("agent_id"):
                 entry.setdefault("source", entry.get("source", "scan"))
                 enriched.append(entry)

--- a/packages/netllm-discovery/src/netllm_discovery/mdns.py
+++ b/packages/netllm-discovery/src/netllm_discovery/mdns.py
@@ -105,6 +105,8 @@ class MdnsAdvertiser:
             )
 
         try:
+            from netllm_discovery.lan import is_loopback_url
+
             host, port = parse_listen_host_port(self.listen)
             advertise_host, addr = _advertise_address(self.listen)
             listen_url = f"http://{advertise_host}:{port}"
@@ -113,6 +115,10 @@ class MdnsAdvertiser:
                 "role": self.role,
                 "version": self.version,
                 "listen_url": listen_url,
+                # Loopback binds are visible on mDNS but not routable from
+                # other hosts — flag them so peers can explain instead of
+                # silently dropping us.
+                "reachable": "false" if is_loopback_url(listen_url) else "true",
             }
             zc = Zeroconf()
             info = ServiceInfo(

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -606,6 +606,45 @@ def test_order_message_candidates_spillover_sorts_by_load() -> None:
     assert ordered[0].id == "local"
 
 
+def test_auto_subnet_fallback_only_for_lan_binds() -> None:
+    from netllm_agent.service import AgentService
+
+    lan_cfg = NetllmConfig()
+    lan_cfg.agent.listen = "0.0.0.0:11400"
+    with patch("netllm_discovery.lan.local_lan_ip", return_value="192.168.1.5"):
+        assert AgentService(lan_cfg)._should_auto_subnet_fallback() is True
+
+    loop_cfg = NetllmConfig()  # default loopback bind
+    assert AgentService(loop_cfg)._should_auto_subnet_fallback() is False
+
+    no_mdns = NetllmConfig()
+    no_mdns.agent.listen = "0.0.0.0:11400"
+    no_mdns.swarm.mdns = False
+    assert AgentService(no_mdns)._should_auto_subnet_fallback() is False
+
+
+@pytest.mark.asyncio
+async def test_mdns_fallback_scan_skipped_when_peers_known() -> None:
+    from netllm_agent.service import AgentService
+    from netllm_discovery.swarm import PeerRecord
+
+    cfg = NetllmConfig()
+    cfg.agent.listen = "0.0.0.0:11400"
+    service = AgentService(cfg)
+    with patch.object(
+        service, "_discover_subnet_peers", new_callable=AsyncMock
+    ) as mock_scan:
+        await service._mdns_fallback_subnet_scan(delay_s=0)
+        mock_scan.assert_awaited_once()
+
+        service.swarm.register_peer(
+            PeerRecord(agent_id="p1", listen_url="http://192.168.1.9:11400")
+        )
+        mock_scan.reset_mock()
+        await service._mdns_fallback_subnet_scan(delay_s=0)
+        mock_scan.assert_not_awaited()
+
+
 def test_peer_forward_headers_loop_guard() -> None:
     from netllm_agent.service import AgentService
     from netllm_core.models import LOCAL_ONLY_HEADER

--- a/tests/test_lan.py
+++ b/tests/test_lan.py
@@ -136,6 +136,38 @@ async def test_discover_lan_agents_filters_by_agent_id_not_listen_url() -> None:
 
 
 @pytest.mark.asyncio
+async def test_discover_lan_agents_keeps_unreachable_rows_without_fetch() -> None:
+    """Loopback-bound mDNS peers are surfaced (not silently dropped) and
+    their loopback URL is never fetched — that would hit our own agent."""
+    cfg = NetllmConfig()
+    cfg.agent.agent_id = "me"
+
+    props = {
+        "agent_id": "loopback-peer",
+        "role": "peer",
+        "listen_url": "http://127.0.0.1:11400",
+        "reachable": "false",
+        "source": "mdns",
+    }
+    with (
+        patch(
+            "netllm_discovery.lan.browse_mdns_peers",
+            return_value=[props],
+        ),
+        patch(
+            "netllm_discovery.lan.fetch_agent_status",
+            new_callable=AsyncMock,
+        ) as mock_fetch,
+    ):
+        peers = await discover_lan_agents(cfg, use_mdns=True, use_subnet=False)
+
+    mock_fetch.assert_not_awaited()
+    assert len(peers) == 1
+    assert peers[0]["unreachable"] is True
+    assert peers[0]["agent_id"] == "loopback-peer"
+
+
+@pytest.mark.asyncio
 async def test_fetch_agent_status_uses_probe_url_as_listen_url() -> None:
     from netllm_discovery.lan import fetch_agent_status
 

--- a/tests/test_mdns.py
+++ b/tests/test_mdns.py
@@ -58,6 +58,55 @@ def test_mdns_advertise_address_uses_lan_for_wildcard_bind() -> None:
     assert host == "10.0.0.32"
 
 
+def _captured_advertise_props(listen: str) -> dict[str, str]:
+    captured: dict[str, dict[str, bytes]] = {}
+
+    class FakeZeroconf:
+        def register_service(self, info: object) -> None:
+            pass
+
+        def unregister_service(self, info: object) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    def fake_service_info(*_args: object, **kwargs: object) -> MagicMock:
+        captured["props"] = kwargs.get("properties", {})
+        return MagicMock()
+
+    fake_zc_mod = MagicMock()
+    fake_zc_mod.Zeroconf = FakeZeroconf
+    fake_zc_mod.ServiceInfo = fake_service_info
+    fake_zc_mod.NonUniqueNameException = _FakeNonUnique
+
+    from netllm_discovery.mdns import MdnsAdvertiser
+
+    advertiser = MdnsAdvertiser(listen, "agent-x", "peer")
+    with (
+        patch("netllm_discovery.lan.local_lan_ip", return_value="10.0.0.32"),
+        patch.dict("sys.modules", {"zeroconf": fake_zc_mod}),
+    ):
+        thread = threading.Thread(target=advertiser._run, daemon=True)
+        thread.start()
+        assert advertiser._ready.wait(timeout=3.0)
+        advertiser._stop.set()
+        thread.join(timeout=3.0)
+    return {k: v.decode() for k, v in captured["props"].items()}
+
+
+def test_mdns_loopback_bind_advertises_unreachable_flag() -> None:
+    props = _captured_advertise_props("127.0.0.1:11400")
+    assert props["reachable"] == "false"
+    assert props["listen_url"] == "http://127.0.0.1:11400"
+
+
+def test_mdns_lan_bind_advertises_reachable_flag() -> None:
+    props = _captured_advertise_props("0.0.0.0:11400")
+    assert props["reachable"] == "true"
+    assert props["listen_url"] == "http://10.0.0.32:11400"
+
+
 def test_mdns_advertiser_sets_error_on_hard_failure() -> None:
     class FailingZeroconf:
         def register_service(self, info: object) -> None:


### PR DESCRIPTION
## Summary

PR 4 of the v0.4.0 "deliver the swarm promise" series (follows #20, #21, #22). Makes discovery work in "most LAN situations" and kills the silent non-meshing failure mode.

- Loopback-bound agents advertise `reachable=false` over mDNS; `netllm peers` shows "found but unreachable" with the exact rebind fix, discovery keeps the row without fetching its loopback URL (which would hit our own agent), and the swarm registry skips registration with an info log
- LAN-bound agents with mDNS enabled run a one-shot subnet scan fallback 10 s after startup when no peers were found (loopback binds and explicit `subnet_scan` configs are untouched)
- `netllm doctor` and the `peers` empty-state print per-platform firewall commands (firewalld / ufw / netsh / macOS) for UDP 5353 + TCP 11400

## Test plan

- [x] `./scripts/ci.sh` green (215 tests)
- [x] mDNS prop tests (loopback vs LAN bind), unreachable-row discovery without fetch, fallback gating (LAN-only, skips when peers known)