### PR TITLE
docs(architecture): add architecture reference and audit register

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,6 +16,7 @@ User-facing install, troubleshoot, editor wiring, platform matrix, CI/release, a
 | Learnings | `solutions/` |
 | SDK maintenance | `sdk-versions.md` |
 | Routing audit & hardening | `routing-hardening-plan.md` |
+| Architecture & audit | `architecture/` (diagrams, dependency map, findings register) |
 
 Parent rail: [../AGENTS.md](../AGENTS.md).
 
@@ -48,6 +49,7 @@ Parent rail: [../AGENTS.md](../AGENTS.md).
 
 | Path | Contract |
 |------|----------|
+| [`architecture/`](architecture/AGENTS.md) | Architecture reference + point-in-time audit; every claim carries `file:line` evidence |
 | [`release-notes/`](release-notes/) | Versioned release notes (no AGENTS.md — filenames are the index) |
 | [`solutions/`](solutions/) | Durable QA and workflow learnings |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Overview: [platform-matrix.md](platform-matrix.md)
 
 | Topic | Doc |
 |-------|-----|
+| **Architecture, dependencies & audit** | [architecture/](architecture/README.md) — system + component diagrams, request lifecycle, swarm behaviour, dependency map, findings register, feature integration status |
 | CI, macOS build, release | [ci-and-release.md](ci-and-release.md) |
 | macOS Developer ID + notarization | [macos-code-signing.md](macos-code-signing.md) |
 | Pre-push verification | `scripts/verify-before-pr.sh` from repo root |

--- a/docs/architecture/01-system-overview.md
+++ b/docs/architecture/01-system-overview.md
@@ -1,0 +1,212 @@
+# 01 · System overview
+
+## What the product is
+
+**netllm** is a per-host daemon that turns the LLM servers on your machines into a single
+OpenAI- and Anthropic-compatible endpoint. Each host runs one agent. The agent:
+
+1. **Discovers** local inference servers (oMLX, Ollama, LM Studio, vLLM) by probing known ports.
+2. **Discovers** sibling agents on the LAN (mDNS, static peers, optional subnet scan).
+3. **Exposes** two client-facing API dialects on one port — `http://<host>:11400/v1` (OpenAI:
+   chat, responses, embeddings, models) and `http://<host>:11400/v1/messages` (Anthropic Messages).
+4. **Routes** each request to a backend using a configurable strategy, translating between
+   dialects where the chosen backend speaks the other one.
+5. **Falls back** to configured cloud providers when local capacity is unavailable (opt-in).
+
+The value proposition is that any tool that accepts `OPENAI_BASE_URL` or `ANTHROPIC_BASE_URL`
+— Claude Code, Codex CLI, Cursor, Gemini CLI, Honcho, custom harnesses — points at netllm once
+and transparently gets the whole fleet.
+
+## Deployment topologies
+
+```mermaid
+flowchart TB
+    subgraph T1["Topology A — single machine (default: netllm init --single)"]
+        direction LR
+        C1["Claude Code / Cursor / Codex"] -->|127.0.0.1:11400| A1["netllm agent"]
+        A1 --> P1["oMLX :8080"]
+        A1 --> P2["Ollama :11434"]
+        A1 --> P3["LM Studio :1234"]
+    end
+
+    subgraph T2["Topology B — LAN swarm (netllm init --swarm)"]
+        direction LR
+        C2["clients"] -->|0.0.0.0:11400| G["agent (gateway role)"]
+        G <-->|"heartbeat /netllm/v1/heartbeat"| W1["agent (peer)"]
+        G <-->|heartbeat| W2["agent (peer)"]
+        G -->|"forward /v1/* + x-netllm-local-only"| W1
+        W1 --> PW1["local providers"]
+        W2 --> PW2["local providers"]
+        G --> PG["local providers"]
+    end
+
+    subgraph T3["Topology C — mesh + cloud spillover"]
+        direction LR
+        C3["clients"] --> A3["agent"]
+        A3 --> LOCAL["local + peer mesh"]
+        A3 -.->|"[cloud] enabled + keyed"| CL["Moonshot · Z.ai · OpenAI · Anthropic · OpenRouter"]
+    end
+```
+
+Every agent is architecturally identical. `agent.role` (`peer` | `gateway`) only affects
+(a) whether peers adopt this agent's `default_strategy` via `routing.follow_gateway`, and
+(b) doctor warnings. There is no leader election, no shared state store, no quorum.
+
+## Container / component view
+
+```mermaid
+flowchart LR
+    subgraph clients["Client surfaces"]
+        CLI["netllm CLI (Typer/Rich)"]
+        MAC["macOS menubar app (SwiftUI)"]
+        WEB["Web dashboard (/ui/, vanilla JS)"]
+        SDKC["Any OpenAI/Anthropic SDK client"]
+    end
+
+    subgraph agent["netllm-agent (FastAPI + uvicorn, port 11400)"]
+        API["HTTP layer — app.py"]
+        ADMIN["Admin layer — admin.py"]
+        SVC["AgentService — service.py"]
+        TEL["TelemetryService"]
+        MET["Prometheus /metrics"]
+    end
+
+    subgraph core["netllm-core (no HTTP server, no vendor SDKs)"]
+        POOL["RouterPool — strategies, health cache"]
+        POL["routing_policy · source_identity · scenarios"]
+        MODELS["Pydantic config + domain models"]
+        MERGE["config_merge · config_schema"]
+        BRIDGE["anthropic_bridge · openai_responses_bridge"]
+        CLOUD["cloud_providers · known_harnesses registries"]
+    end
+
+    subgraph disc["netllm-discovery"]
+        LOCAL["local.py — provider port scan"]
+        LAN["lan.py — subnet scan, URL helpers"]
+        MDNS["mdns.py — advertise + browse"]
+        SWARM["swarm.py — SwarmRegistry, gossip"]
+    end
+
+    subgraph sdk["Vendor SDK adapters (isolation boundary)"]
+        OAI["netllm-sdk-openai → openai"]
+        ANT["netllm-sdk-anthropic → anthropic"]
+    end
+
+    subgraph upstream["Upstream"]
+        PROV["oMLX · Ollama · LM Studio · vLLM"]
+        PEERS["peer agents /v1"]
+        CLOUDP["cloud providers"]
+    end
+
+    SDKC --> API
+    WEB --> API
+    WEB --> ADMIN
+    MAC -->|"HTTP: status, telemetry, cloud, harnesses"| ADMIN
+    MAC -->|"subprocess: netllm config export/import/schema"| CLI
+    CLI -->|"HTTP for status/drain; in-process for serve"| API
+
+    API --> SVC
+    ADMIN --> SVC
+    SVC --> POOL
+    SVC --> POL
+    SVC --> BRIDGE
+    SVC --> SWARM
+    SVC --> TEL
+    SVC --> OAI
+    SVC --> ANT
+    POOL --> MODELS
+    SWARM --> LAN
+    SVC --> LOCAL
+    LOCAL --> PROV
+    OAI --> PROV
+    OAI --> PEERS
+    OAI --> CLOUDP
+    ANT --> CLOUDP
+    MDNS --> PEERS
+```
+
+### Layering rule that is actually enforced
+
+`netllm-core` must never import `openai` or `anthropic`; only the two `netllm-sdk-*` packages
+may. This is enforced by a test (`tests/test_sdk_isolation.py`) and a dedicated CI job
+(`./scripts/ci.sh sdk`). It is the cleanest boundary in the codebase and it holds.
+
+## Tech stack
+
+| Layer | Choice | Version floor |
+|-------|--------|---------------|
+| Language | Python | ≥ 3.11 (`tomllib`) |
+| Workspace / resolver | uv workspace monorepo, `uv.lock` committed | — |
+| Build backend | hatchling (all 6 packages) | — |
+| HTTP server | FastAPI + uvicorn[standard] | 0.115 / 0.32 |
+| HTTP client | httpx (async + sync) | 0.28 |
+| Config models | pydantic v2 (+ pydantic-settings, tomli-w) | 2.10 |
+| CLI | Typer + Rich | 0.15 / 13.9 |
+| Metrics | prometheus-client | 0.21 |
+| Service discovery | zeroconf | 0.132 |
+| Vendor SDKs | `openai`, `anthropic` (isolated) | 1.60 / 0.45 |
+| macOS app | Swift 5.9 tools, SwiftUI, macOS 14+ target | — |
+| macOS Python embedding | venvstacks | 0.5 |
+| Dashboard | vanilla HTML/CSS/JS, no build step, no framework | — |
+| Tests | pytest + pytest-asyncio (`asyncio_mode = auto`) | 8.0 / 0.24 |
+| Lint / types | ruff (E,F,I,UP; line 88) · basedpyright (standard) | 0.8 / 1.20 |
+
+Notably **absent by design**: no database, no message broker, no external cache, no
+container runtime requirement. All state is either in-process or a single TOML file.
+
+## State: where things live
+
+| State | Location | Lifetime |
+|-------|----------|----------|
+| User config | `~/.config/netllm/config.toml` (mode 0600 on POSIX) | Durable |
+| Backend pool + health cache | `RouterPool` in-process | Process |
+| Peer registry | `SwarmRegistry.peers` in-process | Process, pruned at `peer_stale_after_s` |
+| Local provider scan | `AgentService._local_scan_cache`, 10 s TTL | Process |
+| Upstream SDK clients | `AgentService._upstream_cache`, ≤64 entries | Process |
+| Batch shard assignments | `BatchRequestLedger`, ≤8192 entries | Process |
+| Drain flag | `AgentService.draining` | Process (deliberately not persisted) |
+| Session telemetry | `TelemetryService._session` | Process |
+| All-time telemetry | `~/.config/netllm/stats.json` | Durable |
+| Prometheus counters | prometheus-client registry | Process |
+| Agent log | `<log_dir>/agent.log` | Durable, **unrotated** (see F-19) |
+
+## Surfaces exposed on port 11400
+
+| Route | Auth | Purpose |
+|-------|------|---------|
+| `GET /` | none | JSON service card, or 307 → `/ui/` for browsers |
+| `GET /health` | none | Liveness (used by subnet scan) |
+| `GET /metrics` | none | Prometheus exposition |
+| `GET /ui/*` | none | Bundled dashboard (static mount) |
+| `POST /v1/chat/completions` | optional cluster token | OpenAI chat, streaming or not |
+| `POST /v1/responses` | optional cluster token | OpenAI Responses (Codex CLI) |
+| `POST /v1/embeddings` | optional cluster token | OpenAI embeddings |
+| `POST /v1/messages` | optional cluster token | Anthropic Messages, streaming or not |
+| `GET /v1/models` | optional cluster token | Aggregated catalog |
+| `GET /netllm/v1/status` | none | Swarm status snapshot **(see F-13)** |
+| `GET /netllm/v1/peers`, `/backends` | none | Read-only debug |
+| `POST /netllm/v1/heartbeat` | cluster token if set | Peer gossip ingress |
+| `GET /netllm/v1/telemetry` | none | Dashboard/menubar telemetry |
+| `GET /netllm/v1/{doctor,version,config,config/schema,logs,harnesses}` | local **or** cluster token | Admin reads |
+| `GET /netllm/v1/cloud/providers[/{id}/models]` | local or token | Cloud registry + live catalog probe |
+| `GET /netllm/v1/update/check` | local or token | GitHub release check |
+| `GET /netllm/v1/client-env` | none | Env-var snippet for editor wiring |
+| `POST /netllm/v1/admin/{config,discover,peers-scan,drain}` | local or token | Admin writes |
+
+"Optional cluster token" = enforced only when `swarm.require_token_for_inference = true`
+**and** a `swarm.cluster_token` is set; loopback clients are always exempt.
+
+## Codebase size
+
+| Area | Files | Lines |
+|------|-------|-------|
+| `packages/` Python (6 packages) | 51 | 13,288 |
+| ↳ largest: `netllm_agent/service.py` | 1 | 2,149 |
+| ↳ second: `netllm_cli/main.py` | 1 | 2,119 |
+| `apps/netllm-mac/Sources` Swift | 45 | ~7,500 |
+| ↳ largest: `SettingsWindowView.swift` | 1 | 1,244 |
+| Bundled dashboard (JS/CSS/HTML) | 3 | 3,457 |
+| Tests (`tests/` + SDK package tests) | 63 | — |
+
+Two 2 kLOC modules (`service.py`, `main.py`) carry most of the complexity and most of the
+findings in [07](07-findings-register.md); both are flagged for decomposition (F-24).

--- a/docs/architecture/02-component-architecture.md
+++ b/docs/architecture/02-component-architecture.md
@@ -1,0 +1,335 @@
+# 02 · Component architecture
+
+## Package dependency graph
+
+```mermaid
+flowchart BT
+    core["netllm-core<br/><i>routing, config, bridges, registries</i><br/>3,398 LOC"]
+    oai["netllm-sdk-openai<br/><i>openai SDK adapter</i><br/>117 LOC"]
+    ant["netllm-sdk-anthropic<br/><i>anthropic SDK adapter</i><br/>77 LOC"]
+    disc["netllm-discovery<br/><i>local scan, mDNS, swarm registry</i><br/>1,629 LOC"]
+    agent["netllm-agent<br/><i>FastAPI app, AgentService, admin</i><br/>3,572 LOC"]
+    cli["netllm-cli<br/><i>Typer CLI, lifecycle, install</i><br/>3,062 LOC"]
+    meta["netllm (meta-package)<br/>src/netllm"]
+
+    disc --> core
+    agent --> core
+    agent --> oai
+    agent --> ant
+    agent --> disc
+    cli --> core
+    cli --> disc
+    cli --> agent
+    meta --> cli
+
+    style core fill:#e8f0fe,stroke:#4285f4
+    style oai fill:#fff4e5,stroke:#f4b400
+    style ant fill:#fff4e5,stroke:#f4b400
+```
+
+The graph is acyclic and the SDK isolation boundary is real. Two observations:
+
+- `netllm-cli` depends on `netllm-agent`, which pulls FastAPI, uvicorn, prometheus-client
+  and both vendor SDKs into every CLI-only install. This is deliberate (`netllm serve` runs
+  the agent in-process) but means there is no lightweight "client-only" install path (F-25).
+- `netllm-core` depends on nothing but httpx/pydantic/tomli-w. It is genuinely portable
+  and is the right home for anything reusable.
+
+## netllm-core — the domain
+
+| Module | LOC | Responsibility |
+|--------|-----|----------------|
+| `models.py` | 597 | All pydantic config models + `Backend`/`BackendHealth` domain types, protocol header constants, `load_config`/`save_config`, `ensure_lan_mesh_defaults` |
+| `pool.py` | 647 | `RouterPool`: candidate selection, 8 routing strategies, health cache, in-flight ledger, model-alias/pool resolution, rendezvous sharding |
+| `anthropic_bridge.py` | 461 | Anthropic Messages ⇄ OpenAI chat translation, including SSE stream translation |
+| `openai_responses_bridge.py` | 423 | OpenAI Responses ⇄ chat translation (Codex CLI surface) |
+| `update.py` | 328 | GitHub release check, asset selection per install method, SHA256 sidecar handling |
+| `health.py` | 260 | OpenAI and Anthropic reachability probes (async + sync), 1-token diagnose |
+| `config_merge.py` | 244 | **The single shared merge implementation** for both config write paths |
+| `install_detect.py` | 202 | app-bundle / Homebrew / systemd / Windows-service / source detection |
+| `routing_policy.py` | 191 | `resolve_routing()` — merges globals, policies, source, scenario, headers |
+| `cloud_providers.py` | 176 | Static registry of 5 cloud providers (endpoints, auth modes, catalogs) |
+| `config_schema.py` | 169 | Walks pydantic models → generic form schema for UI clients |
+| `source_identity.py` | 131 | `resolve_source()` — header → virtual key → User-Agent → default |
+| `scenarios.py` | 129 | Heuristic classification: long_context / web_search / think / background |
+| `known_harnesses.py` | 87 | Static registry of 6 known CLIs |
+| `capabilities.py` | 68 | Name-heuristic model capability (chat/embedding/audio/rerank/other) |
+| `platform.py` | 63 | OS-specific paths, `local_admin_client_hosts()` |
+| `config.py` | 41 | Pure re-export shim over `models.py` |
+| `harness_detection.py` | 39 | `shutil.which` detection with 5-min TTL cache |
+| `sdk_versions.py` / `version.py` | 44 | Installed-version reporting |
+
+### Domain model
+
+```mermaid
+classDiagram
+    class NetllmConfig {
+        AgentConfig agent
+        DiscoveryLocalConfig discovery
+        DiscoverySwarmConfig swarm
+        RoutingConfig routing
+        UiConfig ui
+        CloudConfig cloud
+    }
+    class RoutingConfig {
+        RoutingStrategy default_strategy
+        bool allow_remote
+        int max_in_flight_per_backend
+        int spillover_max_local_in_flight
+        float health_ttl_s
+        float offline_retry_s
+        int max_backend_failures
+        bool follow_gateway
+        dict model_aliases
+        dict~str,ModelPool~ model_pools
+        list~BackendOverride~ backends
+        list~RoutingPolicy~ policies
+        list~SourceConfig~ sources
+    }
+    class SourceConfig {
+        str id
+        str known_id
+        str secret / secret_env
+        RoutingStrategy strategy
+        bool local_only / allow_cloud
+        list cloud_providers
+        int max_concurrency
+        dict model_rewrites
+        dict~str,ScenarioRule~ scenarios
+        SourceMatch match
+        is_elevated()
+    }
+    class Backend {
+        str id
+        str base_url
+        ProviderId provider
+        ApiFormat api_format
+        bool local
+        str agent_id
+        str cloud_provider
+        str auth_mode
+        int in_flight
+        float latency_ema_ms
+        int max_concurrency
+        BackendHealth health
+    }
+    class ModelPool {
+        bool enabled
+        list hosts
+        list models
+    }
+    class CloudProviderConfig {
+        bool enabled
+        str region
+        CloudAuthMode auth
+        str api_key / api_key_env
+        list models
+    }
+
+    NetllmConfig *-- RoutingConfig
+    NetllmConfig *-- CloudConfig
+    RoutingConfig *-- SourceConfig
+    RoutingConfig *-- ModelPool
+    RoutingConfig *-- RoutingPolicy
+    RoutingConfig *-- BackendOverride
+    CloudConfig *-- CloudProviderConfig
+    SourceConfig *-- ScenarioRule
+    Backend ..> BackendOverride : materialized from
+    Backend ..> CloudProviderConfig : materialized from
+    Backend ..> PeerRecord : materialized from
+```
+
+**Key insight:** `Backend` is a *runtime* type that is never persisted. It is materialized
+from three sources every refresh cycle — the local provider scan, `[[routing.backends]]`
+overrides, and peer heartbeats — plus two ephemeral cloud paths. This is why pruning
+(`prune_local_provider_rows`, `prune_peer_rows`, `prune_cloud_provider_rows`) exists and
+why in-place field updates in `merge_backends` matter (see F-03).
+
+### Three overlapping model-name mechanisms
+
+This is the single most confusing part of the domain for a new reader:
+
+| Mechanism | Matched against | Effect |
+|-----------|-----------------|--------|
+| `routing.model_aliases` | the **requested** name | canonical name → list of provider-specific IDs |
+| `routing.model_pools` | the **host**, not the name | any request name may run on that host, using whatever pool-allowed model it serves |
+| `sources[].model_rewrites` | the **requested** name, per caller | rewritten before aliases/pools are consulted |
+| `sources[].scenarios[x].model` | the classified scenario | overrides everything above for that scenario |
+
+Resolution order in `AgentService`: `model_rewrites` → `scenario.model` → capability guard →
+`resolve_routing` → candidate collection (aliases, then pools) → `_model_for_backend`
+(aliases exact → tag-prefix → case-folded → `resolve_via_pool`).
+
+`routing-hardening-plan.md` §Phase 4 already states the intent to fold `model_pools` into a
+future `model_groups`; until then, three name mechanisms plus a fourth (`model_groups`) is
+a real simplification target (F-23).
+
+## netllm-discovery
+
+| Module | LOC | Responsibility |
+|--------|-----|----------------|
+| `local.py` | 610 | Provider port scan, URL normalisation, `Backend` materialisation, all oMLX admin/telemetry probing |
+| `lan.py` | 366 | Loopback/own-URL detection, subnet CIDR scan, mDNS browse (sync), `discover_lan_agents` aggregation |
+| `mdns.py` | 298 | zeroconf advertiser + browser, `ServiceInfo` encode/decode |
+| `swarm.py` | 235 | `SwarmRegistry`, `PeerRecord`, heartbeat gossip loop, peer → `Backend` materialisation |
+| `process_util.py` | 160 | Port ownership / PID inspection for `serve --replace` |
+| `runtime.py` | 142 | Listen-port conflict detection and human-readable hints |
+
+`local.py` carries all oMLX-specific admin/telemetry probing (~280 lines of the 610). That is
+provider-specific knowledge sitting in a package named "discovery" — a cohesion smell, not a
+defect (F-26).
+
+## netllm-agent
+
+| Module | LOC | Responsibility |
+|--------|-----|----------------|
+| `service.py` | 2,149 | `AgentService` — the orchestrator. Owns pool, swarm, telemetry, all four proxy paths, cloud materialisation, background tasks |
+| `admin.py` | 521 | Loopback/token-gated admin helpers: doctor, config summary, patch save, peers-scan, log tail, registries |
+| `app.py` | 444 | FastAPI factory, route definitions, exception → HTTP status mapping, static mount |
+| `telemetry.py` | 257 | Session/all-time counters, oMLX telemetry proxy, ring-buffer history |
+| `shard.py` | 137 | Shard-context extraction and the bounded batch ledger |
+| `metrics.py` | 58 | 7 Prometheus collectors |
+| `static/` | 3,457 | Bundled dashboard (`dashboard.js` alone is 2,721 lines) |
+
+### AgentService responsibilities (why it is 2.1 kLOC)
+
+```mermaid
+mindmap
+  root((AgentService))
+    Backend lifecycle
+      refresh_local_backends
+      _scan_local_backends
+      apply_config hot-reload
+      prune coordination
+    Cloud
+      _inject_openai_cloud_backend
+      _inject_anthropic_cloud_backend
+      _materialize_cloud_provider_backends
+      cloud_provider_models_probe
+    Request paths
+      proxy_chat_completion + stream
+      proxy_responses + stream
+      proxy_embeddings
+      proxy_messages + stream
+    Per-request policy
+      _attribute_source
+      _classify_and_record_scenario
+      _resolved_routing
+      _check_source_capacity
+    Selection & failover
+      _select_backend_for_request
+      _offload_if_probing
+      _mark_backend_failure
+    Model naming
+      _model_for_backend
+      _reject_non_chat_model
+      _restore_stream_model
+    Swarm
+      handle_heartbeat
+      _maybe_follow_gateway
+      _try_start_mdns
+      _rediscovery_loop
+      _discover_subnet_peers
+    Observability
+      status_payload
+      peer_config_warnings
+      _update_health_metrics
+      _record_success_telemetry
+```
+
+Nine distinct responsibilities in one class. The four proxy paths share a near-identical
+~70-line acquire/call/account/failover loop that is copy-pasted four times — the single
+largest simplification opportunity in the repo (F-22).
+
+## netllm-cli
+
+| Module | LOC | Responsibility |
+|--------|-----|----------------|
+| `main.py` | 2,119 | 24 top-level commands + `config`/`cloud`/`sources` sub-apps |
+| `ui.py` | 314 | Rich rendering helpers (tables, panels, hint blocks) |
+| `install.py` | 196 | Global CLI install via `uv tool install`, shell PATH wiring |
+| `oauth_pkce.py` | 143 | OpenRouter OAuth PKCE flow with localhost callback |
+| `lifecycle/` | 240 | Per-channel start/stop/restart: macOS app control socket, Homebrew, systemd, Windows `sc.exe` |
+| `config_json.py` | 40 | `config export` / `config import` — the macOS app's save path |
+| `install_detect.py` | 35 | Re-export shim over `netllm_core.install_detect` |
+
+### CLI command surface
+
+```mermaid
+flowchart LR
+    subgraph setup["Setup"]
+        init["init [--swarm --secure --single]"]
+        install["install"]
+        join["join URL --token"]
+        st["swarm-token [--create --rotate]"]
+    end
+    subgraph run["Lifecycle"]
+        serve["serve [--host --port --replace --quiet]"]
+        start["start / stop / restart"]
+        drain["drain on|off"]
+        gw["gateway"]
+    end
+    subgraph inspect["Inspect"]
+        status["status"]
+        models["models [--lan]"]
+        peers["peers"]
+        discover["discover"]
+        test["test [--api anthropic]"]
+        doctor["doctor"]
+        env["env"]
+    end
+    subgraph cfg["Config"]
+        ce["config-edit"]
+        cx["config export / import / schema"]
+    end
+    subgraph cloudg["cloud"]
+        cl["list · enable · disable · set-key · fallback · test · connect"]
+    end
+    subgraph srcg["sources"]
+        sl["list · toggle"]
+    end
+```
+
+`config export|import|schema` are machine-facing (stdout JSON / stdin JSON) and exist purely
+so the macOS app can read and write config without the agent running.
+
+## The three client surfaces and how they reach the agent
+
+```mermaid
+flowchart LR
+    subgraph mac["macOS menubar app"]
+        SVM["SettingsViewModel"]
+        CS["ConfigStore"]
+        AAPI["AgentAPI"]
+        SP["ServerProcess supervisor"]
+        ACS["AppControlServer (unix socket)"]
+    end
+    subgraph py["Python"]
+        CLIP["netllm-cli (bundled, subprocess)"]
+        AG["agent HTTP :11400"]
+    end
+
+    CS -->|"config export / import / schema (stdin/stdout JSON)"| CLIP
+    AAPI -->|"GET status, telemetry, cloud, harnesses, update/check"| AG
+    SP -->|"spawn + supervise"| AG
+    ACS -->|"netllm start/stop/restart from terminal"| SP
+    CLIP --> AG
+```
+
+The macOS app deliberately uses **two** channels: config read/write goes through the bundled
+CLI (works when the agent is stopped), everything live goes over HTTP. That split is
+documented in `ConfigStore.swift` and is sound — but it is also the reason the elevated-source
+security check is enforced on only one of the two write paths (F-02).
+
+## Test topology
+
+| Suite | Where | Runs in |
+|-------|-------|---------|
+| Cross-package integration (61 files) | `tests/` | `ci.sh test` (Ubuntu + Windows) |
+| SDK adapter contracts | `packages/netllm-sdk-*/tests/` | `ci.sh sdk` (Ubuntu) |
+| Two-agent end-to-end | `tests/test_e2e_two_agents.py` | `ci.sh test` |
+| Bundled install scripts (shell) | `tests/test_bundled_install_scripts.sh` | manual / pre-release |
+| macOS menubar e2e + lifecycle | `scripts/test-menubar-*.sh` | `menubar-lifecycle` job (macos-14) |
+
+584 tests pass in ~50 s. Coverage is genuinely good on routing, config merge, source identity,
+scenarios, cloud, and swarm URLs. The gaps that matter are listed as F-27.

--- a/docs/architecture/03-request-lifecycle.md
+++ b/docs/architecture/03-request-lifecycle.md
@@ -1,0 +1,212 @@
+# 03 · Request lifecycle and routing
+
+## The four proxy surfaces
+
+| Route | Entry point | Translation |
+|-------|-------------|-------------|
+| `POST /v1/chat/completions` | `proxy_chat_completion[_stream]` | none (native) |
+| `POST /v1/responses` | `proxy_responses[_stream]` | Responses ⇄ chat at the edge, then reuses the chat path verbatim |
+| `POST /v1/embeddings` | `proxy_embeddings` | none; Anthropic-format backends pre-excluded |
+| `POST /v1/messages` | `proxy_messages[_stream]` | Messages ⇄ chat per selected backend; Anthropic-native backends called directly |
+
+The Responses surface exists because Codex CLI removed Chat Completions support for custom
+providers (Feb 2026); netllm translates once at the edge so every downstream behaviour —
+source identity, per-source routing, scenarios, capacity, failover — is shared.
+
+## End-to-end sequence (non-streaming chat)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant API as app.py route
+    participant S as AgentService
+    participant SI as source_identity
+    participant SC as scenarios
+    participant RP as routing_policy
+    participant P as RouterPool
+    participant U as OpenAIUpstream
+    participant B as Backend
+
+    C->>API: POST /v1/chat/completions
+    API->>API: require_inference_access()
+    API->>S: proxy_chat_completion(payload, headers)
+    S->>SI: resolve_source(headers, routing.sources)
+    SI-->>S: ResolvedSource(id, resolved_via, authenticated)
+    S->>SC: classify_scenario(payload, api_format, UA)
+    SC-->>S: long_context | web_search | think | background | default
+    S->>S: model_rewrites → scenario.model → capability guard
+    S->>RP: resolve_routing(globals, policies, source, scenario, headers)
+    RP-->>S: ResolvedRouting(strategy, local_only, allow_cloud_inject,<br/>prefer_provider, pinned_backend, cloud_leads, allowlist)
+    S->>S: _check_source_capacity() → 429 if over cap
+    S->>S: refresh_local_backends()  [10 s TTL scan + peer merge + prune]
+    opt routing.allow_cloud_inject
+        S->>S: inject env-key cloud backend + materialize [cloud.providers.*]
+    end
+    loop attempt ≤ len(pool.backends)
+        S->>P: select_backend(model, strategy, exclude=tried, ...)
+        P-->>S: Backend | None
+        S->>P: acquire(backend) + _source_acquire()
+        S->>U: chat_completion({**payload, model: _model_for_backend()})
+        alt success
+            U-->>S: response
+            S->>P: mark_success(backend, latency)
+            S->>S: metrics + telemetry + shard ledger
+            S-->>C: response (model rewritten back to requested name)
+        else OpenAIUpstreamError
+            U-->>S: error
+            S->>P: mark_failure(backend, capacity=is_capacity_error(...))
+            S->>S: tried.add(backend.id) → next attempt
+        end
+        S->>P: release(backend) + _source_release()
+    end
+    S-->>C: last error, or 404 "model not found on any backend"
+```
+
+## Routing decision flow
+
+```mermaid
+flowchart TD
+    START([request]) --> SRC["resolve_source()<br/>header → netllm-&lt;id&gt;[.secret] key → User-Agent → 'default'"]
+    SRC --> SCEN["classify_scenario()<br/>long_context &gt; web_search &gt; think &gt; background &gt; default"]
+    SCEN --> REW["model_rewrites → scenario.model"]
+    REW --> CAP{"model_capability<br/>== chat?"}
+    CAP -->|no| E400["400 — cannot serve chat"]
+    CAP -->|yes| RES
+
+    subgraph RES["resolve_routing() — lowest to highest precedence"]
+        direction TB
+        G["[routing] globals: default_strategy, cloud.fallback"]
+        --> POLM["first matching routing.policies entry<br/>(model_prefix, api_format, source)"]
+        --> SRCD["source defaults: strategy, local_only, allow_cloud,<br/>cloud_providers, prefer_provider"]
+        --> SCR["source.scenarios[scenario] rule"]
+        --> HDR["headers: x-netllm-strategy, x-netllm-backend"]
+        --> LO["x-netllm-local-only / hops ≥ 2 — absolute ceiling"]
+    end
+
+    RES --> PIN{"x-netllm-backend pin<br/>resolvable & allowed?"}
+    PIN -->|yes, attempt 1| USE([use pinned backend])
+    PIN -->|no| CAND["backends_for_model()"]
+
+    CAND --> F1["drop disabled · drop remote if !allow_remote<br/>· drop remote if local_only"]
+    F1 --> F2["match served catalog against model_aliases<br/>OR model_pools membership"]
+    F2 --> F3{"candidates<br/>empty?"}
+    F3 -->|yes| REPROBE["force-refresh local probes, retry once"]
+    REPROBE --> F4
+    F3 -->|no| F4["prefer healthy; else all candidates"]
+    F4 --> F5["exclude_ids (already-failed this request)"]
+    F5 --> F6["prefer_provider narrowing"]
+    F6 --> F7["cloud_provider_allowlist narrowing (cloud rows only)"]
+    F7 --> F8["prefer_cloud (cloud.fallback = 'local')"]
+    F8 --> F9["back-pressure: keep only backends under<br/>max_concurrency ?? max_in_flight_per_backend"]
+    F9 --> STRAT{strategy}
+
+    STRAT -->|auto| AUTO["batch_shard if shard ctx, else least_load"]
+    STRAT -->|failover| FO["first untried in local→remote order"]
+    STRAT -->|round_robin| RR["rotating index"]
+    STRAT -->|least_load| LL["min in_flight; rotate among ties"]
+    STRAT -->|latency_weighted| LW["min latency_ema_ms"]
+    STRAT -->|local_first| LF["first local; shard_key indexes if &gt;1"]
+    STRAT -->|local_spillover| LS["local while in_flight &lt; threshold,<br/>else strictly-less-loaded peer"]
+    STRAT -->|batch_shard| BS["ledger assign, or HRW/modulo shard_index"]
+```
+
+### Strategy semantics cheat sheet
+
+| Strategy | Balances by | Peer usage | Typical use |
+|----------|-------------|------------|-------------|
+| `local_first` | nothing | only if no local backend | single machine (default) |
+| `local_spillover` | local in-flight threshold | only when local ≥ threshold **and** peer strictly less loaded | LAN default (auto-applied once on LAN bind) |
+| `least_load` | live in-flight, ties rotated | full | busy mixed fleet |
+| `latency_weighted` | EMA latency | full | heterogeneous hardware |
+| `round_robin` | call count | full | even, model-identical fleet |
+| `failover` | preference order | on failure | deterministic primary/secondary |
+| `batch_shard` | shard key (HRW or modulo) | full | connector/batch workloads |
+| `auto` | shard ctx → `batch_shard`, else `least_load` | full | recommended general default |
+
+`batch_shard` without shard context degrades to `round_robin` and increments
+`shardless_fallbacks` (surfaced in `/netllm/v1/status` and telemetry) — a deliberate
+observability fix for a real field incident.
+
+## Failover semantics
+
+- **Retry budget** = `max(len(pool.backends), 1)`; every failed backend id is added to
+  `tried` and excluded from subsequent selection, so no attempt is ever burnt twice.
+- **Capacity vs hard failure.** `is_capacity_error()` classifies 409/429/503/507 and known
+  body markers (`prefill_memory_exceeded`, `memory pressure`, `is busy`, `rate limit`) as
+  *full now, not broken*: the backend is excluded for this request only and is **not** counted
+  toward the offline trip. This prevents a loaded-but-working machine from being blackholed
+  for `offline_retry_s` while its work piles onto survivors.
+- **Load-aware strategies keep balancing on retries.** `least_load`, `latency_weighted`,
+  `round_robin`, `local_spillover` are not downgraded to `failover` on attempt 2+.
+- **Streaming is not retried after first byte.** Once any chunk has reached the client,
+  a failure emits an SSE error frame and ends the stream rather than replaying a second
+  response into the same stream. Correct, and non-obvious.
+
+## Loop prevention across the mesh
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as Agent A
+    participant B as Agent B (peer)
+    participant P as B's local provider
+
+    C->>A: POST /v1/chat/completions
+    A->>A: selects peer:B (least_load)
+    A->>B: POST /v1/chat/completions<br/>x-netllm-local-only: 1<br/>x-netllm-hops: 1
+    B->>B: _wants_local_only() → true (header)
+    Note over B: even if header were stripped,<br/>hops ≥ MAX_FORWARD_HOPS (2) forces local
+    B->>P: upstream call
+    P-->>B: response
+    B-->>A: response
+    A-->>C: response
+```
+
+Two independent guards (header + hop counter) mean a peer that ignores or strips
+`x-netllm-local-only` still cannot ping-pong the request.
+
+## Anthropic Messages path
+
+`proxy_messages` runs the **same** strategy loop as chat completions over the OpenAI-format
+mesh, then falls back to Anthropic-format backends as a final tier:
+
+```mermaid
+flowchart LR
+    M["POST /v1/messages"] --> EXCL["exclude every api_format='anthropic'<br/>backend from the strategy loop"]
+    EXCL --> LOOP["strategy loop over local + peer<br/>OpenAI-format backends"]
+    LOOP -->|"selected"| TR["anthropic_to_openai_request()<br/>→ chat_completion()<br/>→ openai_to_anthropic_response()"]
+    LOOP -->|"exhausted"| FB["_anthropic_fallback_backends()"]
+    FB --> NATIVE["AnthropicUpstream.messages_create()<br/>(x-api-key or Bearer per auth_mode)"]
+```
+
+This ordering is deliberate: the Anthropic cloud must never shadow the free local mesh in a
+rotation. Streaming mirrors it with an explicit `candidates_exhausted` / `fallback_iter`
+state machine.
+
+`anthropic_bridge` translates system prompts, multi-block content, tool definitions,
+`tool_choice`, tool results, and — for streaming — synthesises `message_start`,
+`content_block_start/delta/stop`, `message_delta`, `message_stop` events including
+`tool_use` blocks. It imports no vendor SDK.
+
+## Concurrency accounting
+
+Three independent counters gate a request:
+
+| Counter | Scope | Enforced in | Over-limit behaviour |
+|---------|-------|-------------|----------------------|
+| `Backend.in_flight` vs `max_concurrency` ?? `routing.max_in_flight_per_backend` | per backend row | `pool.select_backend` | prefer another backend; if all saturated, proceed anyway |
+| `agent.max_concurrency` | per machine, self-declared | broadcast via heartbeat → copied onto the peer's `Backend.max_concurrency` on every other agent | peers stop selecting it |
+| `sources[].max_concurrency` | per calling harness | `_check_source_capacity` | **HTTP 429**, no queuing |
+
+Peer in-flight is heartbeat-reported plus this agent's own un-acked forwards
+(`RouterPool._own_peer_hops`), so load is visible between heartbeats.
+
+## Where the event loop is at risk
+
+The code carefully offloads *selection* to a worker thread only when a probe could fire
+(`_offload_if_probing` → `pool.any_health_stale()`). But `_update_health_metrics()` — called
+from `refresh_local_backends()` on **every** request and again in the `finally` of every
+attempt — iterates all backends calling `RouterPool.is_healthy()`, which performs
+**synchronous httpx calls on the event loop** when an entry is stale. This inverts the
+intent of the offload guard. See F-04.

--- a/docs/architecture/04-discovery-and-swarm.md
+++ b/docs/architecture/04-discovery-and-swarm.md
@@ -1,0 +1,203 @@
+# 04 · Discovery, swarm, and network behaviour
+
+## Two independent discovery planes
+
+```mermaid
+flowchart TB
+    subgraph plane1["Plane 1 — local providers (this host only)"]
+        direction LR
+        CFG1["discovery.provider_urls<br/>(saved overrides, tried first)"] --> PROBE
+        ENV["env hints: OLLAMA_HOST,<br/>OMLX_PORT, LMSTUDIO_PORT, VLLM_PORT"] --> PROBE
+        PORTS["default ports:<br/>oMLX 8080/8088/8081 · Ollama 11434<br/>LM Studio 1234/41334 · vLLM 8000/8001"] --> PROBE
+        CUST["discovery.custom_endpoints<br/>+ [[routing.backends]]"] --> PROBE
+        PROBE["GET &lt;base&gt;/models on 127.0.0.1 and localhost<br/>(all candidates concurrently, first hit wins)"] --> BE1["Backend rows (local=true)"]
+        BE1 --> PERSIST["merge_discovered_provider_urls()<br/>→ discovery.provider_urls (startup only)"]
+    end
+
+    subgraph plane2["Plane 2 — peer agents (LAN)"]
+        direction LR
+        MD["mDNS _netllm._tcp.local."] --> REG
+        SP["swarm.peers (static config)"] --> REG
+        SS["subnet scan of /24 CIDRs on :11400"] --> REG
+        HB["inbound POST /netllm/v1/heartbeat"] --> REG
+        REG["SwarmRegistry.peers{agent_id → PeerRecord}"] --> BE2["one Backend row per peer<br/>base_url = &lt;peer&gt;/v1, local=false"]
+    end
+
+    BE1 --> POOL["RouterPool"]
+    BE2 --> POOL
+```
+
+### Plane 1 details
+
+- The scan is **TTL-cached at 10 s** (`AgentService._local_scan_ttl_s`) with an
+  `asyncio.Lock` stampede guard. Before that cache existed it ran on every proxied request.
+- Routine scans are **read-only**: the 1-token inference `diagnose` probe is opt-in
+  (`netllm discover`, `netllm test`) because it forces the provider to *load* a chat model,
+  which evicts the resident model on memory-constrained hosts.
+- `401`/`403` counts as **online (reachable)** for the probe, but a *local* backend that
+  probes 401/403 with an empty catalog is excluded from candidacy — otherwise an
+  auth-gated LM Studio shows `in_flight = 0`, wins every `least_load` pick, and starves the
+  real backends. Cloud injects stay blind candidates because their key arrives per-request.
+- Failed probes **keep the last known model catalog** rather than wiping it to `[]`.
+
+### Plane 2 details
+
+- `PeerRecord` carries `agent_id`, `listen_url`, `role`, `hostname`, `backends[]`,
+  `routing_strategy`, `version`, `max_concurrency`, `draining`, `last_seen`.
+- Only the peer's `local = true` backend rows are consumed
+  (`SwarmRegistry._peer_local_rows`). Using a peer's *remote* rows would echo backends
+  transitively around the mesh and invite multi-hop chains.
+- A peer advertising a **loopback** `listen_url` is skipped with a log line — its URL would
+  resolve to our own agent. `netllm peers` surfaces this as the "must serve with
+  `--host 0.0.0.0`" hint.
+- A **draining** peer is omitted from `peer_agent_backends()` entirely, so it vanishes from
+  every strategy's candidate list on the next heartbeat.
+
+## Peer lifecycle state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Undiscovered
+    Undiscovered --> Registered: mDNS add_service /<br/>static peer fetch /<br/>subnet scan hit /<br/>inbound heartbeat
+    Registered --> Routable: is_lan_reachable_agent_url()<br/>and not draining
+    Routable --> Draining: heartbeat draining=true
+    Draining --> Routable: heartbeat draining=false
+    Routable --> Stale: now - last_seen &gt; peer_stale_after_s (45 s)
+    Draining --> Stale: same
+    Stale --> Pruned: prune_stale() in gossip loop
+    Pruned --> Registered: _rediscovery_loop re-probes<br/>known_peer_urls every 60 s
+    Pruned --> [*]: url forgotten only on process exit
+    Routable --> Offline: max_backend_failures (3) hard failures
+    Offline --> Routable: re-probe after offline_retry_s (10 s)
+```
+
+`known_peer_urls` is append-only for the process lifetime — this is what makes recovery from
+a sleep/Wi-Fi blip work without a restart, and it is intentional.
+
+## Gossip loop
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Agent A gossip loop
+    participant CFG as swarm.peers
+    participant B as Peer B
+
+    loop every swarm.heartbeat_interval_s (10 s)
+        A->>CFG: refresh_static_peers() — GET /netllm/v1/status on each
+        A->>A: prune_stale() — drop peers older than peer_stale_after_s
+        A->>A: payload = status_payload()
+        loop each known peer
+            A->>B: POST /netllm/v1/heartbeat (Bearer cluster_token if set)
+            B->>B: register_peer, then _maybe_follow_gateway, then refresh_local_backends
+        end
+    end
+```
+
+**Heartbeats are sent sequentially and awaited one at a time.** With N peers and a 5 s
+per-peer timeout, one unreachable peer delays every peer behind it in the list, and the
+effective heartbeat interval becomes `interval + Σ timeouts`. See F-10.
+
+The heartbeat payload is the **full** `status_payload()` — every backend row with its model
+catalog. On a fleet with large catalogs this is a non-trivial payload sent N×N times per
+interval; there is no delta encoding or catalog hash (F-21).
+
+## Discovery triggers at startup
+
+```mermaid
+flowchart TD
+    START["serve → lifespan startup"] --> RLB["refresh_local_backends(persist_provider_urls=True)"]
+    RLB --> SBG["start_background()"]
+    SBG --> MDNSQ{"agent.advertise<br/>and swarm.mdns?"}
+    MDNSQ -->|yes| TRY["_try_start_mdns(): advertiser + browser"]
+    TRY -->|failure| WARN["startup warning; retried by rediscovery loop"]
+    MDNSQ -->|no| SKIP
+    SBG --> GOSSIP["swarm.start_gossip()"]
+    SBG --> SUBNET{"swarm.subnet_scan?"}
+    SUBNET -->|yes| SCAN["_discover_subnet_peers() immediately"]
+    SUBNET -->|no| FALLBACK{"mDNS on and<br/>LAN-bound?"}
+    FALLBACK -->|yes| DELAY["_mdns_fallback_subnet_scan():<br/>wait 10 s, scan once if still no peers"]
+    SBG --> REDISC{"rediscover_interval_s &gt; 0?"}
+    REDISC -->|yes| LOOP["_rediscovery_loop() every 60 s:<br/>retry mDNS · re-probe lost URLs ·<br/>re-scan subnet if registry empty"]
+```
+
+The one-shot mDNS-blocked fallback scan is a good design touch: corporate/VLAN networks that
+drop multicast still form a mesh, and home installs that never bind the LAN never probe the
+subnet.
+
+## Network requirements
+
+| Direction | Port / protocol | Required for |
+|-----------|-----------------|--------------|
+| Client → agent | TCP 11400 | all APIs and the dashboard |
+| Agent → local providers | TCP 8080/8088/8081, 11434, 1234/41334, 8000/8001 (loopback) | local inference |
+| Agent ↔ agent | TCP 11400 | heartbeat, forwarded inference, status fetch |
+| Agent ↔ LAN | UDP 5353 multicast | mDNS discovery (optional) |
+| Agent → subnet | TCP 11400, 64-way concurrency | subnet scan (optional) |
+| Agent → internet | TCP 443 | cloud providers, GitHub update check |
+
+The subnet scan enumerates **every host** in the configured /24 and issues a `GET /health`
+with a 1.5 s timeout at 64-way concurrency. On a corporate network this looks like a port
+scan; it is off by default and only auto-enabled on LAN binds. Worth calling out in
+deployment guidance (F-18).
+
+## Security model on the LAN
+
+```mermaid
+flowchart LR
+    subgraph open["Default: open trusted LAN (netllm init --swarm)"]
+        direction TB
+        O1["agent.listen = 0.0.0.0:11400"]
+        O2["no swarm.cluster_token"]
+        O3["POST /v1/* — unauthenticated from anywhere on the LAN"]
+        O4["POST /netllm/v1/heartbeat — unauthenticated"]
+        O5["admin routes — loopback only (LAN gets 403)"]
+    end
+    subgraph secured["Secured (netllm init --swarm --secure)"]
+        direction TB
+        S1["swarm.cluster_token generated"]
+        S2["heartbeat requires Bearer token"]
+        S3["admin routes accept Bearer token from LAN"]
+        S4["/v1/* still open unless<br/>swarm.require_token_for_inference = true"]
+    end
+    open -->|"netllm swarm-token --create"| secured
+```
+
+Three distinct gates, and they are **not** the same gate:
+
+| Gate | Function | Default |
+|------|----------|---------|
+| `local_admin_client_hosts()` | admin routes: loopback + this host's own addresses | always on |
+| `swarm.cluster_token` | heartbeat ingress + remote admin auth | unset |
+| `swarm.require_token_for_inference` | `/v1/*` auth for non-local clients | `false` |
+
+Consequence worth stating plainly to the PM: **setting a cluster token does not by itself
+protect inference.** A LAN-bound agent with a token still serves `/v1/chat/completions` to any
+host on the network until `require_token_for_inference` is also enabled. The CLI warns about
+the open case at `serve`, and doctor notes it — but the two-flag design is easy to get wrong
+(F-14).
+
+Additionally, `/netllm/v1/status` is unauthenticated and returns every backend URL, model
+catalog, hostname, agent id, peer list and version — full fleet reconnaissance for any host
+on the LAN (F-13). It has to stay reachable for peer discovery, so the fix is
+token-gating it when a token is configured rather than removing it.
+
+## Timing constants
+
+| Constant | Default | Where |
+|----------|---------|-------|
+| `swarm.heartbeat_interval_s` | 10 s | gossip cadence |
+| `swarm.peer_stale_after_s` | 45 s | peer prune age (≈ 4 missed heartbeats) |
+| `swarm.rediscover_interval_s` | 60 s | re-probe lost peers, retry mDNS |
+| `routing.health_ttl_s` | 30 s | healthy probe freshness |
+| `routing.offline_retry_s` | 10 s | offline re-probe (clamped ≤ health_ttl_s) |
+| `routing.max_backend_failures` | 3 | consecutive hard failures → offline |
+| local scan TTL | 10 s | hardcoded in `AgentService` |
+| harness PATH detection TTL | 300 s | hardcoded in `harness_detection` |
+| GitHub release cache | 900 s | hardcoded in `update` |
+| peer HTTP timeout | 5 s | `fetch_peer`, `send_heartbeat` |
+| subnet health probe timeout | 1.5 s | `probe_agent_port` |
+| upstream connect / read | 5 s / 120 s | both SDK adapters |
+
+Four of these (local scan TTL, harness TTL, release cache, peer timeout) are hardcoded while
+their siblings are configurable — an inconsistency more than a defect (F-20).

--- a/docs/architecture/05-configuration-and-control-plane.md
+++ b/docs/architecture/05-configuration-and-control-plane.md
@@ -1,0 +1,226 @@
+# 05 · Configuration and the control plane
+
+## The config file
+
+Single TOML file, `~/.config/netllm/config.toml` (or `$XDG_CONFIG_HOME/netllm/config.toml`),
+written with mode `0600` on POSIX because it holds cluster tokens and API keys.
+Six top-level sections, all optional — an absent section validates to its pydantic defaults,
+so an empty file is a valid config.
+
+```mermaid
+flowchart TD
+    ROOT["NetllmConfig"]
+    ROOT --> AG["[agent]<br/>listen · role · advertise<br/>agent_id · hostname · max_concurrency"]
+    ROOT --> DI["[discovery]<br/>providers · custom_endpoints · provider_urls"]
+    ROOT --> SW["[swarm]<br/>peers · mdns · subnet_scan · subnet_cidrs<br/>cluster_token · require_token_for_inference<br/>heartbeat_interval_s · peer_stale_after_s · rediscover_interval_s"]
+    ROOT --> RT["[routing]"]
+    ROOT --> UI["[ui]<br/>auto_start_on_launch · log_dir · update check<br/>model_favorites · 6 menubar_* toggles"]
+    ROOT --> CL["[cloud]<br/>enabled · fallback · fallback_enabled"]
+
+    RT --> RT1["scalars: default_strategy · allow_remote<br/>max_in_flight_per_backend · spillover_max_local_in_flight<br/>health_ttl_s · offline_retry_s · max_backend_failures<br/>follow_gateway · lan_defaults_applied (read-only)<br/>require_same_model_for_shard (DEAD — F-15)"]
+    RT --> RT2["[routing.model_aliases]<br/>canonical → [provider ids]"]
+    RT --> RT3["[routing.model_pools.&lt;name&gt;]<br/>enabled · hosts · models"]
+    RT --> RT4["[[routing.backends]] — BackendOverride"]
+    RT --> RT5["[[routing.policies]] — RoutingPolicy"]
+    RT --> RT6["[[routing.sources]] — SourceConfig<br/>+ [routing.sources.&lt;id&gt;.scenarios.&lt;scenario&gt;]"]
+    CL --> CL1["[cloud.providers.&lt;id&gt;]<br/>moonshot · zai · openai · anthropic · openrouter"]
+```
+
+### Field marking conventions
+
+`json_schema_extra` on pydantic fields drives every UI client:
+
+| Marker | Meaning | Examples |
+|--------|---------|----------|
+| `widget: "secret"` + `write_only: true` | never returned by read APIs; empty on save = keep stored value | `cluster_token`, `api_key`, `sources[].secret` |
+| `read_only: true` | server-owned, never form-editable | `agent_id`, `hostname`, `lan_defaults_applied`, `cloud_defaults_applied`, `BackendOverride.cloud_provider` |
+| `widget: "select"` + `options_from` | populated from a server registry | `CloudProviderConfig.region` |
+| `default_factory: "<name>"` | client-side named builder for "Add row" | `routing.policies` |
+
+## The three config write paths
+
+```mermaid
+flowchart TB
+    subgraph clients["Writers"]
+        DASH["Web dashboard<br/>POST /netllm/v1/admin/config"]
+        MACAPP["macOS Settings<br/>netllm config import (stdin JSON)"]
+        HAND["Hand edit / netllm config-edit /<br/>netllm init · join · cloud · sources"]
+    end
+
+    DASH --> ADMPATCH["admin.apply_config_patch()"]
+    MACAPP --> CJ["config_json.import_config()"]
+
+    ADMPATCH --> MERGE["config_merge.apply_config_patch()"]
+    CJ --> MERGE
+
+    MERGE --> V["NetllmConfig.model_validate()"]
+
+    ADMPATCH --> G1["_filter_own_swarm_peers()"]
+    ADMPATCH --> G2["_validate_elevated_sources() → HTTP 400"]
+    CJ --> G3["ensure_lan_mesh_defaults()"]
+
+    G1 --> SAVE
+    G2 --> SAVE
+    G3 --> SAVE
+    V --> SAVE["save_config() → TOML, chmod 0600"]
+    HAND --> SAVE
+
+    DASH --> HOT["service.apply_config() + refresh(force_scan)<br/>— hot reload, no restart"]
+
+    style G2 fill:#ffe0e0,stroke:#d33
+    style G3 fill:#fff6d6,stroke:#c90
+```
+
+### Merge semantics (`config_merge.py` — the shared implementation)
+
+The module exists precisely because the CLI and dashboard previously hand-rolled two
+divergent merges. Three behaviours, chosen per field:
+
+| # | Behaviour | Applies to | Deletion works? |
+|---|-----------|------------|-----------------|
+| 1 | Patch value fully replaces | all scalars and lists | yes (omit an entry) |
+| 2 | Full-replace dict | `routing.model_pools`, `routing.model_aliases`, `discovery.provider_urls` | yes (omit a key) |
+| 3 | Recursive dict-merge, omitted keys preserved | everything else under the 6 sections | no — by design, so unmodeled Swift/JS fields round-trip |
+| 3a | Identity-keyed rebuild on top of (3) | `routing.sources` (by `id`), `cloud.providers` (by id) | write-only secrets preserved when omitted |
+
+Special cases layered on top: `swarm.cluster_token` and every `api_key`/`secret` are preserved
+when the patch sends empty; `agent.agent_id`/`hostname` are preserved when omitted; unknown
+`cloud.providers` keys are dropped by a model validator because the merge layer has no way to
+delete them.
+
+**This is well-designed and well-documented — and it has two field-level holes**
+(`_merge_backends` drops `max_concurrency`/`cloud_provider`; `_merge_policies` drops `source`).
+Both reproduced. See F-01.
+
+### The path asymmetry that matters
+
+| Guard | Dashboard (HTTP) | macOS app / `config import` |
+|-------|------------------|------------------------------|
+| shared deep-merge | ✅ | ✅ |
+| pydantic validation | ✅ | ✅ |
+| own-peer URL filtering | ✅ | ❌ |
+| elevated-source secret enforcement | ✅ | ❌ **(F-02, reproduced)** |
+| LAN mesh defaults | ❌ | ✅ |
+| live hot-apply | ✅ | ❌ (needs restart) |
+
+Neither path is a superset of the other. Two of the four asymmetries are defects.
+
+## Schema-driven UI
+
+```mermaid
+sequenceDiagram
+    participant UI as dashboard.js / SettingsViewModel
+    participant SCH as GET /netllm/v1/config/schema<br/>(or `netllm config schema`)
+    participant VAL as GET /netllm/v1/config<br/>(or `netllm config export`)
+    participant SAVE as POST /netllm/v1/admin/config<br/>(or `netllm config import`)
+
+    UI->>SCH: fetch shape (cacheable, keyed on "version")
+    SCH-->>UI: {version, sections: {agent, discovery, swarm, routing, ui, cloud}}
+    UI->>VAL: fetch current values (secrets blanked)
+    VAL-->>UI: config_summary()
+    UI->>UI: renderSchemaForm() — widget per field type/hint
+    UI->>SAVE: patch (only changed sections)
+    SAVE-->>UI: {ok, needs_restart, path, warnings?}
+```
+
+`config_schema.py` walks the pydantic models and emits widget hints, so a new config field
+appears in the generic renderer without touching Swift or JS. `_field_default` deliberately
+returns `None` for read-only fields so the document stays byte-identical between calls and
+remains cacheable on `version`.
+
+**Scope limits (documented in `config-schema-rewrite-plan.md`, still true):** the macOS app
+only renders the `ui` section from schema; `routing`'s non-`model_pools` fields and all of
+`cloud` are still hand-typed Swift structs. The triple-mirror (Python ↔ Swift ↔ JS) is reduced,
+not eliminated (F-16).
+
+## Admin API
+
+| Endpoint | Method | Gate | Notes |
+|----------|--------|------|-------|
+| `/netllm/v1/config` | GET | local/token | values, secrets blanked |
+| `/netllm/v1/config/schema` | GET | local/token | form shape, version-cacheable |
+| `/netllm/v1/doctor` | GET | local/token | subset of CLI doctor |
+| `/netllm/v1/version` | GET | local/token | + resolved SDK versions |
+| `/netllm/v1/update/check` | GET | local/token | GitHub latest, 15-min cache |
+| `/netllm/v1/logs?tail=N` | GET | local/token | reverse-block tail, N clamped 1..2000 |
+| `/netllm/v1/harnesses` | GET | local/token | registry × configured sources × PATH detection |
+| `/netllm/v1/cloud/providers` | GET | local/token | static registry |
+| `/netllm/v1/cloud/providers/{id}/models` | GET | local/token | live probe, static fallback |
+| `/netllm/v1/admin/config` | POST | local/token | merge + save + hot-apply |
+| `/netllm/v1/admin/discover` | POST | local/token | force scan + force probe |
+| `/netllm/v1/admin/peers-scan?save=1` | POST | local/token | subnet scan, optional persist |
+| `/netllm/v1/admin/drain` | POST | local/token | runtime-only drain toggle |
+| `/netllm/v1/client-env` | GET | **none** | env-var snippet (non-secret) |
+
+`require_admin_access()` allows any client whose source IP is in
+`local_admin_client_hosts()` — loopback, `localhost`, `testclient`, plus every address
+`getaddrinfo(gethostname())` returns and the interface address discovered by the
+`connect(8.8.8.8)` trick. Computed once and cached for the process. On a multi-homed or
+oddly-resolving host this set is wider than "this machine" implies (F-17).
+
+## Source identity and per-caller routing
+
+```mermaid
+flowchart TD
+    REQ["incoming request headers"] --> H{"x-netllm-source<br/>names an enabled source?"}
+    H -->|yes| HS{"that source has<br/>a secret configured?"}
+    HS -->|no| OK1["→ source (resolved_via=header)"]
+    HS -->|yes| NEEDKEY["only a virtual key<br/>netllm-&lt;id&gt;.&lt;secret&gt; satisfies it"]
+    H -->|no| K{"Authorization: Bearer / x-api-key<br/>= netllm-&lt;id&gt;[.&lt;secret&gt;]?"}
+    NEEDKEY --> K
+    K -->|"match + secret ok"| OK2["→ source (resolved_via=key, authenticated)"]
+    K -->|no| UA{"User-Agent contains a<br/>match.user_agent_contains needle?<br/>(secret-protected sources skipped)"}
+    UA -->|yes| OK3["→ source (resolved_via=user_agent)"]
+    UA -->|no| DEF["→ 'default' — never a 401"]
+```
+
+**Attributive by default, authenticated by exception.** An unrecognised caller is labelled
+`default` and routed exactly as before the feature existed; it is never rejected. Identity
+only becomes a security boundary once a source sets `secret`/`secret_env` — and a source that
+grants *elevated* capability (`allow_cloud`, `cloud_providers`, or a `max_concurrency` above
+the global cap) **must** be secret-backed once the agent binds beyond loopback.
+
+That last rule is enforced in `admin._validate_elevated_sources` — and bypassed entirely by
+the macOS/CLI write path (F-02).
+
+`is_netllm_placeholder_key()` guarantees no `netllm-*` sentinel is ever forwarded upstream as
+a real vendor credential; real keys always carry vendor prefixes (`sk-`, `sk-ant-`), so the
+check cannot collide.
+
+## Cloud provider control plane
+
+```mermaid
+flowchart LR
+    REG["cloud_providers.py registry<br/>(code-owned: endpoints, auth modes,<br/>api_key_env, static catalogs)"] --> MAT
+    CFGP["[cloud.providers.&lt;id&gt;]<br/>enabled · region · auth · api_key(_env) · models"] --> MAT
+    MAT["_materialize_cloud_provider_backends()"] --> ROWS["Backend rows id=cloud-&lt;provider&gt;<br/>cloud_provider=&lt;id&gt;, local=false"]
+    MAT --> PRUNE["prune_cloud_provider_rows()<br/>disable → row gone immediately"]
+    ROWS --> POOL["RouterPool"]
+
+    LEGACY["legacy env-key injects:<br/>_inject_openai_cloud_backend<br/>_inject_anthropic_cloud_backend"] -.->|"ids openai-cloud / anthropic-cloud"| POOL
+```
+
+Two parallel mechanisms reach the same pool: the registry-driven `[cloud.providers.*]` path
+and the legacy "caller sent a real API key → inject a cloud backend" path. The legacy path is
+the source of F-06 (a caller's key becomes the pool's shared credential) and is a prime
+consolidation candidate (F-23).
+
+A provider that is `enabled` but has no resolvable key is **not** materialised (it would be
+guaranteed to 401); doctor flags that state instead.
+
+## Config-affecting CLI commands
+
+| Command | Writes | Guards applied |
+|---------|--------|----------------|
+| `init [--swarm --secure]` | full file | `ensure_lan_mesh_defaults` |
+| `join URL --token` | listen + peer + token | `ensure_lan_mesh_defaults`, token validation against the target |
+| `swarm-token --create/--rotate` | `swarm.cluster_token` | — |
+| `gateway` | `agent.role` | — |
+| `cloud enable/disable/set-key/fallback/connect` | `[cloud.*]` | provider id validated against registry |
+| `sources toggle <id>` | `routing.sources` | registers from `KNOWN_HARNESSES` if new |
+| `config import` | any section | merge only — **no elevated-source or own-peer guard** |
+| `serve` | `lan_defaults_applied`, `subnet_scan` | one-shot LAN upgrade |
+| agent startup | `discovery.provider_urls` | `persist_provider_urls=True` on lifespan |
+
+Nine commands and two UIs can write this file. The merge module made the *mechanics*
+consistent; the *guards* are still per-caller (F-02).

--- a/docs/architecture/06-dependencies.md
+++ b/docs/architecture/06-dependencies.md
@@ -1,0 +1,166 @@
+# 06 · Dependencies
+
+Resolved from the committed `uv.lock` on the audited checkout (2026-07-29).
+**86 packages** in the default + dev resolution.
+
+## Internal dependency matrix
+
+| Package | Depends on (internal) | Depends on (external) |
+|---------|----------------------|----------------------|
+| `netllm-core` | — | `httpx`, `pydantic`, `pydantic-settings`, `tomli-w` |
+| `netllm-sdk-openai` | — | `openai`, `httpx` |
+| `netllm-sdk-anthropic` | — | `anthropic`, `httpx` |
+| `netllm-discovery` | `netllm-core` | `httpx`, `zeroconf` |
+| `netllm-agent` | `netllm-core`, `netllm-sdk-openai`, `netllm-sdk-anthropic`, `netllm-discovery` | `fastapi`, `uvicorn[standard]`, `prometheus-client`, `httpx` |
+| `netllm-cli` | `netllm-core`, `netllm-discovery`, `netllm-agent` | `typer`, `rich`, `httpx` |
+| `netllm` (meta) | `netllm-cli` | — |
+
+All six are version-locked in lockstep at `0.4.5.0`; `tests/test_version_sync.py` enforces it.
+
+## Direct runtime dependencies
+
+| Package | Floor pin | Resolved | Role | Blast radius if it breaks |
+|---------|-----------|----------|------|---------------------------|
+| `httpx` | ≥0.28 | 0.28.1 | every HTTP call, sync + async | total |
+| `pydantic` | ≥2.10 | 2.13.4 | config models, validation, schema generation | total |
+| `pydantic-settings` | ≥2.6 | 2.14.2 | declared, **no import found in `packages/`** — see note | none |
+| `tomli-w` | ≥1.0 | 1.2.0 | `save_config` | config writes |
+| `fastapi` | ≥0.115 | 0.136.3 | HTTP surface | agent |
+| `uvicorn[standard]` | ≥0.32 | 0.49.0 | ASGI server (pulls uvloop, httptools, watchfiles, websockets, PyYAML, python-dotenv) | agent |
+| `prometheus-client` | ≥0.21 | (locked) | `/metrics` | observability only |
+| `zeroconf` | ≥0.132 | 0.149.16 | mDNS advertise/browse (pulls `ifaddr`) | LAN auto-discovery only |
+| `typer` | ≥0.15 | 0.26.7 | CLI (pulls `click`) | CLI |
+| `rich` | ≥13.9 | 15.0.0 | CLI rendering | CLI |
+| `openai` | ≥1.60 | **2.41.0** | OpenAI-compatible upstream calls | all OpenAI-format routing |
+| `anthropic` | ≥0.45 | **0.106.0** | Anthropic Messages upstream | Anthropic-native backends |
+
+> **Floor-pin drift.** `openai>=1.60` resolves to 2.41.0 — a full major version above the
+> declared floor — and `anthropic>=0.45` resolves to 0.106.0. The lock protects the repo,
+> but anyone installing `netllm-sdk-openai` standalone (or resolving without the lock) can
+> land on an SDK generation the adapter was never tested against. See F-12.
+
+> **`pydantic-settings`** is declared by `netllm-core` but no module under `packages/`
+> imports it. Either dead weight or a leftover from an earlier config loader. See F-09.
+
+## Undeclared and optional dependencies
+
+| Package | Where used | Declared? | Effect |
+|---------|-----------|-----------|--------|
+| `psutil` | `netllm_agent/telemetry.py:248` — `_host_block()` | **No** — not in any `pyproject.toml`, not in `uv.lock` | The telemetry `host` block (CPU %, memory) is `None` on every shipped install. Documented in `packages/netllm-agent/AGENTS.md` as "optional psutil host block on Linux when installed", but nothing installs it. See F-08. |
+| `zeroconf` | mDNS | Yes (core dep of `netllm-discovery`) | The `mdns = []` optional-extra in `pyproject.toml` and two package files is a no-op backwards-compat alias. See F-15. |
+
+## Dev / tooling dependencies
+
+| Package | Resolved | Role |
+|---------|----------|------|
+| `pytest` | 9.0.3 | test runner (`asyncio_mode = auto`) |
+| `pytest-asyncio` | ≥0.24 | async tests |
+| `ruff` | 0.15.16 | lint + format (E, F, I, UP; line 88) |
+| `basedpyright` | 1.39.6 | type checking, `standard` mode — **not run by `scripts/ci.sh` or any CI job** (F-27) |
+| `httpx` | 0.28.1 | test client |
+| `venvstacks` | 0.7.0 | macOS Python layer builder |
+| `pre-commit` | ≥4.0 | local hooks (`.pre-commit-config.yaml`) |
+
+## Platform and build dependencies
+
+```mermaid
+flowchart TB
+    subgraph mac["macOS"]
+        M1["Xcode / swift-tools 5.9, macOS 14+ target"]
+        M2["venvstacks → cpython-3.11.10 runtime layer<br/>+ framework-netllm layer"]
+        M3["build.py generates venvstacks.generated.toml<br/>from uv export (single source of truth)"]
+        M4["apps/netllm-mac/Scripts/build.sh release → dist/netllm-mac.dmg"]
+        M5["LIQUID_GLASS_SDK gate — Tahoe glassEffect only on macOS 26+ SDK"]
+        M2 --> M4
+        M3 --> M2
+        M1 --> M4
+        M5 --> M4
+    end
+    subgraph lin["Linux"]
+        L1["dpkg-dev (dpkg-deb), rpm (rpmbuild), rsync"]
+        L2["packaging/linux/build-deb.sh + build-rpm.sh → dist/*.deb, *.rpm"]
+        L3["systemd --user unit: netllm.service"]
+        L1 --> L2 --> L3
+    end
+    subgraph win["Windows"]
+        W1["pwsh"]
+        W2["packaging/windows/build-zip.ps1 → netllm-&lt;ver&gt;-windows-x64.zip"]
+        W3["install-service.ps1 → NetllmAgent service"]
+        W1 --> W2 --> W3
+    end
+```
+
+**Only macOS ships a GUI.** Linux and Windows use the bundled web dashboard at
+`http://127.0.0.1:11400/ui/`.
+
+**arm64-only macOS packaging.** `packaging/venvstacks.toml` declares
+`platforms = ["macosx_arm64"]` and `environments = ["sys_platform == 'darwin' and
+platform_machine == 'arm64'"]`. There is no Intel-Mac artifact path (F-18).
+
+## CI dependency
+
+```mermaid
+flowchart LR
+    LINT["lint · ubuntu-latest<br/>ruff check + format on packages/ tests/<br/>+ dashboard token drift check"]
+    LINT --> TEST["test · ubuntu + windows<br/>pytest tests/ -v"]
+    LINT --> SDKJ["sdk · ubuntu<br/>adapter + bridge contract tests"]
+    LINT --> MB["menubar-lifecycle · macos-14<br/>build.sh release + e2e + lifecycle"]
+    LINT --> PKG["packaging-smoke · ubuntu + windows<br/>deb/rpm + zip, artifact upload"]
+```
+
+Every job needs `lint`. `astral-sh/setup-uv@v5` with cache, `uv sync --frozen` — the lock is
+authoritative in CI.
+
+**Gaps in the gate:** `basedpyright` is configured but never invoked; `ruff` covers only
+`packages/` and `tests/`, leaving `scripts/`, `packaging/build.py`, and `src/` unlinted even
+though `pyproject.toml`'s `[tool.ruff]` is repo-wide; there is no Swift lint, no JS lint, and
+no macOS packaging smoke on PRs (only the full `build.sh release`). See F-27.
+
+## Release-time external dependencies
+
+| Dependency | Used by | Failure mode |
+|------------|---------|--------------|
+| `api.github.com/repos/matthewdcage/llm-swarm-router/releases/latest` | `netllm_core.update`, macOS `UpdateController` | update check returns `error`, agent unaffected; 15-min cache, unauthenticated (60 req/h/IP rate limit) |
+| GitHub release asset hosting | DMG / deb / rpm / zip download | update install fails |
+| `SHA256SUMS` or `<asset>.sha256` sidecars | integrity verification | verification skipped if absent — the Swift path only verifies **when a sidecar exists** |
+| Apple notarization service | signed DMG | currently **not enabled**; DMGs are ad-hoc signed and Gatekeeper blocks them on macOS 26+ |
+| Homebrew tap (`Formula/`) | `brew install netllm` | — |
+
+## Upstream inference servers (runtime, not build)
+
+| Provider | Default ports probed | API | Notes |
+|----------|---------------------|-----|-------|
+| oMLX (Apple Silicon) | 8080, 8088, 8081 | OpenAI-compatible + `/admin` API | only provider with deep telemetry integration; default key `omlx-local` |
+| Ollama | 11434 | OpenAI-compatible | honours `OLLAMA_HOST` |
+| LM Studio | 1234, 41334 | OpenAI-compatible | may require an API key |
+| vLLM | 8000, 8001 | OpenAI-compatible | |
+| custom | `discovery.custom_endpoints`, `[[routing.backends]]` | OpenAI or Anthropic | |
+
+Per-provider env overrides: `OMLX_PORT`, `OLLAMA_PORT`/`OLLAMA_HOST`, `LMSTUDIO_PORT`,
+`VLLM_PORT`; keys via `OMLX_API_KEY`, `OLLAMA_API_KEY`, `LMSTUDIO_API_KEY`, `VLLM_API_KEY`.
+
+## Cloud provider registry (code-owned reference data)
+
+| id | Auth modes | Default format | Live `/models`? | Caveat recorded in-code |
+|----|-----------|----------------|-----------------|------------------------|
+| `moonshot` | api_key | openai | yes | PAYG keys only |
+| `zai` | api_key | openai | **no** (static catalog) | Coding Plan keys are contractually restricted to an approved-tools list — using them from a generic router may be outside that policy |
+| `openai` | api_key | openai | yes | no public OAuth for third-party tools |
+| `anthropic` | api_key, plan_token | anthropic | yes | `plan_token` (from `claude setup-token`) is documented for Claude Code CI only — unofficial for third-party routers |
+| `openrouter` | api_key, oauth_pkce | openai | yes | the only sanctioned third-party OAuth |
+
+The registry is honest about the two policy-sensitive modes, and both are opt-in.
+`static_models` entries (e.g. `kimi-k3`, `glm-5.2`, `gpt-5.6`, `claude-opus-4-7`) are
+hand-maintained code constants and will drift — the live probe is preferred wherever the
+provider offers one (F-21).
+
+## Supply-chain surface summary
+
+| Vector | Exposure | Mitigation in place |
+|--------|----------|--------------------|
+| Python deps | 86 packages, `uv.lock` committed, `--frozen` in CI | good |
+| Vendor SDK majors | floors far below resolved versions | lock only — F-12 |
+| `zeroconf` | listens on UDP 5353, parses untrusted multicast | wrapped in try/except; failure degrades to static peers |
+| GitHub update JSON | parsed into `ReleaseAsset` | download URLs come from the API response and are not host-validated |
+| DMG/zip integrity | SHA256 sidecar | verified **only when present**; absent sidecar silently skips verification |
+| Local provider probes | `verify=False` on the shared scan client | applies to *all* scanned URLs including remote HTTPS overrides — F-05 |

--- a/docs/architecture/07-findings-register.md
+++ b/docs/architecture/07-findings-register.md
@@ -1,0 +1,737 @@
+# 07 · Findings register
+
+29 findings from a source-level audit of `main` @ `a3ec16a` (release 0.4.5.0), 2026-07-29.
+Four were reproduced with executable scripts; the rest carry `file:line` evidence.
+
+**Baseline health is good.** `uv run pytest -q` → **584 passed** in 50 s. Lint is clean.
+The SDK isolation boundary holds. The routing hardening work described in
+`docs/routing-hardening-plan.md` is genuinely implemented, and the failover, capacity-error
+classification, and mesh loop guards are better than typical for a project this size.
+Nothing below contradicts that; these are the remaining edges.
+
+## Severity summary
+
+| Severity | Count | Theme |
+|----------|-------|-------|
+| **S1** — production-affecting correctness or security | 4 | silent config data loss, a bypassed security guard, event-loop blocking, credential reuse across callers |
+| **S2** — real user-visible defect or meaningful risk | 12 | restart-required config, TLS off, billable probes, races, IPv6 crash, LAN exposure, log growth |
+| **S3** — maintenance, clarity, latent risk | 13 | dead code, duplicated logic, CI gate gaps, packaging limits |
+
+## Recommended order of work
+
+```mermaid
+flowchart LR
+    W1["Sprint 1 — S1<br/>F-01 F-02 F-03 F-04"] --> W2["Sprint 2 — S2 correctness<br/>F-05 F-06 F-07 F-08 F-09 F-11"]
+    W2 --> W3["Sprint 3 — S2 exposure<br/>F-10 F-12 F-13 F-14 F-15 F-16"]
+    W3 --> W4["Backlog — S3<br/>F-17…F-29 (bundle with the<br/>service.py decomposition)"]
+```
+
+---
+
+# S1 — production-affecting
+
+## F-01 · Saving config silently drops three fields
+
+**Severity** S1 · **Area** configuration integrity · **Reproduced**
+
+`config_merge._merge_backends()` rebuilds each `[[routing.backends]]` entry from an explicit
+field list that omits `max_concurrency` and `cloud_provider`.
+`config_merge._merge_policies()` rebuilds each `[[routing.policies]]` entry from a list that
+omits `source`.
+
+- `packages/netllm-core/src/netllm_core/config_merge.py:60` (`_merge_backends`)
+- `packages/netllm-core/src/netllm_core/config_merge.py:86` (`_merge_policies`)
+
+Both write paths — the web dashboard and the macOS Settings app — go through this module,
+so **any** save that touches `routing.backends` or `routing.policies` silently resets those
+fields, even if the user never edited them.
+
+**Reproduction (run and confirmed):**
+
+```python
+cfg.routing.backends = [BackendOverride(base_url="http://x:1/v1", provider="vllm", max_concurrency=4)]
+cfg.routing.policies = [RoutingPolicy(name="p1", source="buzz", model_prefix="glm", allow_cloud=True)]
+out = apply_config_patch(cfg, {"routing": {"backends": [...], "policies": [...]}})
+# backend max_concurrency after save: 0   (was 4)
+# policy.source after save: ''            (was 'buzz')
+```
+
+**Why it matters beyond data loss:** `RoutingPolicy.source` scopes a policy to one caller.
+Dropping it converts a policy written as *"the `buzz` harness may reach cloud"* into
+*"**everyone** may reach cloud"* — a silent privilege widening triggered by an unrelated save.
+
+**Fix.** Add the missing keys to both field lists, and add a regression test that asserts
+`set(merged.keys()) == set(Model.model_fields)` for `BackendOverride` and `RoutingPolicy`, so
+the next field addition cannot reintroduce the class of bug. `_merge_sources` and
+`_merge_cloud_providers` already use an explicit tuple + `prior.model_dump()` base — copy that
+shape rather than the hand-built dict.
+
+---
+
+## F-02 · Elevated-source secret enforcement is bypassed by the macOS app and CLI
+
+**Severity** S1 · **Area** security · **Reproduced**
+
+`admin._validate_elevated_sources()` refuses to save a `routing.sources` entry that grants
+elevated capability (`allow_cloud`, `cloud_providers`, or `max_concurrency` above the global
+cap) without a `secret`/`secret_env` when `agent.listen` is LAN-reachable.
+
+- Guard: `packages/netllm-agent/src/netllm_agent/admin.py:334`
+- Called only from: `packages/netllm-agent/src/netllm_agent/admin.py:324` (HTTP path)
+- Bypassing path: `packages/netllm-cli/src/netllm_cli/config_json.py:19` (`import_config`)
+
+The macOS Settings **Save** button and `netllm config import` call
+`config_merge.apply_config_patch()` directly and never run the guard.
+
+**Reproduction (run and confirmed)** — LAN-bound config, save via the CLI path:
+
+```
+CLI path saved elevated source with no secret: evil allow_cloud=True secret=''
+is_elevated: True
+```
+
+**Impact.** On a LAN-bound agent, any host that can send `x-netllm-source: evil` (or the bare
+virtual key `netllm-evil`) then inherits that source's cloud access and concurrency
+allowance. `source_identity.resolve_source()` is attributive by design: with no secret
+configured, *any* matching signal wins the identity. The whole point of the guard is to make
+sure identity spoofing can only ever win cheap local routing.
+
+The same path also skips `_filter_own_swarm_peers()`, so the macOS app can persist a
+self-referential peer URL that the dashboard would have rejected.
+
+**Fix.** Move both post-merge guards out of `admin.py` into `config_merge` (or a new
+`config_guards` module) and call them from every writer. Raise a domain exception that
+`admin.py` maps to HTTP 400 and the CLI maps to a non-zero exit with a readable message —
+`config_merge` must not import `fastapi.HTTPException`.
+
+---
+
+## F-03 · Synchronous health probes run on the event loop on every request
+
+**Severity** S1 · **Area** performance / concurrency
+
+`AgentService._update_health_metrics()` iterates every backend calling
+`RouterPool.is_healthy()`, which issues **blocking** `httpx.Client` calls
+(`probe_openai_compat_sync` / `probe_anthropic_compat_sync`) whenever a cache entry is stale.
+
+- `packages/netllm-agent/src/netllm_agent/service.py:315` (`_update_health_metrics`)
+- called from `service.py:241` (`refresh_local_backends`, awaited by **every** proxy entry point)
+- and again in the `finally` of every attempt: `service.py:1032`, `1138`, `1285`, `1625`, `1852`
+- blocking call site: `packages/netllm-core/src/netllm_core/pool.py:290-294`
+
+The codebase already recognises the hazard and guards *selection* with
+`_offload_if_probing()` → `pool.any_health_stale()` (`service.py:920`). But
+`_update_health_metrics` bypasses that guard entirely, so with a 5 s probe timeout a single
+unresponsive backend stalls the entire ASGI loop — every concurrent request, the dashboard,
+the heartbeat loop, and `/health`.
+
+There is a second-order effect: because `_update_health_metrics` refreshes all cache entries
+first, `any_health_stale()` is usually `False` by the time selection runs, so the
+`_offload_if_probing` optimisation almost never fires. The offload was defeated by the
+metrics update.
+
+**Fix.** Wrap the whole loop in `asyncio.to_thread`, or better: make `_update_health_metrics`
+read-only (report the cached `_health_cache` state, never probe) and let probing happen only
+in the already-offloaded selection path. The metrics gauge does not need probe freshness —
+it needs the router's current belief.
+
+---
+
+## F-04 · A caller's cloud API key becomes a shared pool credential
+
+**Severity** S1 · **Area** security / billing
+
+`_inject_openai_cloud_backend()` and `_inject_anthropic_cloud_backend()` take the API key
+from the **incoming request's** `Authorization` / `x-api-key` header and merge a cloud
+`Backend` row carrying that key into the long-lived pool.
+
+- `packages/netllm-agent/src/netllm_agent/service.py:1318` (`_inject_anthropic_cloud_backend`)
+- `packages/netllm-agent/src/netllm_agent/service.py:1341` (`_inject_openai_cloud_backend`)
+- caller key extraction: `service.py:1291-1308`
+
+Both are idempotent by *existence*, not by key:
+
+```python
+if any(b.api_format == "anthropic" for b in self.pool.backends):
+    return                       # first key in wins, and stays
+```
+
+So the first caller to present a real vendor key seeds a routable backend. Every subsequent
+request from **any other client on the LAN** can be routed to `openai-cloud` /
+`anthropic-cloud` and billed to that first caller's account. The row survives until the
+provider is disabled or the process restarts; `prune_cloud_provider_rows` explicitly keeps
+the legacy ids alive (`service.py:1463`).
+
+The Anthropic variant is broader still: the guard is "any anthropic-format backend exists",
+so a locally-configured Anthropic-format backend suppresses the inject entirely, and vice
+versa.
+
+**Impact scales with the deployment.** On a single-user loopback install this is harmless.
+On the LAN-swarm topology the product actively promotes, it is cross-tenant credential reuse.
+
+**Fix.** Either (a) scope caller-supplied keys to the single request — build a throwaway
+`OpenAIUpstream`/`AnthropicUpstream` for that request instead of a pool row, or (b) retire
+the legacy inject path entirely in favour of the registry-driven
+`_materialize_cloud_provider_backends()` (which uses *configured* keys, not caller keys) and
+document the migration. Option (b) also resolves half of F-25.
+
+---
+
+# S2 — real defects and meaningful risk
+
+## F-05 · Changed `max_concurrency` never reaches an existing pool row
+
+**Severity** S2 · **Area** configuration / routing
+
+`RouterPool.merge_backends()` updates existing local rows **in place** (correctly — in-flight
+requests hold the object reference), but the field list it copies omits `max_concurrency` and
+`cloud_provider`:
+
+- `packages/netllm-core/src/netllm_core/pool.py:126-134`
+
+So editing a backend's concurrency cap has no effect until the process restarts, even though
+`apply_config()` invalidates the scan cache and the dashboard reports a successful hot-apply.
+Combined with **F-01** (the value is dropped on save anyway), `BackendOverride.max_concurrency`
+is currently unusable end to end.
+
+**Fix.** Add both fields to the in-place update block; fix F-01 in the same change; add a test
+that sets a cap through `apply_config` and asserts the live pool row reflects it.
+
+---
+
+## F-06 · TLS verification is disabled for every discovery probe
+
+**Severity** S2 · **Area** security
+
+```python
+def loopback_async_client(**kwargs) -> httpx.AsyncClient:
+    return httpx.AsyncClient(verify=False, **kwargs)
+```
+
+- `packages/netllm-discovery/src/netllm_discovery/local.py:30`
+
+The docstring justifies it as "bundled macOS Python may lack CA bundle" for *localhost*
+probes — a reasonable motivation. But the same client is used in `scan_local_providers()` for
+`discovery.custom_endpoints` and every `[[routing.backends]]` override
+(`local.py:254-274`), which may be arbitrary remote `https://` URLs. Health responses feed the
+model catalog that drives routing, so a MITM on a remote custom endpoint can influence which
+backend is selected.
+
+**Fix.** Split the clients: `verify=False` only when the resolved host is loopback; a normal
+verifying client otherwise. `is_loopback_url()` already exists in `netllm_discovery.lan`.
+
+---
+
+## F-07 · Anthropic health probes are billable API calls with a hardcoded model
+
+**Severity** S2 · **Area** cost / correctness
+
+`probe_anthropic_compat_sync()` and its async twin POST a real Messages request
+(`max_tokens: 1`, `"hi"`) against a hardcoded `claude-3-5-haiku-20241022`:
+
+- `packages/netllm-core/src/netllm_core/health.py:188` and `:212`
+
+This runs through `RouterPool.is_healthy()` for any `api_format == "anthropic"` backend —
+including the materialised `cloud-anthropic` row — every `routing.health_ttl_s` (30 s default),
+and via F-03 on the request path. That is a paid API call roughly every 30 seconds for the
+lifetime of the agent, plus a hard dependency on one model id remaining available on every
+Anthropic-compatible provider (Moonshot's and Z.ai's Anthropic endpoints will not serve it).
+
+**Fix.** Probe `GET /v1/models` with `x-api-key` first (Anthropic and OpenRouter both support
+it — `cloud_provider_models_probe` already does exactly this at `service.py:1523`) and fall
+back to the message probe only when the provider has no catalog endpoint. If the message
+probe must stay, take the model from `backend.health.models` or the provider spec's
+`static_models` rather than a constant.
+
+---
+
+## F-08 · Per-source concurrency cap is check-then-act across an await
+
+**Severity** S2 · **Area** concurrency
+
+```
+_check_source_capacity(source_id, source_cfg)   # reads _source_in_flight
+...
+await self.refresh_local_backends()             # ← await point
+...
+self._source_acquire(resolved_source.id)        # increments
+```
+
+- check: `packages/netllm-agent/src/netllm_agent/service.py:766`
+- call sites: `service.py:954`, `1064`, `1207`, `1656`, `1759`
+- acquire: `service.py:778`, called inside the attempt loop
+
+Because the check happens once before an `await`, N concurrent requests for the same source
+can all observe `in_flight < cap` and all proceed. The cap is advisory under exactly the load
+it exists to bound.
+
+**Fix.** Check-and-increment atomically before the first await (a small helper that raises
+`SourceCapacityExceeded` and otherwise increments), and release once per request rather than
+once per attempt. Note the current code also acquires/releases per *attempt*, so a retrying
+request briefly counts as one, then zero, then one again.
+
+---
+
+## F-09 · All-time telemetry is written to disk synchronously on every request
+
+**Severity** S2 · **Area** performance
+
+`TelemetryService.record_usage()` calls `_save_alltime()` on every call, which does
+`mkdir` + `json.dumps` + `write_text` to `~/.config/netllm/stats.json` — synchronously, on the
+event loop, once per completed request.
+
+- `packages/netllm-agent/src/netllm_agent/telemetry.py:156` (call) and `:120` (write)
+
+**Fix.** Debounce: persist at most every N seconds or every N requests, plus a final flush in
+`TelemetryService.close()` (which is already wired into the FastAPI lifespan shutdown).
+
+---
+
+## F-10 · `psutil` is used but never declared — host telemetry is always empty
+
+**Severity** S2 · **Area** dependency / feature completeness
+
+`TelemetryService._host_block()` imports `psutil` inside a `try/except ImportError` and
+returns `None` on failure.
+
+- `packages/netllm-agent/src/netllm_agent/telemetry.py:248`
+
+`psutil` appears in **no** `pyproject.toml` and **not** in `uv.lock`. `packages/netllm-agent/AGENTS.md`
+documents it as "optional psutil host block on Linux when installed" — but nothing in any
+install channel installs it, so the `host` block of `GET /netllm/v1/telemetry` is `null` on
+every shipped build. The macOS app is unaffected (it has its own `HostSampler.swift`); the
+**web dashboard on Linux and Windows** is the surface that silently loses the feature.
+
+**Fix.** Either declare `psutil` as a real dependency of `netllm-agent` (it is small,
+pure-ish, and widely deployed) or as a documented `netllm-agent[host-metrics]` extra that the
+Linux/Windows packages install — then say so in the docs. Leaving it undeclared means the
+feature ships dead.
+
+---
+
+## F-11 · A bracketed IPv6 `agent.listen` passes validation, then crashes `serve`
+
+**Severity** S2 · **Area** correctness · **Reproduced**
+
+`AgentConfig._validate_listen()` explicitly accepts bracketed IPv6 (`[::]:11400`):
+
+- `packages/netllm-core/src/netllm_core/models.py:340-361`
+
+But `serve` parses it with `partition(":")`:
+
+```python
+host_part, _, port_part = cfg.agent.listen.partition(":")   # main.py:1146
+uvicorn.run(fastapi_app, host=host_part or "127.0.0.1", port=int(port_part or 11400))
+```
+
+For `"[::]:11400"` that yields `host_part = "["`, `port_part = ":]:11400"`, and
+`int(":]:11400")` raises `ValueError` — the agent fails to start with a raw traceback.
+
+**Reproduction (run and confirmed):**
+
+```
+serve partition -> '[' ':]:11400'
+PORT PARSE FAILS: invalid literal for int() with base 10: ':]:11400'
+```
+
+Two more sites share the flaw: the `--host`/`--port` override at `main.py:974-975`
+(`listen.split(":")[0]`), and `lan.agent_url_from_listen()` (`lan.py:86`), which happens to
+produce a correct-looking string by accident while never extracting the port.
+
+**Fix.** There is already a correct helper — `netllm_cli.main._listen_port_of()`
+(`main.py:150`), which is IPv6-aware. Promote it (and a matching `_listen_host_of`) into
+`netllm_core.models` next to the validator, and use it at all three sites. Add a test case for
+`[::]:11400` and `[::1]:11400`.
+
+---
+
+## F-12 · Heartbeats are sent sequentially and awaited one at a time
+
+**Severity** S2 · **Area** scalability
+
+```python
+for peer in list(self.peers.values()):
+    await self.send_heartbeat(payload, peer.listen_url)     # 5 s timeout each
+```
+
+- `packages/netllm-discovery/src/netllm_discovery/swarm.py:197-200`
+- `refresh_static_peers()` at `swarm.py:179` has the same shape
+
+With a 10 s interval and a 5 s per-peer timeout, three unreachable peers push the effective
+heartbeat cycle past 15 s — beyond the 45 s stale window after four such cycles, so healthy
+peers can be pruned because a *different* peer is down.
+
+**Fix.** `asyncio.gather` the heartbeat fan-out (and the static-peer refresh) with a bounded
+semaphore, mirroring the pattern `subnet_scan_agents` already uses (`lan.py:214`).
+
+---
+
+## F-13 · `/netllm/v1/status` and `/netllm/v1/telemetry` are unauthenticated
+
+**Severity** S2 · **Area** security / information disclosure
+
+Both routes are registered with no gate:
+
+- `packages/netllm-agent/src/netllm_agent/app.py:137` (`netllm_status`)
+- `app.py:163` (`netllm_telemetry`)
+- also ungated: `/netllm/v1/peers` (`:184`), `/netllm/v1/backends` (`:188`),
+  `/netllm/v1/client-env` (`:273`)
+
+On a LAN-bound agent, any host on the network gets: every backend base URL, the full model
+catalog per backend, hostnames, agent ids, the peer list with versions and strategies,
+per-backend routed counts and in-flight load, token totals, and whether a cluster token is
+set. That is complete fleet reconnaissance, and `routed_requests`/token counters leak usage
+patterns.
+
+`status` genuinely must stay reachable — `SwarmRegistry.fetch_peer()` and the subnet scan both
+GET it, though **both already send the cluster token** when one is configured
+(`swarm.py:147`, `lan.py:119`).
+
+**Fix.** Gate `status`, `peers`, `backends`, and `telemetry` with the same optional-token check
+the heartbeat uses: when `swarm.cluster_token` is set, require it from non-local clients.
+Peer-to-peer discovery keeps working unchanged because peers already authenticate. Keep them
+open when no token is configured, preserving today's zero-config behaviour.
+
+---
+
+## F-14 · A cluster token does not protect inference
+
+**Severity** S2 · **Area** security UX
+
+Three independent gates exist and are easy to conflate:
+
+| | gates | default |
+|---|---|---|
+| `swarm.cluster_token` | heartbeat ingress + *remote admin* auth | unset |
+| `swarm.require_token_for_inference` | `/v1/*` for non-local clients | **false** |
+| `local_admin_client_hosts()` | admin routes | always |
+
+- `packages/netllm-agent/src/netllm_agent/app.py:62-85` (`require_inference_access`)
+
+So `netllm init --swarm --secure` — which a user reasonably reads as "the secure option" —
+generates a token, secures gossip and remote admin, and still leaves
+`POST /v1/chat/completions` open to the entire LAN. Nothing in the `--secure` flow sets
+`require_token_for_inference`.
+
+`doctor` notes the open case and `serve` warns, but the warning fires on the *no-token* path,
+not on the token-but-open-inference path.
+
+**Fix (product decision, not just code).** Make `--secure` set
+`require_token_for_inference = true`, and have `netllm join` configure joining clients
+accordingly (peers already forward the token via `_upstream_api_key`). At minimum, add a
+doctor issue for "cluster token set but inference is open" so the state is visible.
+
+---
+
+## F-15 · `agent.log` grows without bound
+
+**Severity** S2 · **Area** operations
+
+`serve` attaches a plain `logging.FileHandler` to the uvicorn loggers:
+
+- `packages/netllm-cli/src/netllm_cli/main.py:1138`
+
+No `RotatingFileHandler`, no size cap, no retention — and the file is the one
+`GET /netllm/v1/logs` tails and the one every troubleshooting doc points users at. A
+long-running agent with per-request warnings (a flapping backend, the `shardless_fallbacks`
+warning path) will grow it indefinitely. macOS app installs also write `app.log` under
+`~/Library/Application Support/netllm/logs/`.
+
+**Fix.** `RotatingFileHandler(maxBytes=10*1024*1024, backupCount=3)`. One line, and
+`tail_log_file()` already handles arbitrary file sizes correctly via reverse block reads.
+
+---
+
+## F-16 · Vendor SDK floor pins sit a major version below what ships
+
+**Severity** S2 · **Area** dependency risk
+
+| Package | Declared floor | Resolved in `uv.lock` |
+|---------|---------------|----------------------|
+| `openai` | `>=1.60` | **2.41.0** |
+| `anthropic` | `>=0.45` | **0.106.0** |
+
+- `packages/netllm-sdk-openai/pyproject.toml`, `packages/netllm-sdk-anthropic/pyproject.toml`
+- documented as current in `docs/sdk-versions.md`, "last validated 2026-06-08"
+
+The lock protects this repo and CI. It does **not** protect anyone who installs
+`netllm-sdk-openai` from an index, or a downstream resolver that re-resolves — those can land
+on `openai==1.x`, which the adapter has not been tested against since the 2.x migration.
+
+**Fix.** Raise the floors to the tested major (`openai>=2.0`, `anthropic>=0.100`) and add an
+upper bound on the next major (`<3`, `<1`) so a silent major bump can't reach an untested
+adapter. The `sdk-canary.yml` workflow already exists to catch upstream drift deliberately;
+floors should encode what is *supported*, not what once worked.
+
+---
+
+# S3 — maintenance, clarity, latent risk
+
+## F-17 · `require_same_model_for_shard` is dead, and the docs say otherwise
+
+`RoutingConfig.require_same_model_for_shard` is documented in-code as *"Deprecated: only
+consumed by the removed batch planner"* (`models.py:272-273`) — yet it is still exported by
+`config_summary()` (`admin.py:277`), rendered in `dashboard.js`, modelled in
+`NetllmConfigDocument.swift`, and shown in `SettingsWindowView.swift`. Meanwhile
+`docs/routing-hardening-plan.md` claims it "is now actually wired into `plan_batch_shard`
+(was a fully-plumbed no-op toggle)" — the opposite of the truth after `plan_batch_shard` was
+deleted in Phase 2.
+
+**Fix.** Remove the field from all four surfaces (keep it accepted-and-ignored in the model
+for one release so old configs still load), and correct the plan doc so it stops asserting a
+removed behaviour.
+
+---
+
+## F-18 · Orphaned code inventory
+
+Verified with repo-wide greps that include the test suites:
+
+| Symbol | Location | Status |
+|--------|----------|--------|
+| `OpenAIUpstream.list_models()` | `netllm_sdk_openai/client.py:50` | zero callers anywhere, including tests |
+| `OpenAIUpstream.chat_completion_sync()` | `client.py:82` | zero callers |
+| `OpenAIUpstream.embeddings_sync()` | `client.py:96` | zero callers |
+| `BatchRequestLedger.completed` / `mark_done()` | `netllm_agent/shard.py:34,77` | written on every shard success, **never read** |
+| `update.cleanup_cache()` | `netllm_core/update.py:250` | no production caller (the Swift `UpdateController` does its own cache management) |
+| `update.verify_sha256()` | `update.py:245` | tests only (`UpdateController.verifySHA256` is the shipping implementation) |
+| `known_harnesses.CUSTOM_SENTINEL_ID` | `known_harnesses.py:16` | defined and documented, referenced nowhere |
+| `mdns = []` optional extra | `pyproject.toml:16`, `netllm-agent/pyproject.toml`, `netllm-discovery/pyproject.toml` | self-described no-op backwards-compat alias, ×3 |
+| `pydantic-settings` | declared by `netllm-core` | no `pydantic_settings` import in any first-party module — see F-19 |
+| `netllm_core/config.py` | 41 lines | pure re-export of `models.py`; both are imported across the codebase, so there are two names for one module |
+
+The `completed` set is the interesting one: `BatchRequestLedger` tracks which shards finished
+but nothing consumes it, so a retried batch cannot distinguish "not yet assigned" from
+"already succeeded". Either wire it into `reassign_failed`/`assign` or delete it.
+
+**Fix.** Delete the unreferenced symbols; keep `verify_sha256` only if the Python update path
+is intended to grow an installer (say so in a comment); collapse `config.py` into `models.py`
+with a deprecation shim.
+
+---
+
+## F-19 · `pydantic-settings` is declared but never imported
+
+`netllm-core/pyproject.toml` lists `pydantic-settings>=2.6`. No first-party module imports
+`pydantic_settings` or subclasses `BaseSettings`. It ships in the macOS bundle, in every deb/rpm,
+and in the Windows zip for nothing.
+
+**Fix.** Remove the dependency, or adopt it for the env-var handling that is currently done
+by hand (`OMLX_PORT`, `OLLAMA_HOST`, `LMSTUDIO_API_KEY`, … are read with bare `os.environ.get`
+in at least four modules — that scattered env access is itself worth consolidating).
+
+---
+
+## F-20 · `local_admin_client_hosts()` is wider than "this machine"
+
+`platform.local_admin_client_hosts()` (`platform.py:26-49`) seeds the admin allowlist with
+loopback plus **every** address `getaddrinfo(gethostname())` returns and the interface address
+from a `connect(("8.8.8.8", 80))` probe, then caches it for the process lifetime.
+
+Two consequences: on a host whose name resolves to a shared or wildcard DNS record the set can
+include addresses that are not exclusively ours; and because it is computed once, a DHCP
+change or interface switch leaves the agent trusting a stale address while failing to trust the
+new one. `"testclient"` (the FastAPI TestClient sentinel) is also permanently in the set — it
+cannot be reached over TCP, but it is a test hook in a production security predicate.
+
+**Fix.** Compare against the actual bound socket's local addresses, or restrict to loopback
+plus explicitly configured addresses. If the broad set stays, recompute it on a TTL and drop
+`"testclient"` behind a test-only injection.
+
+---
+
+## F-21 · The config schema mirror is reduced, not eliminated
+
+`config_schema.py` was built to end the Python ↔ Swift ↔ JS triple-mirror, and it works — but
+only the `ui` section is schema-driven in the macOS app, and `routing`'s non-`model_pools`
+fields plus all of `cloud` remain hand-typed Swift structs (documented in
+`config-schema-rewrite-plan.md` §4/§5). `dashboard.js` (2,721 lines) still carries
+hand-written renderers alongside the generic one.
+
+The practical cost is visible in F-01 and F-17: fields exist in Python that no client can edit,
+and fields exist in clients that Python has deprecated.
+
+**Fix.** Finish the migration section by section, and add a drift test that asserts every
+`NetllmConfig` field is either schema-rendered or explicitly listed in a
+`KNOWN_UNRENDERED` allowlist — so adding a Python field forces a conscious client decision.
+`tests/test_config_schema.py` is the right home.
+
+---
+
+## F-22 · Timing constants are inconsistently configurable
+
+Configurable: `heartbeat_interval_s`, `peer_stale_after_s`, `rediscover_interval_s`,
+`health_ttl_s`, `offline_retry_s`, `max_backend_failures`.
+
+Hardcoded: local scan TTL 10 s (`service.py:145`), harness PATH cache 300 s
+(`harness_detection.py:23`), GitHub release cache 900 s (`update.py:29`), peer HTTP timeout
+5 s (`swarm.py:149,173`), subnet probe timeout 1.5 s (`lan.py:143`), upstream connect/read
+5 s/120 s (both SDK adapters), `MAX_FORWARD_HOPS = 2` (`models.py:51`), ledger cap 8192
+(`shard.py:29`), upstream client cache cap 64 (`service.py:674`).
+
+The upstream **read timeout of 120 s** is the one most likely to bite: a large local model
+doing a long generation on a slow host will be cut off, and there is no way to raise it
+without editing source.
+
+**Fix.** Promote at least the upstream timeouts and the local-scan TTL into `[routing]`; leave
+the rest but move them into one named-constants block per module so they are discoverable.
+
+---
+
+## F-23 · Heartbeats ship full catalogs on an N×N mesh
+
+`SwarmRegistry.gossip_loop` sends the complete `status_payload()` — every backend row with its
+full `health.models` list — to every peer, every interval. With N agents that is N×(N−1)
+full-catalog POSTs per interval. A host serving 40 models produces a multi-kilobyte payload
+each time, and nothing dedupes or delta-encodes it.
+
+Related: `cloud_providers.py` `static_models` tuples are hand-maintained code constants
+(`kimi-k3`, `glm-5.2`, `gpt-5.6`, `claude-opus-4-7`) that will silently go stale; only Z.ai
+genuinely lacks a live `/models` endpoint.
+
+**Fix.** Send a catalog hash in the heartbeat and let the receiver fetch the full catalog only
+on change. For the static lists, add a dated comment and a CI reminder, or drop them to
+"last-known" hints that the live probe always overrides.
+
+---
+
+## F-24 · Four near-identical proxy loops in `service.py`
+
+`proxy_chat_completion`, `proxy_chat_completion_stream`, `proxy_embeddings`, and
+`proxy_messages`/`proxy_messages_stream` each reimplement the same ~70-line sequence:
+attribute source → classify scenario → rewrite model → resolve routing → check capacity →
+refresh backends → cloud inject → `while attempt < max_attempts` → select → acquire → call →
+account → release. Roughly 400 lines of near-duplicate control flow.
+
+Every fix in this register that touches the request path (F-03, F-08) has to be applied four
+times, and divergence has already happened: `proxy_chat_completion_stream` does **not** call
+`_mark_backend_failure` in its own except block (it relies on `_stream_with_metrics` doing it),
+while `proxy_messages_stream` calls it directly.
+
+**Fix.** Extract a `_RequestPlan` (source, scenario, model, routing, shard) built once, and a
+generic `_run_with_failover(plan, invoke)` that takes an async callable. The four public
+methods become thin wrappers. This is the single highest-leverage refactor in the repo.
+
+---
+
+## F-25 · Overlapping mechanisms doing the same job
+
+| Overlap | Members | Direction |
+|---------|---------|-----------|
+| Model-name resolution | `model_aliases`, `model_pools`, `sources[].model_rewrites`, `sources[].scenarios[].model` — and a planned `model_groups` | `routing-hardening-plan.md` §Phase 4 already states `model_pools` should fold into `model_groups` rather than coexist |
+| Cloud backend injection | legacy env/caller-key inject (`openai-cloud`, `anthropic-cloud`) **and** registry materialisation (`cloud-<id>`) | retire the legacy path (also fixes F-04) |
+| Config module naming | `netllm_core.config` (re-export) and `netllm_core.models` | collapse |
+| Install detection | `netllm_core.install_detect` and `netllm_cli.install_detect` (pure re-export) | collapse |
+| Routing precedence | globals → policies → source → scenario → headers, five layers that can each set `strategy`/`local_only`/`allow_cloud` | document a single precedence table in the config reference; the logic is correct but only discoverable by reading `resolve_routing` |
+
+**Fix.** Each is small individually; sequence them behind F-24 so the refactor lands once.
+
+---
+
+## F-26 · Two 2 kLOC modules concentrate the complexity
+
+`netllm_agent/service.py` (2,149 lines, 9 distinct responsibilities — see
+[02](02-component-architecture.md)) and `netllm_cli/main.py` (2,119 lines, 24 commands plus
+3 sub-apps in one file). Between them they host 11 of the 29 findings here.
+
+**Fix.** `service.py` → `service/` package: `backends.py` (refresh, prune, cloud
+materialisation), `policy.py` (source/scenario/routing resolution), `proxy.py` (the generic
+failover loop from F-24), `swarm_tasks.py` (mDNS, rediscovery, subnet), `status.py`.
+`main.py` → `commands/` package, one module per command group, `main.py` keeps only the Typer
+wiring. Both are mechanical moves with the existing 584-test suite as the safety net.
+
+---
+
+## F-27 · CI gate gaps
+
+| Gap | Evidence |
+|-----|----------|
+| `basedpyright` is configured (`pyproject.toml [tool.basedpyright]`, dev dependency) but **never invoked** by `scripts/ci.sh` or any workflow | `scripts/ci.sh:22-26` |
+| `ruff` runs only on `packages/` and `tests/` — `scripts/`, `packaging/build.py`, and `src/` are unlinted despite a repo-wide `[tool.ruff]` config | `scripts/ci.sh:23-24` |
+| No Swift lint or format check for ~7.5 kLOC of SwiftUI | `docs/lint-index.md` confirms: "no SwiftLint, ESLint, or Biome config" |
+| No JS/CSS lint for 3.4 kLOC of dashboard | same |
+| No coverage measurement or threshold | — |
+| macOS packaging is only exercised by the full `menubar-lifecycle` build, with no fast smoke equivalent to the Linux/Windows jobs | `.github/workflows/ci.yml` |
+
+Type-annotation drift that a type-check gate would catch: `SwarmRegistry.all_peer_urls()` is
+annotated `list[dict[str, str]]` but returns `last_seen` as a `float`
+(`swarm.py:223-235`).
+
+**Fix.** Add `uv run basedpyright` as a non-blocking CI job first (to size the backlog), then
+promote it to blocking. Widen the ruff paths to `.` — `[tool.ruff] extend-exclude` already
+handles the coordinator files deterministically, which was the original reason for the narrow
+scope. Add `swift format --lint` on the macOS job.
+
+---
+
+## F-28 · Packaging and platform limits worth stating explicitly
+
+- **macOS artifacts are arm64-only.** `packaging/venvstacks.toml` declares
+  `platforms = ["macosx_arm64"]` and a matching `[tool.uv] environments` marker. There is no
+  Intel-Mac path, and no error message tells an Intel user that.
+- **DMGs are ad-hoc signed.** Gatekeeper blocks them on macOS 26+; the documented workaround
+  is build-from-source. `docs/macos-code-signing.md` has the full enablement procedure ready —
+  it is a credentials/process task, not an engineering one.
+- **SHA256 verification is conditional.** Both the Python helper and the Swift
+  `UpdateController` verify only when a `.sha256` / `SHA256SUMS` sidecar exists
+  (`UpdateController.swift:318`); a release published without sidecars silently downgrades to
+  size-only checking.
+- **The subnet scan looks like a port scan.** 64-way concurrent `GET /health` across an entire
+  /24 will trip IDS on corporate networks. It is off by default and only auto-enabled on LAN
+  binds, but deployment docs should say so plainly.
+- **`packaging/_build/`, `packaging/_export/`, and `apps/netllm-mac/build/` are large build
+  trees in the working directory.** Correctly gitignored; worth a `make clean` equivalent.
+
+---
+
+## F-29 · oMLX-specific logic lives in the generic discovery package
+
+`netllm_discovery/local.py` is 610 lines, of which roughly 280 are oMLX admin/telemetry
+probing: `omlx_admin_url`, `_best_omlx_base_url`, `probe_omlx_admin`,
+`_normalize_omlx_admin_payload`, `_normalize_omlx_stats_scope`, `_normalize_omlx_stats_payload`,
+`_normalize_omlx_activity_payload`, `probe_omlx_telemetry`. `AgentService.status_payload()` and
+`TelemetryService` both reach into it.
+
+No other provider has an equivalent, so the abstraction is "generic discovery + one special
+case". That is a legitimate product choice (oMLX is the flagship macOS backend), but it should
+be named as such rather than hidden inside a package called `discovery`.
+
+**Fix.** Move it to `netllm_discovery/providers/omlx.py` (or a `netllm-provider-omlx` package)
+behind a small "provider extras" interface, so adding equivalent depth for Ollama or vLLM later
+has an obvious shape.
+
+---
+
+## Traceability matrix
+
+| ID | Severity | Primary file | Repro'd | Fix size |
+|----|----------|--------------|---------|----------|
+| F-01 | S1 | `config_merge.py:60,86` | ✅ | S |
+| F-02 | S1 | `admin.py:334` / `config_json.py:19` | ✅ | M |
+| F-03 | S1 | `service.py:315` | — | M |
+| F-04 | S1 | `service.py:1318,1341` | — | M |
+| F-05 | S2 | `pool.py:126` | — | S |
+| F-06 | S2 | `local.py:30` | — | S |
+| F-07 | S2 | `health.py:188,212` | — | M |
+| F-08 | S2 | `service.py:766` | — | S |
+| F-09 | S2 | `telemetry.py:156` | — | S |
+| F-10 | S2 | `telemetry.py:248` | — | S |
+| F-11 | S2 | `main.py:1146` | ✅ | S |
+| F-12 | S2 | `swarm.py:197` | — | S |
+| F-13 | S2 | `app.py:137,163` | — | S |
+| F-14 | S2 | `app.py:62` | — | M (product) |
+| F-15 | S2 | `main.py:1138` | — | S |
+| F-16 | S2 | `netllm-sdk-*/pyproject.toml` | — | S |
+| F-17 | S3 | `models.py:273` (+4 clients) | — | S |
+| F-18 | S3 | 10 sites | — | S |
+| F-19 | S3 | `netllm-core/pyproject.toml` | — | S |
+| F-20 | S3 | `platform.py:26` | — | M |
+| F-21 | S3 | `config_schema.py` + clients | — | L |
+| F-22 | S3 | 9 modules | — | M |
+| F-23 | S3 | `swarm.py:185` | — | M |
+| F-24 | S3 | `service.py` ×4 paths | — | L |
+| F-25 | S3 | 5 overlaps | — | L |
+| F-26 | S3 | `service.py`, `main.py` | — | L |
+| F-27 | S3 | `scripts/ci.sh`, workflows | — | M |
+| F-28 | S3 | `packaging/` | — | M |
+| F-29 | S3 | `local.py` | — | M |

--- a/docs/architecture/08-feature-integration-status.md
+++ b/docs/architecture/08-feature-integration-status.md
@@ -1,0 +1,156 @@
+# 08 · Feature integration status
+
+Product-facing view: what is fully shipped, what exists in the engine but cannot be reached
+from a UI, and what is code with no user at all. Verified by grepping each client surface
+(`dashboard.js`, `apps/netllm-mac/Sources`, `netllm_cli/main.py`) for the feature's config keys
+and endpoints.
+
+## Legend
+
+| Mark | Meaning |
+|------|---------|
+| ✅ | Fully usable from that surface |
+| ◐ | Partially usable — present but incomplete or read-only |
+| ⬚ | Not exposed; the feature works but this surface cannot reach it |
+| — | Not applicable to that surface |
+
+## Routing engine
+
+| Feature | Engine | CLI | Dashboard | macOS app | Notes |
+|---------|--------|-----|-----------|-----------|-------|
+| 8 routing strategies | ✅ | ✅ | ✅ | ✅ | |
+| Per-request headers (`x-netllm-strategy`, `-backend`, `-local-only`, `-hops`) | ✅ | — | — | — | Protocol-level; documented in `routing-hardening-plan.md` |
+| Failover with per-request exclusion | ✅ | — | — | — | |
+| Capacity-error classification (409/429/503/507 + body markers) | ✅ | — | — | — | Surfaced as `capacity_rejections` in status |
+| `routing.model_aliases` | ✅ | ⬚ | ✅ | ✅ | No CLI command; edit via config or a UI |
+| `routing.model_pools` | ✅ | ⬚ | ✅ | ✅ | Config-only when the plan was written; both UIs now render it |
+| `routing.policies` | ✅ | ⬚ | ✅ | ✅ | **`source` field silently dropped on save — F-01** |
+| `routing.backends` overrides | ✅ | ⬚ | ✅ | ✅ | **`max_concurrency` dropped on save and never hot-applied — F-01, F-05** |
+| `follow_gateway` strategy adoption | ✅ | ⬚ | ✅ | ✅ | Runtime-only, never persisted |
+| Batch sharding (`batch_shard`, HRW/modulo) | ✅ | — | — | — | Header/`user`/`metadata` driven; `shardless_fallbacks` counter surfaces misuse |
+| `model_groups` (weights, prefer, batch eligibility) | ⬚ | ⬚ | ⬚ | ⬚ | **Not built.** Sketched in `routing-hardening-plan.md` Phase 4 |
+
+## Source identity and per-caller routing
+
+| Feature | Engine | CLI | Dashboard | macOS app | Notes |
+|---------|--------|-----|-----------|-----------|-------|
+| Source attribution (header → key → UA → default) | ✅ | ✅ (`sources list`) | ✅ | ✅ | |
+| `sources toggle <id>` one-click registration | ✅ | ✅ | ✅ | ✅ | Never auto-installs a CLI — deliberate |
+| Harness registry + PATH detection + icons | ✅ | ✅ | ✅ | ✅ | 3 of 6 `cli_commands` entries are unverified guesses (flagged in-code) |
+| Per-source `strategy` / `local_only` / `allow_cloud` / `prefer_provider` | ✅ | ⬚ | ✅ | ✅ | |
+| Per-source `cloud_providers` allowlist | ✅ | ⬚ | ◐ | ◐ | Rendered generically; no picker |
+| Per-source `max_concurrency` (429 on breach) | ✅ | ⬚ | ◐ | ◐ | **Cap is check-then-act — F-08** |
+| Per-source `secret` / `secret_env` | ✅ | ⬚ | ✅ | ✅ | Blanked on read by both surfaces |
+| Elevated-source secret enforcement | ◐ | ⬚ | ✅ | ❌ | **Bypassed on the macOS/CLI save path — F-02** |
+| `sources[].model_rewrites` | ✅ | ⬚ | ✅ | ⬚ | Dashboard renders it generically (`dict_strings` widget); **deliberately excluded** from the macOS renderer (`SettingsWindowView.swift:775`) |
+| `sources[].scenarios` (scenario routing) | ✅ | ⬚ | ✅ | ⬚ | Dashboard renders it generically (`dict` + `ScenarioRule` item schema); same documented macOS exclusion |
+| `sources[].match.user_agent_contains` | ✅ | ⬚ | ✅ | ⬚ | Dashboard renders it generically (`object` widget); same documented macOS exclusion |
+| Scenario classification (long_context / web_search / think / background) | ✅ | ⬚ | ⬚ | ⬚ | Engine-side only; the counters it produces are displayed nowhere — see the observability table |
+
+**How the dashboard gets these for free.** `renderSourcesTab()` calls
+`renderSchemaField(byName.sources, …)`, and `schemaListOfObjectsRow` renders **every** field in
+the `SourceConfig` item schema through `renderSchemaField`
+(`dashboard.js:1361-1400`, `:1511-1531`). So `model_rewrites` → `schemaDictStringsRow`,
+`scenarios` → `schemaDictOfObjectsRow`, `match` → `schemaNestedObjectRow` — no per-field JS was
+ever written for them. This is the schema-driven UI work of
+`config-schema-rewrite-plan.md` paying off, and it is invisible to a name-grep of `dashboard.js`
+(searching for the literal string `scenarios` there returns zero hits).
+
+**The real gap is macOS + observability, not configurability.** The macOS Settings app excludes
+those three fields on purpose — `SchemaFormView`'s fallback widget is a plain text field bound to
+`.stringValue`, which is `nil` for a dict/object, so rendering them would let a user silently
+overwrite a structured value with a string. That decision, and the in-app caption pointing users
+to the dashboard, are documented in `cli-source-routing-plan.md` Phase 4b. What is genuinely
+missing is **the feedback loop**: nothing on any surface displays `scenario_requests` or
+`source_requests`, so a user who writes a scenario rule in the dashboard has no way to see
+whether it ever fires. The plan itself records this — Phase 3's live-validation gate was
+deferred to Phase 5 and never closed.
+
+## Cloud providers
+
+| Feature | Engine | CLI | Dashboard | macOS app | Notes |
+|---------|--------|-----|-----------|-----------|-------|
+| 5-provider registry (Moonshot, Z.ai, OpenAI, Anthropic, OpenRouter) | ✅ | ✅ | ✅ | ✅ | Served from one endpoint; no client-side mirroring of display data |
+| Enable/disable per provider | ✅ | ✅ | ✅ | ✅ | Disabling prunes the pool row immediately |
+| API key storage (`api_key`, `api_key_env`) | ✅ | ✅ | ✅ | ✅ | Write-only; macOS also has Keychain support |
+| Region / profile selection | ✅ | ✅ | ✅ | ✅ | |
+| Fallback direction (`cloud` / `local` / `none`) | ✅ | ✅ | ✅ | ✅ | `local` = cloud-primary (`cloud_leads`) |
+| OpenRouter OAuth PKCE | ✅ | ✅ | ⬚ | ⬚ | CLI-only (`cloud connect openrouter`) |
+| Anthropic `plan_token` mode | ✅ | ◐ | ◐ | ◐ | Unofficial by Anthropic's own docs; opt-in, correctly flagged in-code |
+| Live model-catalog probe + allowlist editing | ✅ | ✅ (`cloud test`) | ✅ | ✅ | |
+| Keyless-but-enabled detection | ✅ | ✅ | ✅ | ✅ | Row is not materialised; doctor flags it |
+| Legacy env/caller-key inject | ✅ | — | — | — | **Should be retired — F-04, F-25** |
+
+## Swarm and operations
+
+| Feature | Engine | CLI | Dashboard | macOS app | Notes |
+|---------|--------|-----|-----------|-----------|-------|
+| mDNS advertise + browse | ✅ | ✅ | ✅ | ✅ | Auto-retries after a startup name collision |
+| Static peers | ✅ | ✅ | ✅ | ✅ | Self-peer filtering on the HTTP path only |
+| Subnet scan (manual + auto-fallback) | ✅ | ✅ | ✅ | ✅ | |
+| Heartbeat gossip | ✅ | — | — | — | **Sequential fan-out — F-12** |
+| Peer re-discovery after sleep/blip | ✅ | — | — | — | |
+| Cluster token (create / rotate / join) | ✅ | ✅ | ✅ | ✅ | |
+| `require_token_for_inference` | ✅ | ⬚ | ✅ | ✅ | **No CLI command; not set by `--secure` — F-14** |
+| **Drain (`draining`)** | ✅ | ✅ | ⬚ | ⬚ | **CLI-only.** No button in the dashboard or menubar despite being a pre-restart operation both UIs offer restart for |
+| `agent.max_concurrency` (self-declared ceiling) | ✅ | ⬚ | ✅ | ✅ | Broadcast via heartbeat |
+| Peer config/version drift warnings | ✅ | ✅ | ✅ | ◐ | In `status.peer_warnings` and doctor |
+| Gateway role promotion | ✅ | ✅ | ✅ | ✅ | |
+
+## Observability
+
+| Feature | Engine | CLI | Dashboard | macOS app | Notes |
+|---------|--------|-----|-----------|-----------|-------|
+| Prometheus `/metrics` (7 collectors) | ✅ | — | — | — | Requests, latency, health, in-flight, source, scenario, token counters |
+| Router session + all-time telemetry | ✅ | ⬚ | ✅ | ✅ | **Disk write per request — F-09** |
+| oMLX deep telemetry (stats, activity, loaded models) | ✅ | ⬚ | ✅ | ✅ | Only provider with this depth |
+| **Host CPU/memory block** | ◐ | — | ❌ | ✅ | **Always `null` in the API — `psutil` undeclared (F-10).** macOS has native `HostSampler`; Linux/Windows dashboards show nothing |
+| Per-backend `routed_requests` counters | ✅ | ✅ | ✅ | ◐ | Answers "peer discovered but idle" |
+| `capacity_rejections` counters | ✅ | ⬚ | ✅ | ⬚ | |
+| `shardless_fallbacks` counter | ✅ | ⬚ | ✅ | ⬚ | |
+| **`source_requests` / `scenario_requests` counters** | ✅ | ⬚ | ⬚ | ⬚ | In status + Prometheus, **no UI** |
+| Agent log tail | ✅ | ⬚ | ✅ | ✅ | **Log never rotates — F-15** |
+| Doctor | ✅ | ✅ (full) | ◐ (subset) | ◐ (subset) | |
+
+## Platform and packaging
+
+| Capability | macOS | Linux | Windows |
+|-----------|-------|-------|---------|
+| CLI + foreground `serve` | ✅ | ✅ | ✅ |
+| Background service | ✅ menubar app / `brew services` | ✅ systemd `--user` | ✅ `NetllmAgent` service |
+| Native GUI | ✅ SwiftUI menubar | ⬚ | ⬚ |
+| Web dashboard `/ui/` | ✅ | ✅ | ✅ |
+| In-app updater | ✅ | ⬚ (package manager) | ⬚ (re-download zip) |
+| Signed/notarized artifact | ❌ ad-hoc only | ⬚ unsigned | ⬚ unsigned |
+| oMLX provider support | ✅ | — | — |
+| CPU architecture | **arm64 only** | x86_64 (deb/rpm) | x64 |
+
+**macOS 26 (Tahoe) blocker:** ad-hoc-signed DMGs are refused by Gatekeeper. The documented
+workaround is build-from-source. `docs/macos-code-signing.md` contains the full enablement
+procedure — this is a credentials and release-process task, not engineering work.
+
+## Roadmap-visible gaps (from the project's own plan docs, verified against code)
+
+| Plan | Stated status | Verified reality |
+|------|--------------|------------------|
+| `routing-hardening-plan.md` Phases 1–3, 5 | done | ✅ genuinely implemented |
+| `routing-hardening-plan.md` Phase 4 — `model_groups` | "still future work" | ✅ accurate; `model_pools` shipped as the simpler half |
+| `routing-hardening-plan.md` — `require_same_model_for_shard` "now actually wired in" | claimed done | ❌ **stale**: the batch planner was deleted in Phase 2; the field is dead (F-17) |
+| `config-schema-rewrite-plan.md` Phases 1–5 | "done, with two scope limits" | ✅ accurate; the limits are real and still cost (F-21) |
+| `models-ux-plan.md` A + B1–B3 | delivered (macOS) | ✅ |
+| `models-ux-plan.md` B4, C | deferred | ✅ accurate |
+| `models-ux-plan.md` D — dashboard parity | not started | ✅ accurate |
+| `cloud-providers-plan.md` | "proposed" | ❌ **stale**: the feature is fully implemented across CLI, dashboard, and macOS app; the doc still says proposed |
+| `cli-source-routing-plan.md` Phases 0–4 | — | Engine complete; Phase 3 (scenarios) has **no UI on any surface** |
+
+## Suggested product decisions
+
+| # | Decision needed | Why now |
+|---|-----------------|---------|
+| 1 | **Ship a UI for scenario routing and `model_rewrites`, or document them as advanced config-file features** | The most differentiated capability in the product is currently invisible. Either state is fine; the current silence is not. |
+| 2 | **Decide whether the LAN swarm default is "open" or "secured"** | `--secure` does not secure inference (F-14). Pick one and make the flag mean it. |
+| 3 | **Retire the caller-key cloud inject** | It is a cross-tenant credential path (F-04) and a duplicate of the registry mechanism. |
+| 4 | **Surface drain in the dashboard and menubar** | Both offer "Restart Agent"; drain is the safe pre-restart step and only the CLI has it. |
+| 5 | **Declare `psutil` or drop host metrics** | The feature ships dead on Linux/Windows (F-10). |
+| 6 | **Fund notarization** | The macOS DMG channel is effectively unusable on current macOS without it. |
+| 7 | **Refresh the three stale plan docs** | `cloud-providers-plan.md` (proposed → shipped), `routing-hardening-plan.md` (`require_same_model_for_shard`), and add a status line to `cli-source-routing-plan.md`. |

--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -1,0 +1,61 @@
+# docs/architecture — architecture reference and audit
+
+## Purpose
+
+Two things in one folder, deliberately kept together so they cannot drift apart:
+
+1. **Reference** (01–06) — how the system is built: components, request lifecycle, swarm
+   behaviour, configuration/control plane, dependency map. Intended to stay true.
+2. **Audit** (07–08) — a point-in-time register of defects, risks, and integration gaps,
+   plus the product-facing shipped/partial/orphaned matrix.
+
+Index: [README.md](README.md). Parent rail: [../AGENTS.md](../AGENTS.md).
+
+## Ownership
+
+| Doc | Owns |
+|-----|------|
+| `01-system-overview.md` | topologies, container diagram, stack, state inventory, endpoint table |
+| `02-component-architecture.md` | package graph, per-module responsibility tables, domain model |
+| `03-request-lifecycle.md` | the four proxy surfaces, routing decision flow, failover, loop guards |
+| `04-discovery-and-swarm.md` | both discovery planes, peer state machine, gossip, network/security model, timing constants |
+| `05-configuration-and-control-plane.md` | config model, the three write paths, merge semantics, admin API, source identity |
+| `06-dependencies.md` | internal graph, external/undeclared deps, platform + CI + release dependencies |
+| `07-findings-register.md` | F-01…F-29 with severity, evidence, and fix |
+| `08-feature-integration-status.md` | shipped / partial / orphaned per client surface; product decisions |
+
+## Local Contracts
+
+- **Every claim carries evidence.** Assertions about behaviour cite `path/file.py:line`.
+  Reproduced defects state that they were reproduced and show the observed output.
+- **Findings are append-only in ID.** Never renumber `F-nn`; mark a fixed finding
+  `RESOLVED (<version>, <PR>)` in place and keep it. Other docs and PRs reference the IDs.
+- **Severity means the same thing every time.** `S1` production-affecting correctness or
+  security · `S2` real user-visible defect or meaningful risk · `S3` maintenance/latent.
+- **Diagrams are Mermaid in Markdown.** No binary image assets, no external rendering
+  service — they must render on GitHub and in any Markdown viewer.
+- **Reference and audit are separated.** Do not fold a finding into 01–06 as if it were
+  designed behaviour; link to the `F-nn` instead.
+- This folder does not duplicate user-facing install/troubleshooting guidance — link to
+  `../macos-install.md` and siblings.
+
+## Work Guidance
+
+- **Re-audit on a release boundary**, not per PR. Update the header line in
+  [README.md](README.md) (release, date, commit) whenever any doc here is refreshed.
+- Fixing a finding: change its entry to `RESOLVED`, update the traceability matrix row, and
+  update the matching row in `08-feature-integration-status.md` if a surface changed.
+- Adding a config field, endpoint, strategy, or package: update the owning table in 01–06 in
+  the same PR (the tables are the reason this folder exists).
+- Plan docs (`../routing-hardening-plan.md`, `../cloud-providers-plan.md`,
+  `../cli-source-routing-plan.md`, `../config-schema-rewrite-plan.md`,
+  `../models-ux-plan.md`) hold *intent*; this folder holds *as-built*. When they disagree,
+  fix the plan doc and note it in `08`'s roadmap table.
+
+## Verification
+
+- All relative links resolve from [README.md](README.md).
+- Every `file:line` reference still points at the code it describes.
+- Mermaid blocks parse (no unescaped `|` inside node labels, no bare `[]` in text).
+- Counts stated in prose (findings, packages, LOC, test count) match reality — re-run
+  `uv run pytest -q` and the LOC counts rather than carrying them forward.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,61 @@
+# Architecture & audit documentation
+
+Reviewed release: **0.4.5.0** · Audit date: **2026-07-29** · Branch: `main` @ `a3ec16a`
+
+This set documents **llm-swarm-router** (`netllm`) as built: every component, every
+dependency, the routing and control-plane logic, and a severity-ranked register of
+inconsistencies, logic defects, hardening gaps, and features that are present in the
+code but not fully wired into the product.
+
+It was produced by reading the source (not the marketing docs) and verifying claims
+against a live checkout. Every finding in [07-findings-register.md](07-findings-register.md)
+carries a `file:line` reference and, where practical, a reproduction that was actually run.
+
+## Read this in your role
+
+| You are | Start here | Then |
+|---------|-----------|------|
+| **Product manager** | [08-feature-integration-status.md](08-feature-integration-status.md) — what is shipped, partial, or orphaned | [07-findings-register.md](07-findings-register.md) §Severity summary |
+| **New engineer** | [01-system-overview.md](01-system-overview.md) | [02-component-architecture.md](02-component-architecture.md) → [03-request-lifecycle.md](03-request-lifecycle.md) |
+| **Reviewing a routing change** | [03-request-lifecycle.md](03-request-lifecycle.md) | [07-findings-register.md](07-findings-register.md) §Routing & concurrency |
+| **Reviewing a config/UI change** | [05-configuration-and-control-plane.md](05-configuration-and-control-plane.md) | [07-findings-register.md](07-findings-register.md) §Configuration integrity |
+| **Network / deployment** | [04-discovery-and-swarm.md](04-discovery-and-swarm.md) | [06-dependencies.md](06-dependencies.md) §Runtime & platform |
+| **Release / build owner** | [06-dependencies.md](06-dependencies.md) | [../ci-and-release.md](../ci-and-release.md) |
+
+## Document index
+
+| # | Document | Covers |
+|---|----------|--------|
+| 01 | [System overview](01-system-overview.md) | Product shape, deployment topologies, container diagram, tech stack |
+| 02 | [Component architecture](02-component-architecture.md) | Package-by-package responsibilities, domain model, module map |
+| 03 | [Request lifecycle](03-request-lifecycle.md) | The four proxy surfaces, routing decision flow, failover, streaming |
+| 04 | [Discovery & swarm](04-discovery-and-swarm.md) | Local scan, mDNS, subnet scan, heartbeat gossip, peer state machine |
+| 05 | [Configuration & control plane](05-configuration-and-control-plane.md) | Config model, the three write paths, admin API, schema-driven UI |
+| 06 | [Dependencies](06-dependencies.md) | Internal graph, external packages, platform/build/CI dependencies |
+| 07 | [Findings register](07-findings-register.md) | 29 verified findings: correctness, security, performance, simplification |
+| 08 | [Feature integration status](08-feature-integration-status.md) | Shipped / partial / orphaned matrix for planning |
+
+## Scope and method
+
+**In scope:** the `packages/` Python workspace (6 packages, ~13.3k LOC), the `apps/netllm-mac`
+Swift menubar app (~7.5k LOC), the bundled web dashboard (~3.4k LOC of HTML/CSS/JS),
+`packaging/`, `scripts/`, and CI workflows.
+
+**Verification performed during this audit:**
+
+- Full test suite: `uv run pytest -q` → **584 passed** in 50 s (clean).
+- Reproduced 4 defects with executable scripts (see findings F-01, F-02, F-06, F-11).
+- Cross-checked every "orphan" claim with a repo-wide symbol grep including tests.
+
+**Not in scope:** the local-maintainer coordinator/outreach trees under `.cursor/`
+(gitignored, never on the remote), and third-party upstream inference servers.
+
+## Conventions used
+
+- `path/file.py:123` — clickable evidence pointer into the repo.
+- **Severity** — `S1` production-affecting correctness or security · `S2` real user-visible
+  defect or meaningful risk · `S3` maintenance, clarity, or latent risk.
+- **Orphaned** — code that exists and is reachable in principle but has no production
+  caller or no way for a user to reach it.
+- **Partially integrated** — the backend exists but at least one shipped client
+  (CLI, dashboard, macOS app) cannot use it.


### PR DESCRIPTION
## Summary

Adds `docs/architecture/` — a combined **architecture reference** and **point-in-time audit** for release 0.4.5.0, produced by reading the source and verifying claims against a live checkout.

| Doc | Covers |
|-----|--------|
| `01-system-overview.md` | topologies, container diagram, stack, state inventory, endpoint table |
| `02-component-architecture.md` | package graph, per-module responsibilities, domain model |
| `03-request-lifecycle.md` | the four proxy surfaces, routing decision flow, failover, loop guards |
| `04-discovery-and-swarm.md` | both discovery planes, peer state machine, gossip, network/security model |
| `05-configuration-and-control-plane.md` | config model, the three write paths, merge semantics, admin API |
| `06-dependencies.md` | internal graph, external/undeclared deps, platform + CI + release deps |
| `07-findings-register.md` | F-01…F-29 with severity, evidence, and fix |
| `08-feature-integration-status.md` | shipped / partial / orphaned per client surface |

Reference (01–06) and audit (07–08) are deliberately kept in one folder so they cannot drift apart.

Also registers the folder in the docs child-DOX index (`docs/AGENTS.md`) and the README topic table, per the DOX protocol.

## Notes

- Docs-only — no code, config, or build changes.
- Every behavioural claim carries a `file:line` reference; reproduced defects say so and show observed output.
- The findings register is a snapshot against `main` @ `a3ec16a`; some items may already be addressed by later merges (e.g. #36).

## Test plan

Docs-only change; CI lint/test/packaging run for regression safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)