### PR TITLE
feat(routing): model aliases for mixed-provider fleets and clear 404s

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -33,6 +33,11 @@ require_same_model_for_shard = true
 # local_spillover only: stay local below this many concurrent requests.
 spillover_max_local_in_flight = 2
 
+# Mixed-provider fleets: map one canonical name to per-provider model IDs
+# so the same weights spread across oMLX / Ollama / LM Studio / vLLM.
+# [routing.model_aliases]
+# "llama3" = ["llama3:8b-instruct-q4_K_M", "Meta-Llama-3-8B-Instruct-GGUF"]
+
 # Optional routing policies (first match wins). Cloud paths require allow_cloud = true.
 # [[routing.policies]]
 # name = "local-openai"

--- a/packages/netllm-agent/src/netllm_agent/app.py
+++ b/packages/netllm-agent/src/netllm_agent/app.py
@@ -238,7 +238,10 @@ def create_app(
                 )
             return await service.proxy_chat_completion(payload, headers=request.headers)
         except OpenAIUpstreamError as exc:
-            raise HTTPException(status_code=502, detail=str(exc)) from exc
+            raise HTTPException(
+                status_code=exc.status_code if exc.status_code == 404 else 502,
+                detail=str(exc),
+            ) from exc
 
     # --- Anthropic Messages API proxy ---
     @app.post("/v1/messages")

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -60,6 +61,7 @@ class AgentService:
             spillover_max_local_in_flight=(
                 config.routing.spillover_max_local_in_flight
             ),
+            model_aliases=config.routing.model_aliases,
         )
         self.swarm = SwarmRegistry(config)
         self._mdns_advertiser = None
@@ -183,6 +185,16 @@ class AgentService:
                         "object": "model",
                         "owned_by": b.provider,
                     }
+        # Surface canonical alias names whose provider-specific IDs exist.
+        for canonical, alias_ids in self.config.routing.model_aliases.items():
+            if canonical in seen:
+                continue
+            if any(m == a or m.startswith(a + ":") for a in alias_ids for m in seen):
+                seen[canonical] = {
+                    "id": canonical,
+                    "object": "model",
+                    "owned_by": "netllm-alias",
+                }
         return {"object": "list", "data": list(seen.values())}
 
     @staticmethod
@@ -196,6 +208,53 @@ class AgentService:
         hdrs = AgentService._normalize_headers(headers)
         raw = hdrs.get(LOCAL_ONLY_HEADER, "")
         return raw.strip().lower() in ("1", "true", "yes")
+
+    def _model_for_backend(self, model: str, backend: Backend) -> str:
+        """Resolve the requested (canonical) model name to the ID this
+        backend actually serves, via routing.model_aliases.
+
+        Exact matches win; for tag-prefix matches (Ollama-style
+        ``name:tag``) the full served ID is returned, since bare names
+        only resolve to the ``latest`` tag upstream.
+        """
+        served = backend.health.models
+        if not served:
+            return model
+        for name in self.pool.model_names_for(model):
+            if name in served:
+                return name
+            for served_id in served:
+                if served_id.startswith(name + ":"):
+                    return served_id
+        return model
+
+    def _model_not_found_error(self, model: str) -> OpenAIUpstreamError:
+        if not self.pool.backends:
+            return OpenAIUpstreamError("No healthy backends available for model")
+        known = self.pool.known_models()
+        listing = ", ".join(known) if known else "none discovered yet"
+        return OpenAIUpstreamError(
+            f"Model '{model}' not found on any backend. "
+            f"Known models: {listing}. "
+            "Map provider-specific names with [routing.model_aliases].",
+            status_code=404,
+        )
+
+    @staticmethod
+    async def _restore_stream_model(
+        chunks: AsyncIterator[str], model: str
+    ) -> AsyncIterator[str]:
+        """Rewrite the model field in SSE chunks back to the canonical name."""
+        async for chunk in chunks:
+            if chunk.startswith("data: ") and '"model"' in chunk:
+                try:
+                    body = json.loads(chunk[len("data: ") :])
+                    body["model"] = model
+                    yield f"data: {json.dumps(body)}\n\n"
+                    continue
+                except (ValueError, TypeError):
+                    pass
+            yield chunk
 
     @staticmethod
     def _peer_forward_headers(backend: Backend) -> dict[str, str] | None:
@@ -340,7 +399,15 @@ class AgentService:
                     api_key=backend.api_key or "netllm-local",
                     default_headers=self._peer_forward_headers(backend),
                 )
-                result = await client.chat_completion(payload)
+                upstream_model = self._model_for_backend(model, backend)
+                upstream_payload = (
+                    {**payload, "model": upstream_model}
+                    if upstream_model != model
+                    else payload
+                )
+                result = await client.chat_completion(upstream_payload)
+                if upstream_model != model and isinstance(result, dict):
+                    result["model"] = model
                 latency = time.monotonic() - t0
                 self.pool.mark_success(backend, latency * 1000)
                 REQUESTS_TOTAL.labels(
@@ -371,7 +438,7 @@ class AgentService:
 
         if last_error:
             raise last_error
-        raise OpenAIUpstreamError("No healthy backends available for model")
+        raise self._model_not_found_error(model)
 
     async def proxy_chat_completion_stream(
         self,
@@ -411,9 +478,18 @@ class AgentService:
                     api_key=backend.api_key or "netllm-local",
                     default_headers=self._peer_forward_headers(backend),
                 )
-                async for chunk in self._stream_with_metrics(
-                    client, payload, backend, model, shard
-                ):
+                upstream_model = self._model_for_backend(model, backend)
+                upstream_payload = (
+                    {**payload, "model": upstream_model}
+                    if upstream_model != model
+                    else payload
+                )
+                stream = self._stream_with_metrics(
+                    client, upstream_payload, backend, model, shard
+                )
+                if upstream_model != model:
+                    stream = self._restore_stream_model(stream, model)
+                async for chunk in stream:
                     yield chunk
                 return
             except OpenAIUpstreamError as exc:
@@ -433,7 +509,7 @@ class AgentService:
 
         if last_error:
             raise last_error
-        raise OpenAIUpstreamError("No healthy backends available for model")
+        raise self._model_not_found_error(model)
 
     @staticmethod
     def _anthropic_api_key(headers: Mapping[str, str]) -> str:
@@ -719,6 +795,7 @@ class AgentService:
             )
             return await client.messages_create(payload)
         oai_payload = anthropic_to_openai_request(payload)
+        oai_payload["model"] = self._model_for_backend(model, backend)
         client = OpenAIUpstream(
             backend.base_url,
             api_key=backend.api_key or "netllm-local",
@@ -750,6 +827,7 @@ class AgentService:
                 yield chunk
             return
         oai_payload = anthropic_to_openai_request(payload)
+        oai_payload["model"] = self._model_for_backend(model, backend)
         client = OpenAIUpstream(
             backend.base_url,
             api_key=backend.api_key or "netllm-local",

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -220,9 +220,13 @@ class AgentService:
         served = backend.health.models
         if not served:
             return model
-        for name in self.pool.model_names_for(model):
+        names = self.pool.model_names_for(model)
+        # Exact matches across the whole alias list win before any
+        # prefix match — a backend may serve several tags of one base.
+        for name in names:
             if name in served:
                 return name
+        for name in names:
             for served_id in served:
                 if served_id.startswith(name + ":"):
                     return served_id
@@ -241,20 +245,33 @@ class AgentService:
         )
 
     @staticmethod
+    def _restore_sse_line_model(line: str, model: str) -> str:
+        if line.startswith("data: ") and '"model"' in line:
+            try:
+                body = json.loads(line[len("data: ") :])
+                body["model"] = model
+                return f"data: {json.dumps(body)}"
+            except (ValueError, TypeError):
+                return line
+        return line
+
+    @staticmethod
     async def _restore_stream_model(
         chunks: AsyncIterator[str], model: str
     ) -> AsyncIterator[str]:
-        """Rewrite the model field in SSE chunks back to the canonical name."""
+        """Rewrite the model field in SSE chunks back to the canonical name.
+
+        Handles chunks carrying multiple SSE lines; unparseable lines
+        pass through untouched.
+        """
         async for chunk in chunks:
-            if chunk.startswith("data: ") and '"model"' in chunk:
-                try:
-                    body = json.loads(chunk[len("data: ") :])
-                    body["model"] = model
-                    yield f"data: {json.dumps(body)}\n\n"
-                    continue
-                except (ValueError, TypeError):
-                    pass
-            yield chunk
+            if '"model"' not in chunk:
+                yield chunk
+                continue
+            yield "\n".join(
+                AgentService._restore_sse_line_model(line, model)
+                for line in chunk.split("\n")
+            )
 
     @staticmethod
     def _peer_forward_headers(backend: Backend) -> dict[str, str] | None:

--- a/packages/netllm-core/src/netllm_core/models.py
+++ b/packages/netllm-core/src/netllm_core/models.py
@@ -105,6 +105,11 @@ class RoutingConfig(BaseModel):
     # local_spillover: serve locally below this many concurrent requests,
     # spill to the least-loaded LAN peer at or above it.
     spillover_max_local_in_flight: int = 2
+    # Canonical model name -> provider-specific IDs. Lets mixed fleets
+    # (oMLX vs Ollama vs LM Studio naming) serve one model name:
+    #   [routing.model_aliases]
+    #   "llama3" = ["llama3:8b-instruct-q4_K_M", "Meta-Llama-3-8B-Instruct"]
+    model_aliases: dict[str, list[str]] = Field(default_factory=dict)
     backends: list[BackendOverride] = Field(default_factory=list)
     policies: list[RoutingPolicy] = Field(default_factory=list)
 

--- a/packages/netllm-core/src/netllm_core/pool.py
+++ b/packages/netllm-core/src/netllm_core/pool.py
@@ -73,12 +73,14 @@ class RouterPool:
         *,
         allow_remote: bool = True,
         spillover_max_local_in_flight: int = 2,
+        model_aliases: dict[str, list[str]] | None = None,
     ) -> None:
         self._backends: list[Backend] = []
         self._health_cache: dict[str, _HealthEntry] = {}
         self._round_robin_idx = 0
         self.allow_remote = allow_remote
         self.spillover_max_local_in_flight = max(1, spillover_max_local_in_flight)
+        self.model_aliases = model_aliases or {}
         # Our own active forwards per peer agent URL. Peer rows are
         # rebuilt from heartbeats on every refresh, so this ledger keeps
         # in-flight hop counts from being wiped between heartbeats.
@@ -168,33 +170,60 @@ class RouterPool:
         backend.health.last_check = now
         return online
 
-    def backends_for_model(
-        self, model: str, *, local_only: bool = False
-    ) -> list[Backend]:
-        candidates: list[Backend] = []
+    def model_names_for(self, model: str) -> list[str]:
+        """Requested name plus configured aliases, request name first."""
+        return [model, *self.model_aliases.get(model, [])]
+
+    @staticmethod
+    def _serves_model(served: list[str], names: list[str]) -> bool:
+        return any(m == n or m.startswith(n + ":") for n in names for m in served)
+
+    def known_models(self, *, limit: int = 25) -> list[str]:
+        """Distinct model IDs across enabled backends (for 404 messages)."""
+        seen: dict[str, None] = {}
         for b in self._backends:
             if not b.enabled:
                 continue
-            if not b.local and not self.allow_remote:
-                continue
-            if local_only and not b.local:
-                continue
-            models = b.health.models
-            if not models and self.is_healthy(b):
+            for m in b.health.models:
+                seen.setdefault(m)
+        return list(seen)[:limit]
+
+    def backends_for_model(
+        self, model: str, *, local_only: bool = False
+    ) -> list[Backend]:
+        names = self.model_names_for(model)
+
+        def collect() -> list[Backend]:
+            out: list[Backend] = []
+            for b in self._backends:
+                if not b.enabled:
+                    continue
+                if not b.local and not self.allow_remote:
+                    continue
+                if local_only and not b.local:
+                    continue
                 models = b.health.models
-            if not models:
-                candidates.append(b)
-                continue
-            if any(m == model or m.startswith(model + ":") for m in models):
-                candidates.append(b)
+                if not models and self.is_healthy(b):
+                    models = b.health.models
+                if not models:
+                    # Unknown catalog (unprobed, auth-gated, cloud inject):
+                    # keep as a candidate rather than guessing wrong.
+                    out.append(b)
+                    continue
+                if self._serves_model(models, names):
+                    out.append(b)
+            return out
+
+        candidates = collect()
         if not candidates:
-            candidates = [
-                b
-                for b in self._backends
-                if b.enabled
-                and (not local_only or b.local)
-                and (b.local or self.allow_remote)
-            ]
+            # Catalogs may be stale (model pulled moments ago) — refresh
+            # once and rematch instead of spraying every backend.
+            for b in self._backends:
+                if b.enabled and b.local:
+                    self.is_healthy(b, force_refresh=True)
+            candidates = collect()
+        if not candidates:
+            return []
         healthy = [b for b in candidates if self.is_healthy(b)]
         return healthy or candidates
 

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -1,0 +1,243 @@
+"""Model alias routing for mixed-provider fleets."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+from netllm_agent.app import create_app
+from netllm_core.models import Backend, BackendHealth, NetllmConfig
+from netllm_core.pool import RouterPool
+
+_MOCK_ONLINE = {"status": "online", "models": ["whatever"], "model_count": 1}
+
+ALIASES = {"llama3": ["llama3:8b-instruct-q4_K_M", "Meta-Llama-3-8B-Instruct-GGUF"]}
+
+
+def _backend(bid: str, url: str, models: list[str], *, local: bool = True) -> Backend:
+    return Backend(
+        id=bid,
+        base_url=url,
+        local=local,
+        health=BackendHealth(status="online", models=models),
+    )
+
+
+@patch("netllm_core.pool.probe_openai_compat_sync", return_value=_MOCK_ONLINE)
+def test_backends_for_model_matches_aliases(_mock: object) -> None:
+    pool = RouterPool(model_aliases=ALIASES)
+    ollama = _backend("ollama", "http://a/v1", ["llama3:8b-instruct-q4_K_M"])
+    lmstudio = _backend("lmstudio", "http://b/v1", ["Meta-Llama-3-8B-Instruct-GGUF"])
+    other = _backend("other", "http://c/v1", ["qwen2"])
+    pool.set_backends([ollama, lmstudio, other])
+    matched = pool.backends_for_model("llama3")
+    assert {b.id for b in matched} == {"ollama", "lmstudio"}
+
+
+@patch("netllm_core.pool.probe_openai_compat_sync", return_value=_MOCK_ONLINE)
+def test_backends_for_model_no_match_returns_empty(_mock: object) -> None:
+    """No more spraying all backends when the model is unknown."""
+    pool = RouterPool()
+    pool.set_backends([_backend("a", "http://a/v1", ["qwen2"])])
+    assert pool.backends_for_model("does-not-exist") == []
+
+
+@patch(
+    "netllm_core.pool.probe_openai_compat_sync",
+    return_value={"status": "online", "models": [], "model_count": 0},
+)
+def test_backends_with_unknown_catalog_stay_candidates(_mock: object) -> None:
+    pool = RouterPool()
+    blank = Backend(
+        id="cloud",
+        base_url="http://cloud/v1",
+        local=False,
+        health=BackendHealth(status="online", models=[]),
+    )
+    pool.set_backends([blank])
+    matched = pool.backends_for_model("anything")
+    assert [b.id for b in matched] == ["cloud"]
+
+
+def test_model_for_backend_resolves_alias() -> None:
+    from netllm_agent.service import AgentService
+
+    cfg = NetllmConfig()
+    cfg.routing.model_aliases = ALIASES
+    service = AgentService(cfg)
+    ollama = _backend("ollama", "http://a/v1", ["llama3:8b-instruct-q4_K_M"])
+    served_direct = _backend("direct", "http://b/v1", ["llama3"])
+    unknown = _backend("blank", "http://c/v1", [])
+    assert service._model_for_backend("llama3", ollama) == "llama3:8b-instruct-q4_K_M"
+    assert service._model_for_backend("llama3", served_direct) == "llama3"
+    assert service._model_for_backend("llama3", unknown) == "llama3"
+
+
+@patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)
+@patch("netllm_core.pool.probe_openai_compat_sync")
+@patch("netllm_sdk_openai.client.AsyncOpenAI")
+def test_canonical_request_rewrites_payload_and_response(
+    mock_openai_cls: object,
+    mock_probe: object,
+    mock_scan: AsyncMock,
+) -> None:
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    cfg.routing.model_aliases = ALIASES
+
+    mock_scan.return_value = [
+        {
+            "id": "ollama",
+            "status": "online",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "model_count": 1,
+            "models": ["llama3:8b-instruct-q4_K_M"],
+        }
+    ]
+    mock_probe.return_value = {
+        "status": "online",
+        "models": ["llama3:8b-instruct-q4_K_M"],
+        "model_count": 1,
+    }
+
+    sent_models: list[str] = []
+    mock_client = MagicMock()
+
+    def make_client(*_args: object, **_kwargs: object) -> MagicMock:
+        return mock_client
+
+    mock_openai_cls.side_effect = make_client
+
+    async def fake_create(**kwargs: object) -> MagicMock:
+        sent_models.append(str(kwargs.get("model")))
+        mock_response = MagicMock()
+        mock_response.model_dump.return_value = {
+            "id": "cmpl-1",
+            "object": "chat.completion",
+            "model": kwargs.get("model"),
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+        return mock_response
+
+    mock_client.chat.completions.create = fake_create
+
+    with TestClient(create_app(cfg)) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "llama3",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert resp.status_code == 200
+    assert sent_models == ["llama3:8b-instruct-q4_K_M"]
+    assert resp.json()["model"] == "llama3"
+
+
+@patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)
+@patch("netllm_core.pool.probe_openai_compat_sync")
+def test_unknown_model_returns_404_with_catalog(
+    mock_probe: object,
+    mock_scan: AsyncMock,
+) -> None:
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+
+    mock_scan.return_value = [
+        {
+            "id": "ollama",
+            "status": "online",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "model_count": 1,
+            "models": ["qwen2"],
+        }
+    ]
+    mock_probe.return_value = {
+        "status": "online",
+        "models": ["qwen2"],
+        "model_count": 1,
+    }
+
+    with TestClient(create_app(cfg)) as client:
+        resp = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "gpt-imaginary",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert resp.status_code == 404
+    detail = resp.json()["detail"]
+    assert "gpt-imaginary" in detail
+    assert "qwen2" in detail
+
+
+@patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)
+@patch("netllm_core.pool.probe_openai_compat_sync")
+def test_models_listing_includes_canonical_alias(
+    mock_probe: object,
+    mock_scan: AsyncMock,
+) -> None:
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    cfg.routing.model_aliases = ALIASES
+
+    mock_scan.return_value = [
+        {
+            "id": "ollama",
+            "status": "online",
+            "base_url": "http://127.0.0.1:11434/v1",
+            "model_count": 1,
+            "models": ["llama3:8b-instruct-q4_K_M"],
+        }
+    ]
+    mock_probe.return_value = {
+        "status": "online",
+        "models": ["llama3:8b-instruct-q4_K_M"],
+        "model_count": 1,
+    }
+
+    with TestClient(create_app(cfg)) as client:
+        data = client.get("/v1/models").json()
+    ids = {m["id"] for m in data["data"]}
+    assert "llama3:8b-instruct-q4_K_M" in ids
+    assert "llama3" in ids
+
+
+async def _gen(chunks: list[str]):
+    for c in chunks:
+        yield c
+
+
+def test_restore_stream_model_rewrites_chunks() -> None:
+    import asyncio
+    import json
+
+    from netllm_agent.service import AgentService
+
+    chunk = (
+        'data: {"id":"c1","object":"chat.completion.chunk",'
+        '"model":"llama3:8b-instruct-q4_K_M","choices":[]}\n\n'
+    )
+
+    async def run() -> list[str]:
+        out = []
+        async for c in AgentService._restore_stream_model(
+            _gen([chunk, "data: [DONE]\n\n"]), "llama3"
+        ):
+            out.append(c)
+        return out
+
+    out = asyncio.run(run())
+    assert json.loads(out[0][len("data: ") :])["model"] == "llama3"
+    assert out[1] == "data: [DONE]\n\n"

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -87,8 +87,7 @@ def test_model_for_backend_exact_alias_beats_prefix_match() -> None:
         ["llama3:70b", "llama3:8b-instruct-q4_K_M"],
     )
     assert (
-        service._model_for_backend("llama3", multi_tag)
-        == "llama3:8b-instruct-q4_K_M"
+        service._model_for_backend("llama3", multi_tag) == "llama3:8b-instruct-q4_K_M"
     )
 
 

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -73,6 +73,25 @@ def test_model_for_backend_resolves_alias() -> None:
     assert service._model_for_backend("llama3", unknown) == "llama3"
 
 
+def test_model_for_backend_exact_alias_beats_prefix_match() -> None:
+    """A backend serving several tags of one base must resolve to the
+    exact alias from config, not whichever tag prefix-matches first."""
+    from netllm_agent.service import AgentService
+
+    cfg = NetllmConfig()
+    cfg.routing.model_aliases = ALIASES
+    service = AgentService(cfg)
+    multi_tag = _backend(
+        "ollama",
+        "http://a/v1",
+        ["llama3:70b", "llama3:8b-instruct-q4_K_M"],
+    )
+    assert (
+        service._model_for_backend("llama3", multi_tag)
+        == "llama3:8b-instruct-q4_K_M"
+    )
+
+
 @patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)
 @patch("netllm_core.pool.probe_openai_compat_sync")
 @patch("netllm_sdk_openai.client.AsyncOpenAI")
@@ -239,5 +258,29 @@ def test_restore_stream_model_rewrites_chunks() -> None:
         return out
 
     out = asyncio.run(run())
-    assert json.loads(out[0][len("data: ") :])["model"] == "llama3"
+    assert json.loads(out[0].split("\n")[0][len("data: ") :])["model"] == "llama3"
     assert out[1] == "data: [DONE]\n\n"
+
+
+def test_restore_stream_model_handles_multi_line_chunks() -> None:
+    import asyncio
+    import json
+
+    from netllm_agent.service import AgentService
+
+    multi = (
+        'data: {"id":"c1","model":"llama3:8b-instruct-q4_K_M","choices":[]}\n\n'
+        'data: {"id":"c2","model":"llama3:8b-instruct-q4_K_M","choices":[]}\n\n'
+    )
+
+    async def run() -> list[str]:
+        out = []
+        async for c in AgentService._restore_stream_model(_gen([multi]), "llama3"):
+            out.append(c)
+        return out
+
+    out = asyncio.run(run())
+    data_lines = [ln for ln in out[0].split("\n") if ln.startswith("data: ")]
+    assert len(data_lines) == 2
+    for ln in data_lines:
+        assert json.loads(ln[len("data: ") :])["model"] == "llama3"

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -72,8 +72,8 @@ def test_failover_select_advances(_mock: object) -> None:
             ),
         ]
     )
-    first = pool.select_backend("any", "failover", attempt=1)
-    second = pool.select_backend("any", "failover", attempt=2)
+    first = pool.select_backend("m", "failover", attempt=1)
+    second = pool.select_backend("m", "failover", attempt=2)
     assert first is not None and second is not None
     assert first.base_url == "http://a/v1"
     assert second.base_url == "http://b/v1"
@@ -133,7 +133,10 @@ def test_local_first_prefers_local_backend(_mock: object) -> None:
     assert selected.local is True
 
 
-@patch("netllm_core.pool.probe_openai_compat_sync", return_value=_MOCK_ONLINE)
+@patch(
+    "netllm_core.pool.probe_openai_compat_sync",
+    return_value={"status": "online", "models": ["shared-model"], "model_count": 1},
+)
 def test_round_robin_alternates_local_and_peer_agent(_mock: object) -> None:
     pool = RouterPool()
     local = Backend(


### PR DESCRIPTION
## Summary

PR 5 of the v0.4.0 "deliver the swarm promise" series (follows #20–#23). Makes the mixed-fleet pitch (oMLX + Ollama + LM Studio + vLLM) actually aggregate capacity.

- New `[routing.model_aliases]`: canonical name -> provider-specific IDs; matching, payload rewrite to the ID each backend serves (exact first, full tag ID for Ollama-style prefixes), and canonical names restored in responses and SSE chunks; Anthropic bridge inherits the rewrite
- `/v1/models` surfaces canonical alias names alongside provider IDs
- `backends_for_model` no longer sprays every backend on a miss: stale local catalogs get one forced refresh, then the request fails fast with a 404 listing known models (cloud/auth-gated backends with unknown catalogs remain candidates, so cloud failover is preserved)

## Test plan

- [x] `./scripts/ci.sh` green (223 tests)
- [x] Alias matching, payload/response/stream rewrite, 404 with catalog, canonical listing, unknown-catalog candidacy