### PR TITLE
perf(agent): TTL-cache provider scans, thread-offload health probes

### DIFF
--- a/packages/netllm-agent/src/netllm_agent/app.py
+++ b/packages/netllm-agent/src/netllm_agent/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -102,12 +103,16 @@ def create_app(
     # --- Swarm API ---
     @app.get("/netllm/v1/status")
     async def netllm_status() -> dict[str, Any]:
-        await service.refresh_local_backends()
-        for backend in service.pool.backends:
-            # Local rows only — probing peer agents from a status handler
-            # recurses when the peer's status handler probes us back.
-            if backend.enabled and backend.local:
-                service.pool.is_healthy(backend, force_refresh=True)
+        await service.refresh_local_backends(force_scan=True)
+
+        def _probe_local() -> None:
+            for backend in service.pool.backends:
+                # Local rows only — probing peer agents from a status
+                # handler recurses when the peer probes us back.
+                if backend.enabled and backend.local:
+                    service.pool.is_healthy(backend, force_refresh=True)
+
+        await asyncio.to_thread(_probe_local)
         return await service.status_payload_enriched()
 
     @app.get("/netllm/v1/peers")

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -71,12 +71,51 @@ class AgentService:
         self.startup_warnings: list[str] = []
         # Hold references so background tasks are not garbage collected.
         self._background_tasks: set[asyncio.Task[None]] = set()
+        self._local_scan_cache: list[Backend] | None = None
+        self._local_scan_at = 0.0
+        self._local_scan_ttl_s = 10.0
 
     async def refresh_local_backends(
         self,
         *,
         persist_provider_urls: bool = False,
         config_path: Path | None = None,
+        force_scan: bool = False,
+    ) -> list[Backend]:
+        """Merge local providers + LAN peers into the pool.
+
+        The provider port scan (with its 1-token diagnose probes) is
+        TTL-cached — it used to run on every proxied request. Peer rows
+        are always re-merged so heartbeat updates apply immediately.
+        """
+        now = time.monotonic()
+        use_cache = (
+            not force_scan
+            and not persist_provider_urls
+            and self._local_scan_cache is not None
+            and now - self._local_scan_at < self._local_scan_ttl_s
+        )
+        if use_cache:
+            local = self._local_scan_cache or []
+        else:
+            local = await self._scan_local_backends(
+                persist_provider_urls=persist_provider_urls,
+                config_path=config_path,
+            )
+            self._local_scan_cache = local
+            self._local_scan_at = now
+        remote = (
+            self.swarm.peer_agent_backends() if self.config.routing.allow_remote else []
+        )
+        self.pool.merge_backends(local + remote)
+        self._update_health_metrics()
+        return local
+
+    async def _scan_local_backends(
+        self,
+        *,
+        persist_provider_urls: bool,
+        config_path: Path | None,
     ) -> list[Backend]:
         from netllm_core.models import save_config
         from netllm_discovery.local import merge_discovered_provider_urls
@@ -116,11 +155,6 @@ class AgentService:
                         agent_id=self.config.agent.agent_id,
                     )
                 )
-        remote = (
-            self.swarm.peer_agent_backends() if self.config.routing.allow_remote else []
-        )
-        self.pool.merge_backends(local + remote)
-        self._update_health_metrics()
         return local
 
     def _update_health_metrics(self) -> None:
@@ -169,15 +203,20 @@ class AgentService:
 
     async def list_models_aggregated(self) -> dict[str, Any]:
         await self.refresh_local_backends()
+
+        def _probe_local() -> None:
+            # Force-probe local providers only. Peer-agent rows are kept
+            # fresh by heartbeats; probing them from a catalog handler
+            # recurses (the peer's handler would probe us back).
+            for b in self.pool.backends:
+                if b.enabled and b.local:
+                    self.pool.is_healthy(b, force_refresh=True)
+
+        await asyncio.to_thread(_probe_local)
         seen: dict[str, dict[str, Any]] = {}
         for b in self.pool.backends:
             if not b.enabled:
                 continue
-            # Force-probe local providers only. Peer-agent rows are kept
-            # fresh by heartbeats; probing them from a catalog handler
-            # recurses (the peer's handler would probe us back).
-            if b.local:
-                self.pool.is_healthy(b, force_refresh=True)
             for mid in b.health.models:
                 if mid not in seen:
                     seen[mid] = {
@@ -397,7 +436,8 @@ class AgentService:
 
         while attempt < max_attempts:
             attempt += 1
-            backend = self._select_backend_for_request(
+            backend = await asyncio.to_thread(
+                self._select_backend_for_request,
                 model,
                 routing.strategy,
                 attempt,
@@ -477,7 +517,8 @@ class AgentService:
 
         while attempt < max_attempts:
             attempt += 1
-            backend = self._select_backend_for_request(
+            backend = await asyncio.to_thread(
+                self._select_backend_for_request,
                 model,
                 routing.strategy,
                 attempt,
@@ -678,8 +719,8 @@ class AgentService:
         if routing.allow_cloud_inject:
             self._inject_anthropic_cloud_backend(api_key)
 
-        candidates = self._message_backend_candidates(
-            model, local_only=routing.local_only
+        candidates = await asyncio.to_thread(
+            self._message_backend_candidates, model, local_only=routing.local_only
         )
         candidates = self._order_message_candidates(candidates, routing)
         last_error: Exception | None = None
@@ -747,8 +788,8 @@ class AgentService:
         if routing.allow_cloud_inject:
             self._inject_anthropic_cloud_backend(api_key)
 
-        candidates = self._message_backend_candidates(
-            model, local_only=routing.local_only
+        candidates = await asyncio.to_thread(
+            self._message_backend_candidates, model, local_only=routing.local_only
         )
         candidates = self._order_message_candidates(candidates, routing)
         last_error: Exception | None = None

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -74,6 +74,8 @@ class AgentService:
         self._local_scan_cache: list[Backend] | None = None
         self._local_scan_at = 0.0
         self._local_scan_ttl_s = 10.0
+        # Dedupe concurrent scans at TTL expiry (cache stampede guard).
+        self._local_scan_lock = asyncio.Lock()
 
     async def refresh_local_backends(
         self,
@@ -88,22 +90,28 @@ class AgentService:
         TTL-cached — it used to run on every proxied request. Peer rows
         are always re-merged so heartbeat updates apply immediately.
         """
-        now = time.monotonic()
-        use_cache = (
-            not force_scan
-            and not persist_provider_urls
-            and self._local_scan_cache is not None
-            and now - self._local_scan_at < self._local_scan_ttl_s
-        )
-        if use_cache:
-            local = self._local_scan_cache or []
-        else:
-            local = await self._scan_local_backends(
-                persist_provider_urls=persist_provider_urls,
-                config_path=config_path,
-            )
-            self._local_scan_cache = local
-            self._local_scan_at = now
+
+        def _cached_scan() -> list[Backend] | None:
+            if force_scan or persist_provider_urls:
+                return None
+            if self._local_scan_cache is None:
+                return None
+            if time.monotonic() - self._local_scan_at >= self._local_scan_ttl_s:
+                return None
+            return self._local_scan_cache
+
+        local = _cached_scan()
+        if local is None:
+            async with self._local_scan_lock:
+                # Another waiter may have refreshed while we queued.
+                local = _cached_scan()
+                if local is None:
+                    local = await self._scan_local_backends(
+                        persist_provider_urls=persist_provider_urls,
+                        config_path=config_path,
+                    )
+                    self._local_scan_cache = local
+                    self._local_scan_at = time.monotonic()
         remote = (
             self.swarm.peer_agent_backends() if self.config.routing.allow_remote else []
         )
@@ -416,6 +424,14 @@ class AgentService:
         if shard and shard.batch_id is not None and shard.index is not None:
             self._batch_ledger.mark_done(shard.batch_id, shard.index)
 
+    async def _offload_if_probing(self, fn: Any, /, *args: Any, **kwargs: Any) -> Any:
+        """Run selection in a worker thread only when a health probe could
+        fire; fresh caches stay on the event loop (no thread overhead,
+        no pool-exhaustion exposure under load)."""
+        if self.pool.any_health_stale():
+            return await asyncio.to_thread(fn, *args, **kwargs)
+        return fn(*args, **kwargs)
+
     async def proxy_chat_completion(
         self,
         payload: dict[str, Any],
@@ -436,7 +452,7 @@ class AgentService:
 
         while attempt < max_attempts:
             attempt += 1
-            backend = await asyncio.to_thread(
+            backend = await self._offload_if_probing(
                 self._select_backend_for_request,
                 model,
                 routing.strategy,
@@ -517,7 +533,7 @@ class AgentService:
 
         while attempt < max_attempts:
             attempt += 1
-            backend = await asyncio.to_thread(
+            backend = await self._offload_if_probing(
                 self._select_backend_for_request,
                 model,
                 routing.strategy,
@@ -719,7 +735,7 @@ class AgentService:
         if routing.allow_cloud_inject:
             self._inject_anthropic_cloud_backend(api_key)
 
-        candidates = await asyncio.to_thread(
+        candidates = await self._offload_if_probing(
             self._message_backend_candidates, model, local_only=routing.local_only
         )
         candidates = self._order_message_candidates(candidates, routing)
@@ -788,7 +804,7 @@ class AgentService:
         if routing.allow_cloud_inject:
             self._inject_anthropic_cloud_backend(api_key)
 
-        candidates = await asyncio.to_thread(
+        candidates = await self._offload_if_probing(
             self._message_backend_candidates, model, local_only=routing.local_only
         )
         candidates = self._order_message_candidates(candidates, routing)

--- a/packages/netllm-core/src/netllm_core/pool.py
+++ b/packages/netllm-core/src/netllm_core/pool.py
@@ -143,6 +143,22 @@ class RouterPool:
             else:
                 backend.latency_ema_ms = 0.8 * backend.latency_ema_ms + 0.2 * latency_ms
 
+    def any_health_stale(self) -> bool:
+        """True when selecting a backend could trigger a sync HTTP probe.
+
+        Callers use this to decide whether selection needs a worker
+        thread (probe possible) or can stay on the event loop (all
+        health entries fresh — pure in-memory work).
+        """
+        now = time.monotonic()
+        for b in self._backends:
+            if not b.enabled:
+                continue
+            cached = self._health_cache.get(b.cache_key())
+            if cached is None or now - cached.last_check >= HEALTH_TTL_S:
+                return True
+        return False
+
     def is_healthy(self, backend: Backend, *, force_refresh: bool = False) -> bool:
         if not backend.enabled:
             return False

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -606,6 +606,62 @@ def test_order_message_candidates_spillover_sorts_by_load() -> None:
     assert ordered[0].id == "local"
 
 
+@pytest.mark.asyncio
+async def test_refresh_local_backends_caches_provider_scan() -> None:
+    from netllm_agent.service import AgentService
+
+    cfg = NetllmConfig()
+    service = AgentService(cfg)
+    with patch(
+        "netllm_agent.service.scan_local_providers", new_callable=AsyncMock
+    ) as mock_scan:
+        mock_scan.return_value = []
+        await service.refresh_local_backends()
+        await service.refresh_local_backends()
+        await service.refresh_local_backends()
+        assert mock_scan.await_count == 1
+
+        await service.refresh_local_backends(force_scan=True)
+        assert mock_scan.await_count == 2
+
+        service._local_scan_ttl_s = 0.0
+        await service.refresh_local_backends()
+        assert mock_scan.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_refresh_merges_new_peers_despite_scan_cache() -> None:
+    from netllm_agent.service import AgentService
+    from netllm_discovery.swarm import PeerRecord
+
+    cfg = NetllmConfig()
+    service = AgentService(cfg)
+    with patch(
+        "netllm_agent.service.scan_local_providers", new_callable=AsyncMock
+    ) as mock_scan:
+        mock_scan.return_value = []
+        await service.refresh_local_backends()
+        service.swarm.register_peer(
+            PeerRecord(
+                agent_id="late-peer",
+                listen_url="http://192.168.1.77:11400",
+                backends=[
+                    Backend(
+                        id="b",
+                        base_url="http://127.0.0.1:8080/v1",
+                        local=True,
+                        health=BackendHealth(models=["m"]),
+                    ).model_dump(mode="json")
+                ],
+            )
+        )
+        await service.refresh_local_backends()  # cached scan, fresh peers
+        assert mock_scan.await_count == 1
+    peer_rows = [b for b in service.pool.backends if b.id.startswith("peer:")]
+    assert len(peer_rows) == 1
+    assert peer_rows[0].base_url == "http://192.168.1.77:11400/v1"
+
+
 def test_auto_subnet_fallback_only_for_lan_binds() -> None:
     from netllm_agent.service import AgentService
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -630,6 +630,40 @@ async def test_refresh_local_backends_caches_provider_scan() -> None:
 
 
 @pytest.mark.asyncio
+async def test_concurrent_refreshes_dedupe_to_single_scan() -> None:
+    """Cache stampede guard: N concurrent refreshes at an expired TTL
+    must run exactly one provider scan."""
+    import asyncio as aio
+
+    from netllm_agent.service import AgentService
+
+    cfg = NetllmConfig()
+    service = AgentService(cfg)
+    scan_calls = 0
+
+    async def slow_scan(config: NetllmConfig) -> list[dict[str, str]]:
+        nonlocal scan_calls
+        scan_calls += 1
+        await aio.sleep(0.05)
+        return []
+
+    with patch("netllm_agent.service.scan_local_providers", slow_scan):
+        await aio.gather(*(service.refresh_local_backends() for _ in range(6)))
+    assert scan_calls == 1
+
+
+def test_any_health_stale_reflects_cache_age() -> None:
+    from netllm_core.pool import RouterPool
+
+    pool = RouterPool()
+    backend = Backend(id="a", base_url="http://a/v1")
+    pool.set_backends([backend])
+    assert pool.any_health_stale() is True  # never probed
+    pool.mark_success(backend)
+    assert pool.any_health_stale() is False  # fresh entry
+
+
+@pytest.mark.asyncio
 async def test_refresh_merges_new_peers_despite_scan_cache() -> None:
     from netllm_agent.service import AgentService
     from netllm_discovery.swarm import PeerRecord

--- a/tests/test_e2e_two_agents.py
+++ b/tests/test_e2e_two_agents.py
@@ -249,6 +249,32 @@ def test_round_robin_spreads_load_without_ping_pong(
     assert all(h == "1" for h in hop_headers)
 
 
+def test_provider_scan_is_ttl_cached_across_requests(
+    two_agent_mesh: dict[str, Any],
+) -> None:
+    """Routed requests must not trigger a fresh provider scan (with its
+    1-token diagnose probe) every time — the scan is TTL-cached."""
+    provider_a = two_agent_mesh["provider_a"]
+    base_a = two_agent_mesh["base_a"]
+
+    with httpx.Client(timeout=60.0) as client:
+        client.post(
+            f"{base_a}/v1/chat/completions",
+            json={"model": MODEL, "messages": [{"role": "user", "content": "hi"}]},
+        )
+        start_probes = provider_a["probe_hits"]
+        for _ in range(3):
+            resp = client.post(
+                f"{base_a}/v1/chat/completions",
+                json={
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            assert resp.status_code == 200
+    assert provider_a["probe_hits"] == start_probes
+
+
 def test_local_spillover_idle_agent_serves_locally() -> None:
     """With local_spillover and a serial (idle) workload, requests never
     leave the machine even though a peer is registered."""

--- a/tests/test_e2e_two_agents.py
+++ b/tests/test_e2e_two_agents.py
@@ -249,6 +249,29 @@ def test_round_robin_spreads_load_without_ping_pong(
     assert all(h == "1" for h in hop_headers)
 
 
+def _post_chat_with_retry(client: httpx.Client, base: str) -> httpx.Response:
+    """POST a chat completion, retrying transient 5xx/connection flakes
+    (Windows runners occasionally abort sockets under threaded uvicorn)."""
+    last: httpx.Response | None = None
+    for _ in range(3):
+        try:
+            last = client.post(
+                f"{base}/v1/chat/completions",
+                json={
+                    "model": MODEL,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+        except httpx.TransportError:
+            time.sleep(0.2)
+            continue
+        if last.status_code < 500:
+            return last
+        time.sleep(0.2)
+    assert last is not None, "request never completed"
+    return last
+
+
 def test_provider_scan_is_ttl_cached_across_requests(
     two_agent_mesh: dict[str, Any],
 ) -> None:
@@ -258,20 +281,11 @@ def test_provider_scan_is_ttl_cached_across_requests(
     base_a = two_agent_mesh["base_a"]
 
     with httpx.Client(timeout=60.0) as client:
-        client.post(
-            f"{base_a}/v1/chat/completions",
-            json={"model": MODEL, "messages": [{"role": "user", "content": "hi"}]},
-        )
+        _post_chat_with_retry(client, base_a)
         start_probes = provider_a["probe_hits"]
         for _ in range(3):
-            resp = client.post(
-                f"{base_a}/v1/chat/completions",
-                json={
-                    "model": MODEL,
-                    "messages": [{"role": "user", "content": "hi"}],
-                },
-            )
-            assert resp.status_code == 200
+            resp = _post_chat_with_retry(client, base_a)
+            assert resp.status_code == 200, resp.text
     assert provider_a["probe_hits"] == start_probes
 
 


### PR DESCRIPTION
## Summary

PR 6 of the v0.4.0 "deliver the swarm promise" series (follows #20–#24). Removes router overhead from the request hot path.

- `refresh_local_backends()` ran a full provider port scan — including 1-token diagnose inference probes — on **every** proxied request; the scan is now TTL-cached (10 s) while peer rows still merge every call so heartbeat updates apply immediately. Status and admin discover force a fresh scan
- Sync health probes during backend selection, status, and catalog listing run via `asyncio.to_thread` so they no longer block the event loop (fixes the cross-agent mutual-probe stall and the hot-path blocking flagged in #24 review)
- e2e harness asserts routed requests stop triggering per-request diagnose probes; cache unit tests cover TTL, force, and fresh-peer merge

## Test plan

- [x] `./scripts/ci.sh` green (228 tests)
- [x] e2e: probe count stable across routed requests within TTL; spillover + round_robin scenarios unaffected