### PR TITLE
audit + remediation: follow-up register F-30…F-53 with red-green fixes (21 resolved)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ Prefer `./netllm` from the repo root, works without global PATH (`uv run` wrappe
 | `./netllm sources toggle <id>` | Register (if new) and enable a source, or flip its `enabled` state — never auto-installs the CLI |
 | `./netllm drain [on\|off]` | Stop/resume receiving new swarm work (runtime-only, resets on restart) |
 | `./netllm config-edit` | Open `config.toml` in `$EDITOR` |
+| `./netllm config export` | Full config as JSON to stdout (settings UI) |
+| `./netllm config schema` | Config form schema JSON (same as `GET /netllm/v1/config/schema`; works without a running agent) |
 | `./scripts/ci.sh` | Lint + test (same as CI) |
 | `./scripts/ci.sh lint` | Ruff check + format --check (repo-wide) + dashboard token drift |
 | `./scripts/ci.sh test` | Run tests |
@@ -261,7 +263,8 @@ Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) for fork/PR workflow,
   `netllm-` (the sentinel or a virtual source key) is never forwarded as
   a real cloud credential (`is_netllm_placeholder_key`) — found via live
   smoke testing that `netllm-<source>` keys were leaking upstream before
-  this fix. `netllm sources`/`netllm connect` CLI still not built — see
+  this fix. The `netllm connect` CLI is still not built
+  (`netllm sources list|toggle` shipped — see Key commands) — see
   [docs/cli-source-routing-plan.md](docs/cli-source-routing-plan.md).
 - **Routing hardening (phase 1):** `/v1/messages` honors all routing strategies (not just local_first/spillover); per-request `x-netllm-strategy`, `x-netllm-backend`, `x-netllm-hops` headers on proxy routes; one-shot LAN defaults (`routing.lan_defaults_applied` — explicit `local_first` no longer rewritten); peer row prune + `swarm.rediscover_interval_s` background loop; config hot-apply via admin API + merge-safe `netllm config import`; audit + remaining phases in [docs/routing-hardening-plan.md](docs/routing-hardening-plan.md)
 - **Routing hardening (phase 6, mesh fairness):** auth-gated (401/403) empty-catalog backends are never blind routing candidates; load-aware strategies keep balancing on retries (no local-first failover collapse); routine provider scans never run the 1-token inference diagnose (`scan_local_providers(diagnose=True)` is CLI-`discover`-only — routine diagnose forced chat-model loads under memory pressure); `prune_local_provider_rows` drops rows for de-configured providers; `routing.follow_gateway` (default true) makes peer-role agents adopt the gateway's strategy from heartbeats; macOS Settings index-binding crash fixed (bounds-safe Bindings in policy/override editors) and Settings shows the resolved LAN address — [docs/routing-hardening-plan.md](docs/routing-hardening-plan.md)

--- a/README.md
+++ b/README.md
@@ -66,15 +66,15 @@ Point **Cursor**, **Claude Code**, **Codex**, **Honcho**, or any compatible clie
 ### Two machines, three commands
 
 ```bash
-# Machine A — answer "yes" to the swarm question (or pass --swarm)
-./netllm init --swarm && ./netllm serve
+# Machine A — secured swarm: generates a cluster token, prints the join command
+./netllm init --swarm --secure && ./netllm serve
 # prints: netllm join http://<machine-A-ip>:11400 --token <generated>
 
 # Machine B — paste the join command from machine A
 ./netllm join http://<machine-A-ip>:11400 --token <generated> && ./netllm serve
 ```
 
-Both machines now share one model catalog, authenticate with the generated cluster token, and **spread same-model load automatically** (`local_spillover`: serve locally while idle, spill to the least-loaded peer when busy). Verify with `./netllm peers` and `./netllm models`.
+Both machines now share one model catalog, authenticate with the generated cluster token, and **spread same-model load automatically** (`local_spillover`: serve locally while idle, spill to the least-loaded peer when busy). Verify with `./netllm peers` and `./netllm models`. On a trusted home LAN you can skip the token: run `./netllm init --swarm && ./netllm serve` on both machines (no `join` needed) and they mesh via mDNS.
 
 ### Who reads what
 
@@ -287,15 +287,18 @@ Config: `~/.config/netllm/config.toml`, see [config.example.toml](config.example
 
 ```bash
 ./netllm init              # guided setup (asks: single machine or LAN swarm?)
-./netllm init --swarm      # LAN bind + cluster token + load spreading, prints join cmd
-./netllm join URL --token T     # join this machine to an existing swarm
+./netllm init --swarm      # LAN bind + load spreading (open trusted LAN, no token)
+./netllm init --swarm --secure  # same + cluster token, prints join cmd
+./netllm join URL --token T     # join this machine to a secured swarm
 ./netllm swarm-token       # show (or --rotate) the pairing token
 ./netllm serve             # foreground agent (dev/CI/Linux)
 ./netllm serve --host 0.0.0.0   # LAN bind without re-init
 ./netllm start|stop|restart     # background (app / Homebrew / systemd / Windows service)
 ./netllm status            # backends, health, peers
 ./netllm models            # routed catalog
+./netllm models --local    # local providers only (agent not required)
 ./netllm models --lan      # include remote LAN agents
+./netllm models --lan --subnet-scan   # probe the /24 when mDNS is blocked
 ./netllm peers             # mDNS browse (flags unreachable loopback-bound agents)
 ./netllm discover          # manual rescan (optional; agent auto-discovers)
 ./netllm test              # 1-token latency probe

--- a/config.example.toml
+++ b/config.example.toml
@@ -190,6 +190,12 @@ auto_start_on_launch = true
 check_for_updates_automatically = true
 # log_dir = ""  # default: ~/Library/.../logs (macOS), XDG state (Linux), %LOCALAPPDATA% (Windows)
 # serve writes agent.log under log_dir on all platforms
+# model_favorites = []  # pin model IDs to the top of model pickers
+# menubar_show_cpu = false   # macOS menubar gauges (System Stats)
+# menubar_show_gpu = false
+# menubar_show_mem = false
+# menubar_show_live = false  # live throughput gauge (LIV)
+# menubar_models_favorites_only = false  # menubar Models menu shows favorites only
 
 # Optional manual backend overrides (per-endpoint API keys via env)
 # [[routing.backends]]

--- a/docs/architecture/09-follow-up-audit-2026-07-31.md
+++ b/docs/architecture/09-follow-up-audit-2026-07-31.md
@@ -1,0 +1,414 @@
+# 09 · Follow-up audit — 2026-07-31
+
+Top-down audit of `main` @ `c9bd30a` (post-0.4.5.0, two commits after the
+2026-07-29 baseline audit in [07-findings-register.md](07-findings-register.md)).
+Conducted as six parallel audit dimensions (docs/code alignment, API routes &
+wire fidelity, architecture cohesion, integrations, industry standards, delta vs
+baseline), each followed by an independent adversarial verification pass that
+re-opened every cited `file:line` and attempted to refute the finding. **All 36
+raw findings survived verification (35 CONFIRMED, 1 narrowed in scope);
+deduplicated to 24 findings below**, numbered **F-30…F-53** continuing the
+register's append-only namespace.
+
+**Baseline guard:** `uv run pytest -q` → **647 passed, 4 skipped** (above the
+642-passing baseline). Lint clean. No regression of any RESOLVED F-01…F-29
+finding was found — the specific fix sites of F-01/F-02/F-03/F-04/F-05/F-06/
+F-07/F-09/F-13 were each re-verified intact at HEAD.
+
+## Purpose and target users (from README)
+
+llm-swarm-router (netllm) is a **mesh router/coordinator for local LLM
+backends**: a lightweight per-machine agent that auto-discovers oMLX, Ollama,
+LM Studio, and vLLM, meshes machines over LAN (mDNS / subnet scan / static
+peers), and exposes one stable dual API surface (OpenAI-compatible `/v1` +
+Anthropic Messages) to editors and agent harnesses (Cursor, Claude Code, Codex,
+Honcho, Continue, Cline). Target users are **home-lab and multi-machine
+local-inference operators** who want throughput that scales with hardware, 24/7
+unattended operation, and optional cloud fallback — without per-tool `base_url`
+juggling.
+
+## Thesis
+
+> The product's value depends on three invariants: **(1)** the dual API surface
+> must be a faithful, industry-standard implementation of the OpenAI and
+> Anthropic wire protocols so any compatible client works unmodified; **(2)**
+> the six-package architecture plus three control surfaces (web dashboard,
+> macOS Settings, CLI) must remain one coherent control plane with no divergent
+> parallel implementations; **(3)** rapid feature velocity must not fragment the
+> routing path or silently regress the 2026-07-29 hardening. Hypothesis:
+> the request path is sound, but fragmentation pressure is highest in (a) the
+> four duplicated proxy loops and 2 kLOC modules already open as F-24/F-26,
+> (b) Swift-vs-dashboard feature parity, and (c) README/docs drift.
+
+**Thesis verdict: substantially confirmed.**
+
+- Invariant (2) holds best: package boundaries verified clean (zero
+  `openai`/`anthropic` imports in netllm-core; import graph is a DAG; CLI talks
+  to the agent over HTTP except one straggler, F-40). No divergent code was
+  found *without* justification — the fragmentation that exists is exactly
+  where F-24/F-21 predicted it, now with two new instances from the post-audit
+  commits (F-34, F-49).
+- Invariant (1) is the weak edge: happy-path wire fidelity is genuinely close
+  to spec, but streaming error paths, error body shapes, and the
+  anthropic-format streaming path have real gaps — including the single S1
+  (F-30).
+- Invariant (3) held: neither post-audit commit regressed a resolved finding,
+  and both added tests. Their cost is new S3-class debt (hand-mirrored SDK
+  signature, asymmetric application across proxy loops, undocumented contract).
+- Prediction (c) confirmed at S2: the README's flagship quickstart no longer
+  matches the code (F-31).
+
+## Severity summary
+
+| Severity | Count | Theme |
+|----------|-------|-------|
+| **S1** | 1 | anthropic-format streaming always fails |
+| **S2** | 4 | README quickstart broken, streaming error handling dead, telemetry accounting divergence, Windows service cannot start via SCM |
+| **S3** | 19 | proxy-loop divergence, hand-maintained mirrors, error-shape fidelity, auth-gate stragglers, docs drift, ops hygiene |
+
+## Recommended order of work
+
+1. **Correctness now:** F-30 (one-line SDK fix + un-mocked test), F-32/F-33
+   (streaming error/accounting — same code area, fix together), F-31 (README).
+2. **Consistency batch (post-audit commit cleanup):** F-34, F-35, F-36, F-37 —
+   all in `payload.py`/embeddings; one focused PR closes the c9bd30a debt.
+3. **Exposure/consistency:** F-40, F-41, F-44, F-47.
+4. **Wire fidelity:** F-38, F-42 (error shapes + Responses events, needs a
+   live-Codex check).
+5. **Ops/docs sweep:** everything else; most are one-liners.
+
+---
+
+# S1 — production-affecting
+
+## F-30 · Streaming Anthropic Messages to any anthropic-format backend always fails
+
+**Severity** S1 · **Area** request path / SDK adapter · **Reproduced** · **Verdict** CONFIRMED (found independently by two dimensions)
+
+`packages/netllm-sdk-anthropic/src/netllm_sdk_anthropic/client.py:57-59` —
+`messages_stream` builds `payload = {**payload, "stream": True}` and then calls
+`self._client.messages.stream(**payload)`. The Anthropic SDK's `.stream()`
+helper does not accept a `stream` kwarg; reproduced by driving
+`AnthropicUpstream.messages_stream` under anthropic 0.106.0 → `TypeError`
+before any I/O.
+
+Every streamed `POST /v1/messages` request that routing lands on an
+anthropic-format backend (the materialized cloud-anthropic row, the legacy
+caller-key row, or any `[[routing.backends]]` with `api_format = "anthropic"`)
+raises immediately. Local backends are unaffected (openai-format translation
+path, `service.py:2010-2017`), which is why the mesh's main path masks this.
+Claude Code streams by default, so cloud-Anthropic fallback for the flagship
+Anthropic client is broken.
+
+**Fix:** pop `"stream"` before calling the SDK (`.stream()` implies streaming),
+or use `messages.create(**payload, stream=True)` for raw wire events. Add one
+un-mocked signature/contract test — the existing mocked tests could not catch
+this class.
+
+# S2 — real user-visible defects
+
+## F-31 · README two-machine quickstart cannot work as written
+
+**Severity** S2 · **Area** docs alignment · **Verdict** CONFIRMED
+
+`README.md:69-77` and `README.md:290` claim `./netllm init --swarm` generates a
+cluster token and prints a `join --token` command. Since the open/secure split,
+token minting requires `--secure` (`packages/netllm-cli/src/netllm_cli/main.py:303-332`);
+plain `--swarm` prints the open-LAN panel, and the README's
+`netllm join URL --token <generated>` against an open machine A exits 1 with
+"Token mismatch" (`main.py:529-541`). AGENTS.md:54-56 documents the correct
+split, so the README contradicts both the code and AGENTS.md — in the repo's
+most prominent workflow.
+
+**Fix:** switch the quickstart to `init --swarm --secure`, or rewrite it around
+the open-LAN flow (`init --swarm` on both machines, verify with `./netllm peers`).
+
+## F-32 · Streaming routes' error handling is dead code — errors yield HTTP 200 + aborted stream
+
+**Severity** S2 · **Area** request path · **Verdict** CONFIRMED
+
+`packages/netllm-agent/src/netllm_agent/app.py:409-424` wraps
+`StreamingResponse(service.proxy_chat_completion_stream(...))` in
+`except SourceCapacityExceeded / OpenAIUpstreamError` clauses — but an async
+generator executes nothing until first iteration, and `StreamingResponse` sends
+`http.response.start` before iterating. So for `stream=true`, capacity errors
+(should be 429) and all-backends-failed (should be 502) surface as a 200 with a
+truncated/aborted body. Clients see malformed SSE instead of an actionable
+status. Applies to the streaming arms of all proxy surfaces.
+
+**Fix:** pre-flight the failable work (attribution, admission, routing
+resolution, first-backend selection) before constructing the
+`StreamingResponse`; only stream once a backend connection is established.
+
+## F-33 · Success accounting diverges across the four proxy loops; the new Serving UI makes it visible
+
+**Severity** S2 · **Area** telemetry / F-24 divergence · **Verdict** CONFIRMED
+
+`packages/netllm-agent/src/netllm_agent/service.py:1904-1910` —
+`proxy_messages_stream` yields chunks and returns with **no** `mark_success`,
+no `REQUESTS_TOTAL` increment, no latency/token recording; streamed chat
+records requests but not tokens. This is the exact failure mode F-24 predicted
+(a fix/behavior applied to some loops only), and ccc1c79 built the headline
+Serving telemetry UI on top of these counters — so a node serving streamed
+`/v1/messages` traffic (Claude Code's default mode) shows zero activity and
+skewed health/latency stats that `least_load`/`latency_weighted` also consume.
+
+**Fix:** give `proxy_messages_stream` the `_stream_with_metrics` treatment, and
+have both streaming wrappers parse the final usage-bearing SSE chunk.
+
+## F-34 · Windows "service" is a plain console exe registered with sc.exe — SCM will kill it
+
+**Severity** S2 · **Area** packaging (Windows) · **Verdict** CONFIRMED
+
+`packaging/windows/install-service.ps1:22` registers `netllm.exe serve -q`
+directly via `sc.exe create … start= auto` with no service account (LocalSystem
+by default). No code implements `StartServiceCtrlDispatcher`, so `sc start
+NetllmAgent` — exactly what the docs instruct — hits SCM error 1053 after ~30s.
+The documented Windows alpha service path cannot work as shipped; running as
+LocalSystem is also over-privileged for a user-level LLM router.
+
+**Fix:** wrap with a real service host (WinSW/NSSM in the zip, or pywin32
+`win32serviceutil`), or drop the SCM pretense for a per-user scheduled task
+mirroring the systemd *user*-unit posture.
+
+# S3 — maintenance, consistency, latent risk
+
+## F-35 · c9bd30a payload adaptation applied to chat only — embeddings still 502s on unknown fields
+
+**Verdict** CONFIRMED (two dimensions independently) · **F-24 follow-up**
+
+`packages/netllm-sdk-openai/src/netllm_sdk_openai/client.py:59,71` adapt the
+chat paths; `client.py:79-84` `embeddings.create(**payload)` splats raw
+payloads. The identical failure class c9bd30a fixed for chat (SDK rejects
+wire-valid extension fields → 502 per backend, each marked failed) remains live
+on `/v1/embeddings`. **Fix:** an embeddings twin of the adapter, or generalize
+`adapt_chat_payload_for_sdk` over an allowed-param set.
+
+## F-36 · `_SDK_CHAT_PARAMS` is a hand-maintained mirror of the pinned SDK signature with no drift test
+
+**Verdict** CONFIRMED (three dimensions) · **F-21-class mirror, F-16-adjacent**
+
+`payload.py:8-51` — a 40-name frozenset hand-copied from
+`openai.resources.chat.Completions.create` (verified exactly correct against
+openai 2.41.0 today). A future SDK bump silently breaks it in either direction
+(TypeError → 502s, or new typed params detouring through extra_body).
+**Fix:** one-assert test `set(inspect.signature(...).parameters) - {'self'} ==
+_SDK_CHAT_PARAMS` in `./scripts/ci.sh sdk` / the sdk-canary workflow.
+
+## F-37 · `payload.py` non-dict `extra_body` branch is a contradictory dead store
+
+**Verdict** CONFIRMED (two dimensions) · **F-18-class**
+
+`payload.py:111-115` — the `else` branch assigns `out["extra_body"] = existing`
+then line 115 unconditionally overwrites it; a client's non-dict `extra_body`
+is silently discarded. **Fix:** delete the dead assignment, decide drop-vs-pass
+explicitly, add the case to `tests/test_payload_adaptation.py`.
+
+## F-38 · `/v1/*` error bodies are FastAPI `{"detail"}`, not OpenAI/Anthropic error shapes
+
+**Verdict** CONFIRMED · **NEW**
+
+No `exception_handler` registrations exist anywhere in `packages/`; every
+non-2xx returns Starlette's `{"detail": "..."}`. OpenAI clients expect
+`{"error": {message,type,param,code}}`; Anthropic clients expect
+`{"type":"error","error":{...}}`. Error-body-driven client behavior (e.g.
+`context_length_exceeded` handling) degrades to generic messages. Upstream
+401/429 also collapse to 502 on OpenAI routes. **Fix:** per-surface exception
+handlers keyed on path prefix; forward upstream status codes uniformly.
+
+## F-39 · Responses streaming bridge omits `response.output_item.done` / `content_part.*` events
+
+**Verdict** CONFIRMED · **NEW**
+
+`packages/netllm-core/src/netllm_core/openai_responses_bridge.py:363-419` never
+closes output items or content parts, and `response.completed` carries a
+partial output array. The plan's Phase 3.5 live-Codex verification is
+explicitly unrun. **Fix:** emit the bracketing events; add a recorded-fixture
+test replaying a real Responses SSE transcript; run the live-Codex check.
+
+## F-40 · `/netllm/v1/client-env` is the one `/netllm` route with no gate after F-13
+
+**Verdict** CONFIRMED · **F-13 follow-up**
+
+`app.py:317-320` takes no `Request`, calls neither `require_read_access` nor
+`require_admin_access`. Payload is benign today (base URL + `netllm-local`
+placeholders); this is a consistency/latent-risk gap, not a leak. **Fix:** gate
+it like the other read routes, or mark it deliberately public with a test
+asserting the payload never carries secrets.
+
+## F-41 · `/metrics` stays unauthenticated and exposes fleet-reconnaissance data F-13 gated elsewhere
+
+**Verdict** CONFIRMED · **F-13 follow-up (scope omission)**
+
+`app.py:163-165` — ungated while every other read route is gated. `/metrics`
+leaks backend ids/providers, model names, routed counts and token totals — a
+large subset of what the F-13 docstring itself calls "complete fleet
+reconnaissance". **Fix:** `require_read_access` on `/metrics` (Prometheus
+supports `bearer_token` in scrape configs), preserving open behavior when no
+token is configured.
+
+## F-42 · Wire payloads can steer SDK-level controls: `extra_headers`, `extra_query`, `timeout`
+
+**Verdict** CONFIRMED · **NEW (c9bd30a contract)**
+
+`payload.py:8-51` classifies three SDK *control* kwargs as client-settable: a
+request body `{"extra_headers": {...}}` makes the OpenAI SDK inject arbitrary
+headers into the upstream call. **Fix:** drop the three from
+`_SDK_CHAT_PARAMS` (they fall into `extra_body` as harmless JSON) or strip them
+in `normalize_client_payload`; add a regression test.
+
+## F-43 · CLI `sources toggle` imports `netllm_agent` internals and FastAPI
+
+**Verdict** CONFIRMED · **adjacent to F-02 (which remains resolved)**
+
+`packages/netllm-cli/src/netllm_cli/main.py:2063-2064` imports
+`fastapi.HTTPException` and `netllm_agent.admin.apply_config_patch`, breaking
+the layering the F-02 fix established (`netllm config import` does it right via
+`netllm_core.config_json`). **Fix:** call
+`netllm_core.config_merge.apply_config_patch` + `config_guards` directly,
+catching `ConfigGuardError`.
+
+## F-44 · Dead async `probe_anthropic_compat` still embodies the pre-fix F-07 billable-probe bug
+
+**Verdict** CONFIRMED · **F-07/F-18 follow-up**
+
+`packages/netllm-core/src/netllm_core/health.py:214-237` — the async twin still
+POSTs a billable 1-token request against hardcoded
+`claude-3-5-haiku-20241022`; zero callers anywhere including tests. A latent
+regression vector of exactly the class F-18 catalogued. **Fix:** delete it, or
+mirror the fixed sync logic with a parity test.
+
+## F-45 · `_anthropic_api_key` env fallback lacks the placeholder-key guard `_openai_api_key` has
+
+**Verdict** CONFIRMED · **F-04 follow-up (fix itself holds)**
+
+`service.py:1360-1364` returns `os.environ["ANTHROPIC_API_KEY"]` without
+`is_netllm_placeholder_key`, unlike the OpenAI twin at `:1373`. Residual path:
+an anthropic-format `[[routing.backends]]` row with no `api_key` can send a
+literal `netllm-*` placeholder upstream. **Fix:** one-line mirror + one test.
+
+## F-46 · `cloud.fallback = "local"` is still cloud-first — the acknowledged UX trap is unarmed
+
+**Verdict** CONFIRMED · **NEW as a registered finding (noted in AGENTS.md at baseline)**
+
+`packages/netllm-core/src/netllm_core/routing_policy.py:104-106` — the value
+names the fallback *tier* while every user instinct reads it as the *priority*.
+For a local-first product, one mistyped word silently sends all traffic and
+spend cloud-first. **Fix:** keep the key for compat; accept
+`local-first`/`cloud-first` aliases in the CLI, print an explicit one-line
+explanation on every change, and note it in `doctor`.
+
+## F-47 · Source identity is not propagated on peer hops — mesh traffic attributes as `default`
+
+**Verdict** CONFIRMED · **NEW**
+
+`service.py:662-670` — `_peer_forward_headers` forwards only the loop-guard and
+hops headers; `x-netllm-source` is dropped. Routing correctness is unaffected
+(policies apply on the gateway pre-hop) but per-source telemetry on serving
+nodes shows everything as `source=default`. **Fix:** forward the resolved id as
+attribution-only (peers must not grant elevated capability from an
+unauthenticated forwarded header).
+
+## F-48 · `stats.json` is rewritten in place — crash mid-write zeroes all-time counters
+
+**Verdict** CONFIRMED · **F-09 follow-up (durability, not frequency)**
+
+`packages/netllm-agent/src/netllm_agent/telemetry.py:122-130` —
+`write_text` truncates the live file; `_load_alltime` silently discards partial
+JSON on next start. **Fix:** tmp-file + `os.replace` (atomic on POSIX and
+Windows); log a warning on `JSONDecodeError` instead of silent reset.
+
+## F-49 · Telemetry contract fields hand-mirrored in three surfaces (dashboard JS, two Swift files)
+
+**Verdict** CONFIRMED (two dimensions) · **F-21 follow-up, extended by ccc1c79**
+
+Server always emits canonical keys (`telemetry.py:47`), yet dashboard.js
+(`routerScopeBlock`) and `ServingStatsMenuBuilder.swift` /
+`TelemetryPoller.swift` each re-derive `total_tokens` and carry stringly-typed
+key lists. dashboard.js grew to 2,817 lines (largest first-party source file,
++95 in ccc1c79). **Fix:** treat `docs/telemetry-api.md` as normative, delete
+client-side fallbacks, add a contract test on the documented key set; include
+dashboard.js when the F-24/F-26 refactor is picked up.
+
+## F-50 · c9bd30a's payload contract is documented nowhere; sdk-openai DOX not updated
+
+**Verdict** CONFIRMED (two dimensions) · **NEW (post-audit commit)**
+
+`payload.py` aliases `repeat_penalty→repetition_penalty` for every
+OpenAI-format backend and flattens client `extra_body` — user-observable
+payload rewriting with zero mention in any doc, and
+`packages/netllm-sdk-openai/AGENTS.md` still says "Key module: client.py",
+violating the root DOX rule. **Fix:** document the contract (which fields pass
+typed, which via extra_body, the alias table) in the package AGENTS.md +
+a user-facing note in `docs/editor-integration.md`.
+
+## F-51 · AGENTS.md contradicts itself on the `netllm sources` CLI
+
+**Verdict** CONFIRMED · **NEW**
+
+Key commands (AGENTS.md:77-78) documents `sources list|toggle` (which ship,
+`main.py:2025-2052`); a workspace-facts bullet (AGENTS.md:263-265) says the
+sources CLI is "still not built". **Fix:** edit the bullet to
+"`netllm connect` CLI still not built (`netllm sources list|toggle` shipped)".
+
+## F-52 · `docs/telemetry-api.md` still documents the pre-F-10 psutil behavior
+
+**Verdict** CONFIRMED · **F-10 doc-side follow-up**
+
+`docs/telemetry-api.md:45` says `host` stays null unless psutil is manually
+installed (Linux); psutil is now a hard dependency of netllm-agent
+(`pyproject.toml:18`), so `host` populates on all platforms. **Fix:** update
+the doc and its `"host": null` example.
+
+## F-53 · Undocumented shipped surface: `config export|schema`, `models --local/--subnet-scan`, `[ui]` menubar/favorites keys
+
+**Verdict** DOWNGRADED→narrowed (core confirmed) · **F-21-adjacent (docs, not mirror)**
+
+`main.py:1660-1691` (`config export|schema`) and `main.py:644-662` (models
+flags) appear in no user-facing doc; `[ui]` `model_favorites` /
+`menubar_show_*` keys are absent from `config.example.toml`. **Fix:** add rows
+to the AGENTS.md Key commands table and commented keys to
+`config.example.toml`.
+
+---
+
+## Status verifications (informational, no action)
+
+- **Open/partial baseline findings re-verified unchanged:** F-20, F-21, F-23,
+  F-24, F-25, F-26, F-28, F-29 all remain accurately described at HEAD; none
+  silently resolved or materially worsened (F-21 nudged by ccc1c79 → F-49).
+- **F-26 sizes:** service.py 2,246 · cli main.py 2,141 · dashboard.js 2,817
+  (baseline: 2,149 / 2,119 / 2,721). Growth came from the audit's own
+  remediation; post-audit accretion is dashboard.js only. Stable debt, not
+  growing debt.
+- **Integration roll-up:** Cursor/generic-OpenAI solid · Claude Code local path
+  solid, cloud-Anthropic streaming broken (F-30) · Codex bridge partial (F-39,
+  live verification unrun) · Honcho solid per its doc · Gemini CLI correctly
+  documented as not reliably wireable · Buzz is an attribution label with no
+  dedicated integration (worth stating in docs). Source-identity precedence
+  (header → virtual key → UA → default, secret gating) implemented exactly as
+  documented. OpenRouter OAuth PKCE correct.
+- **Standards posture:** cluster-token handling is right end to end
+  (`secrets.token_urlsafe(24)`, 0o600 config, `secrets.compare_digest` at all
+  gates). Exposure-phase fixes (F-06/07/11–15) held. Two hygiene notes folded
+  into the work queue: basedpyright still non-blocking with no dated milestone
+  (F-27 follow-up), and the deb/rpm systemd user unit ships without the four
+  standard hardening directives (F-28 follow-up).
+- **Architecture doc counts drifted** within 2 days (642→647 tests, LOC
+  figures): expected decay of frozen snapshots; bump figures on the next
+  audit-adjacent PR (per AGENTS.md verification rules) rather than per commit.
+
+## Comparison to the established baseline
+
+The 2026-07-29 register's assessment ("baseline health is good; these are the
+remaining edges") remains accurate and its status table is trustworthy as of
+`c9bd30a`. What this audit adds: the baseline audit was code-inward
+(correctness of what exists); this pass was product-outward (claims vs code,
+wire fidelity vs client expectations, cross-surface consistency), which is
+where the S1/S2 items above were hiding — every one of them sits on a boundary
+the baseline scoped out (streaming error semantics, Anthropic-format streaming,
+README claims, Windows service packaging). The fragmentation thesis was
+confirmed in the specific mechanism F-24 predicted: post-audit fixes landing on
+one proxy loop but not its siblings (F-33, F-35) is now the dominant defect
+generator, which strengthens the register's case for the scoped-out F-24
+consolidation refactor.

--- a/docs/architecture/09-follow-up-audit-2026-07-31.md
+++ b/docs/architecture/09-follow-up-audit-2026-07-31.md
@@ -10,7 +10,7 @@ raw findings survived verification (35 CONFIRMED, 1 narrowed in scope);
 deduplicated to 24 findings below**, numbered **F-30…F-53** continuing the
 register's append-only namespace.
 
-**Baseline guard:** `uv run pytest -q` → **647 passed, 4 skipped** (above the
+**Baseline guard:** `uv run pytest -q` → **647 passed, 4 skipped** at audit time; **699 passed, 4 skipped** after remediation (above the
 642-passing baseline). Lint clean. No regression of any RESOLVED F-01…F-29
 finding was found — the specific fix sites of F-01/F-02/F-03/F-04/F-05/F-06/
 F-07/F-09/F-13 were each re-verified intact at HEAD.
@@ -58,6 +58,10 @@ juggling.
 - Prediction (c) confirmed at S2: the README's flagship quickstart no longer
   matches the code (F-31).
 
+## Remediation status (2026-07-31)
+
+21 of 24 findings **RESOLVED** on this branch (all S1/S2 except F-34, and all S3 except F-49), each with a finding-targeted red-green regression test and an independent verification pass. F-39 partial (events fixed; live-Codex check deferred). F-34 and F-49 deferred with reasons noted in place. Suite 647 → 699 passing.
+
 ## Severity summary
 
 | Severity | Count | Theme |
@@ -82,6 +86,8 @@ juggling.
 # S1 — production-affecting
 
 ## F-30 · Streaming Anthropic Messages to any anthropic-format backend always fails
+
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
 
 **Severity** S1 · **Area** request path / SDK adapter · **Reproduced** · **Verdict** CONFIRMED (found independently by two dimensions)
 
@@ -109,6 +115,8 @@ this class.
 
 ## F-31 · README two-machine quickstart cannot work as written
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — docs corrected; every claim re-verified against the cited code; independently verified.
+
 **Severity** S2 · **Area** docs alignment · **Verdict** CONFIRMED
 
 `README.md:69-77` and `README.md:290` claim `./netllm init --swarm` generates a
@@ -124,6 +132,8 @@ most prominent workflow.
 the open-LAN flow (`init --swarm` on both machines, verify with `./netllm peers`).
 
 ## F-32 · Streaming routes' error handling is dead code — errors yield HTTP 200 + aborted stream
+
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
 
 **Severity** S2 · **Area** request path · **Verdict** CONFIRMED
 
@@ -142,6 +152,8 @@ resolution, first-backend selection) before constructing the
 
 ## F-33 · Success accounting diverges across the four proxy loops; the new Serving UI makes it visible
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Severity** S2 · **Area** telemetry / F-24 divergence · **Verdict** CONFIRMED
 
 `packages/netllm-agent/src/netllm_agent/service.py:1904-1910` —
@@ -157,6 +169,8 @@ skewed health/latency stats that `least_load`/`latency_weighted` also consume.
 have both streaming wrappers parse the final usage-bearing SSE chunk.
 
 ## F-34 · Windows "service" is a plain console exe registered with sc.exe — SCM will kill it
+
+> **DEFERRED — Windows service host design choice; parked for the multi-env dev workspace**
 
 **Severity** S2 · **Area** packaging (Windows) · **Verdict** CONFIRMED
 
@@ -175,6 +189,8 @@ mirroring the systemd *user*-unit posture.
 
 ## F-35 · c9bd30a payload adaptation applied to chat only — embeddings still 502s on unknown fields
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Verdict** CONFIRMED (two dimensions independently) · **F-24 follow-up**
 
 `packages/netllm-sdk-openai/src/netllm_sdk_openai/client.py:59,71` adapt the
@@ -185,6 +201,8 @@ on `/v1/embeddings`. **Fix:** an embeddings twin of the adapter, or generalize
 `adapt_chat_payload_for_sdk` over an allowed-param set.
 
 ## F-36 · `_SDK_CHAT_PARAMS` is a hand-maintained mirror of the pinned SDK signature with no drift test
+
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
 
 **Verdict** CONFIRMED (three dimensions) · **F-21-class mirror, F-16-adjacent**
 
@@ -197,6 +215,8 @@ _SDK_CHAT_PARAMS` in `./scripts/ci.sh sdk` / the sdk-canary workflow.
 
 ## F-37 · `payload.py` non-dict `extra_body` branch is a contradictory dead store
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Verdict** CONFIRMED (two dimensions) · **F-18-class**
 
 `payload.py:111-115` — the `else` branch assigns `out["extra_body"] = existing`
@@ -205,6 +225,8 @@ is silently discarded. **Fix:** delete the dead assignment, decide drop-vs-pass
 explicitly, add the case to `tests/test_payload_adaptation.py`.
 
 ## F-38 · `/v1/*` error bodies are FastAPI `{"detail"}`, not OpenAI/Anthropic error shapes
+
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
 
 **Verdict** CONFIRMED · **NEW**
 
@@ -218,6 +240,8 @@ handlers keyed on path prefix; forward upstream status codes uniformly.
 
 ## F-39 · Responses streaming bridge omits `response.output_item.done` / `content_part.*` events
 
+> **PARTIAL — missing SSE lifecycle events fixed with a fixture-replay test; live-Codex verification deliberately deferred (no Codex in CI)**
+
 **Verdict** CONFIRMED · **NEW**
 
 `packages/netllm-core/src/netllm_core/openai_responses_bridge.py:363-419` never
@@ -228,6 +252,8 @@ test replaying a real Responses SSE transcript; run the live-Codex check.
 
 ## F-40 · `/netllm/v1/client-env` is the one `/netllm` route with no gate after F-13
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Verdict** CONFIRMED · **F-13 follow-up**
 
 `app.py:317-320` takes no `Request`, calls neither `require_read_access` nor
@@ -237,6 +263,8 @@ it like the other read routes, or mark it deliberately public with a test
 asserting the payload never carries secrets.
 
 ## F-41 · `/metrics` stays unauthenticated and exposes fleet-reconnaissance data F-13 gated elsewhere
+
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
 
 **Verdict** CONFIRMED · **F-13 follow-up (scope omission)**
 
@@ -249,6 +277,8 @@ token is configured.
 
 ## F-42 · Wire payloads can steer SDK-level controls: `extra_headers`, `extra_query`, `timeout`
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Verdict** CONFIRMED · **NEW (c9bd30a contract)**
 
 `payload.py:8-51` classifies three SDK *control* kwargs as client-settable: a
@@ -258,6 +288,8 @@ headers into the upstream call. **Fix:** drop the three from
 in `normalize_client_payload`; add a regression test.
 
 ## F-43 · CLI `sources toggle` imports `netllm_agent` internals and FastAPI
+
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
 
 **Verdict** CONFIRMED · **adjacent to F-02 (which remains resolved)**
 
@@ -270,6 +302,8 @@ catching `ConfigGuardError`.
 
 ## F-44 · Dead async `probe_anthropic_compat` still embodies the pre-fix F-07 billable-probe bug
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Verdict** CONFIRMED · **F-07/F-18 follow-up**
 
 `packages/netllm-core/src/netllm_core/health.py:214-237` — the async twin still
@@ -280,6 +314,8 @@ mirror the fixed sync logic with a parity test.
 
 ## F-45 · `_anthropic_api_key` env fallback lacks the placeholder-key guard `_openai_api_key` has
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Verdict** CONFIRMED · **F-04 follow-up (fix itself holds)**
 
 `service.py:1360-1364` returns `os.environ["ANTHROPIC_API_KEY"]` without
@@ -288,6 +324,8 @@ an anthropic-format `[[routing.backends]]` row with no `api_key` can send a
 literal `netllm-*` placeholder upstream. **Fix:** one-line mirror + one test.
 
 ## F-46 · `cloud.fallback = "local"` is still cloud-first — the acknowledged UX trap is unarmed
+
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
 
 **Verdict** CONFIRMED · **NEW as a registered finding (noted in AGENTS.md at baseline)**
 
@@ -300,6 +338,8 @@ explanation on every change, and note it in `doctor`.
 
 ## F-47 · Source identity is not propagated on peer hops — mesh traffic attributes as `default`
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Verdict** CONFIRMED · **NEW**
 
 `service.py:662-670` — `_peer_forward_headers` forwards only the loop-guard and
@@ -311,6 +351,8 @@ unauthenticated forwarded header).
 
 ## F-48 · `stats.json` is rewritten in place — crash mid-write zeroes all-time counters
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — red-green regression test included; independently verified.
+
 **Verdict** CONFIRMED · **F-09 follow-up (durability, not frequency)**
 
 `packages/netllm-agent/src/netllm_agent/telemetry.py:122-130` —
@@ -319,6 +361,8 @@ JSON on next start. **Fix:** tmp-file + `os.replace` (atomic on POSIX and
 Windows); log a warning on `JSONDecodeError` instead of silent reset.
 
 ## F-49 · Telemetry contract fields hand-mirrored in three surfaces (dashboard JS, two Swift files)
+
+> **DEFERRED — telemetry-mirror consolidation folded into the F-24/F-26 refactor plan (phase 10)**
 
 **Verdict** CONFIRMED (two dimensions) · **F-21 follow-up, extended by ccc1c79**
 
@@ -332,6 +376,8 @@ dashboard.js when the F-24/F-26 refactor is picked up.
 
 ## F-50 · c9bd30a's payload contract is documented nowhere; sdk-openai DOX not updated
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — docs corrected; every claim re-verified against the cited code; independently verified.
+
 **Verdict** CONFIRMED (two dimensions) · **NEW (post-audit commit)**
 
 `payload.py` aliases `repeat_penalty→repetition_penalty` for every
@@ -344,6 +390,8 @@ a user-facing note in `docs/editor-integration.md`.
 
 ## F-51 · AGENTS.md contradicts itself on the `netllm sources` CLI
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — docs corrected; every claim re-verified against the cited code; independently verified.
+
 **Verdict** CONFIRMED · **NEW**
 
 Key commands (AGENTS.md:77-78) documents `sources list|toggle` (which ship,
@@ -353,6 +401,8 @@ sources CLI is "still not built". **Fix:** edit the bullet to
 
 ## F-52 · `docs/telemetry-api.md` still documents the pre-F-10 psutil behavior
 
+> **RESOLVED (2026-07-31, remediation on this branch)** — docs corrected; every claim re-verified against the cited code; independently verified.
+
 **Verdict** CONFIRMED · **F-10 doc-side follow-up**
 
 `docs/telemetry-api.md:45` says `host` stays null unless psutil is manually
@@ -361,6 +411,8 @@ installed (Linux); psutil is now a hard dependency of netllm-agent
 the doc and its `"host": null` example.
 
 ## F-53 · Undocumented shipped surface: `config export|schema`, `models --local/--subnet-scan`, `[ui]` menubar/favorites keys
+
+> **RESOLVED (2026-07-31, remediation on this branch)** — docs corrected; every claim re-verified against the cited code; independently verified.
 
 **Verdict** DOWNGRADED→narrowed (core confirmed) · **F-21-adjacent (docs, not mirror)**
 

--- a/docs/architecture/AGENTS.md
+++ b/docs/architecture/AGENTS.md
@@ -6,8 +6,9 @@ Two things in one folder, deliberately kept together so they cannot drift apart:
 
 1. **Reference** (01–06) — how the system is built: components, request lifecycle, swarm
    behaviour, configuration/control plane, dependency map. Intended to stay true.
-2. **Audit** (07–08) — a point-in-time register of defects, risks, and integration gaps,
-   plus the product-facing shipped/partial/orphaned matrix.
+2. **Audit** (07–09) — point-in-time registers of defects, risks, and integration gaps,
+   plus the product-facing shipped/partial/orphaned matrix. 09 continues 07's F-nn
+   namespace at F-30.
 
 Index: [README.md](README.md). Parent rail: [../AGENTS.md](../AGENTS.md).
 
@@ -23,6 +24,7 @@ Index: [README.md](README.md). Parent rail: [../AGENTS.md](../AGENTS.md).
 | `06-dependencies.md` | internal graph, external/undeclared deps, platform + CI + release dependencies |
 | `07-findings-register.md` | F-01…F-29 with severity, evidence, and fix |
 | `08-feature-integration-status.md` | shipped / partial / orphaned per client surface; product decisions |
+| `09-follow-up-audit-2026-07-31.md` | F-30…F-53 with severity, evidence, and fix (same contracts as 07; IDs continue the register namespace) |
 
 ## Local Contracts
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -41,6 +41,7 @@ carries a `file:line` reference and, where practical, a reproduction that was ac
 | 06 | [Dependencies](06-dependencies.md) | Internal graph, external packages, platform/build/CI dependencies |
 | 07 | [Findings register](07-findings-register.md) | 29 verified findings with fix status: correctness, security, performance, simplification |
 | 08 | [Feature integration status](08-feature-integration-status.md) | Shipped / partial / orphaned matrix for planning |
+| 09 | [Follow-up audit 2026-07-31](09-follow-up-audit-2026-07-31.md) | F-30…F-53: product-outward audit at `c9bd30a` (wire fidelity, docs alignment, cross-surface consistency) |
 
 ## Scope and method
 

--- a/docs/editor-integration.md
+++ b/docs/editor-integration.md
@@ -33,6 +33,8 @@ Use the same pattern for **Cursor, Claude Code, Codex, Honcho, Continue, Cline, 
 
 Verify after wiring: `./netllm test --model <your-model>` (add `--api anthropic` for Messages API).
 
+Non-standard sampling knobs (`top_k`, `min_p`, `repeat_penalty`, …) are accepted on the OpenAI-compatible routes and forwarded to backends that support them — netllm normalizes the payload for the upstream (including aliasing `repeat_penalty` to `repetition_penalty` for OpenAI-format backends such as vLLM), so tools that send Ollama/LM Studio-style options keep working through the router.
+
 Per-tool UI steps below; Honcho-specific connector sharding: [honcho-integration.md](honcho-integration.md).
 
 ## Cursor

--- a/docs/telemetry-api.md
+++ b/docs/telemetry-api.md
@@ -29,7 +29,12 @@ Same host access as `/netllm/v1/status` (no admin token required on loopback).
     "backends": []
   },
   "omlx": { "available": false },
-  "host": null,
+  "host": {
+    "cpu_percent": 12.5,
+    "memory_used_gb": 18.42,
+    "memory_total_gb": 32.0,
+    "memory_percent": 57.6
+  },
   "history": {
     "router_rps": [],
     "omlx_pp_tps": [],
@@ -42,7 +47,7 @@ When an oMLX backend is online, `omlx.available` is true and `session` / `alltim
 
 Router all-time counters persist to `~/.config/netllm/stats.json`.
 
-Host metrics (E/P CPU, memory breakdown) are macOS menubar-only today; `host` stays null in the agent response unless `psutil` is installed on the agent host (Linux).
+The `host` block (CPU %, memory used/total/percent) is populated on all platforms — `psutil` is a hard dependency of netllm-agent; it is `null` only if the `psutil` import fails. Richer host metrics (E/P CPU split, memory breakdown) remain macOS menubar-only (native, not from this API).
 
 ## UI surfaces
 

--- a/packages/netllm-agent/src/netllm_agent/app.py
+++ b/packages/netllm-agent/src/netllm_agent/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import secrets
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -30,10 +31,42 @@ from netllm_agent.admin import (
     require_admin_access,
     save_config_patch,
 )
+from netllm_agent.errors import install_error_handlers
 from netllm_agent.metrics import metrics_bytes
 from netllm_agent.service import AgentService, SourceCapacityExceeded
 
 _STATIC_DIR = Path(__file__).resolve().parent / "static"
+
+
+async def _started_stream(gen: AsyncIterator[str]) -> AsyncIterator[str]:
+    """Pull the first chunk before the StreamingResponse exists (F-32).
+
+    An async generator executes nothing until first iteration, and
+    StreamingResponse sends ``http.response.start`` before iterating — so
+    pre-stream failures (source admission, routing resolution, every
+    backend failed) would surface as HTTP 200 with an aborted body.
+    Awaiting the first chunk here makes those errors raise in the route
+    handler, where they map to real status codes (429/502/...).
+
+    Mid-stream failures after bytes are on the wire can still only abort
+    the SSE stream — that is acceptable and standard; the service layer
+    emits an in-band error event for that case.
+    """
+    try:
+        first = await anext(gen)
+    except StopAsyncIteration:
+        first = None
+
+    async def _replay() -> AsyncIterator[str]:
+        try:
+            if first is not None:
+                yield first
+                async for chunk in gen:
+                    yield chunk
+        finally:
+            await gen.aclose()
+
+    return _replay()
 
 
 def create_app(
@@ -58,6 +91,7 @@ def create_app(
     app = FastAPI(title="netllm-agent", version=get_version(), lifespan=lifespan)
     app.state.service = service
     app.state.config = cfg
+    install_error_handlers(app)
 
     def _is_local_client(request: Request) -> bool:
         from netllm_core.platform import local_admin_client_hosts
@@ -161,7 +195,12 @@ def create_app(
         return {"status": "ok"}
 
     @app.get("/metrics")
-    async def metrics() -> Response:
+    async def metrics(request: Request) -> Response:
+        # F-41: /metrics exposes backend ids/providers, model names, routed
+        # counts and token totals — gated like the other read routes once a
+        # cluster token exists (Prometheus scrape configs support
+        # bearer_token); stays open when no token is configured.
+        require_read_access(request)
         return Response(content=metrics_bytes(), media_type="text/plain")
 
     # --- Swarm API ---
@@ -315,7 +354,8 @@ def create_app(
         return {"ok": True, "draining": service.draining}
 
     @app.get("/netllm/v1/client-env")
-    async def netllm_client_env() -> dict[str, Any]:
+    async def netllm_client_env(request: Request) -> dict[str, Any]:
+        require_read_access(request)
         base = service.swarm.local_agent_url()
         return {"vars": client_env_vars(base)}
 
@@ -409,8 +449,10 @@ def create_app(
         try:
             if stream:
                 return StreamingResponse(
-                    service.proxy_chat_completion_stream(
-                        payload, headers=request.headers
+                    await _started_stream(
+                        service.proxy_chat_completion_stream(
+                            payload, headers=request.headers
+                        )
                     ),
                     media_type="text/event-stream",
                 )
@@ -436,7 +478,9 @@ def create_app(
         try:
             if stream:
                 return StreamingResponse(
-                    service.proxy_responses_stream(payload, headers=request.headers),
+                    await _started_stream(
+                        service.proxy_responses_stream(payload, headers=request.headers)
+                    ),
                     media_type="text/event-stream",
                 )
             return await service.proxy_responses(payload, headers=request.headers)
@@ -473,7 +517,9 @@ def create_app(
         try:
             if stream:
                 return StreamingResponse(
-                    service.proxy_messages_stream(payload, headers=hdrs),
+                    await _started_stream(
+                        service.proxy_messages_stream(payload, headers=hdrs)
+                    ),
                     media_type="text/event-stream",
                 )
             return await service.proxy_messages(payload, headers=hdrs)

--- a/packages/netllm-agent/src/netllm_agent/errors.py
+++ b/packages/netllm-agent/src/netllm_agent/errors.py
@@ -1,0 +1,90 @@
+"""Per-surface HTTP error envelopes (F-38).
+
+FastAPI's default renders every HTTPException as ``{"detail": "..."}``,
+which no OpenAI or Anthropic client understands. Handlers installed here
+key on the request path:
+
+- ``/v1/messages*`` — Anthropic shape:
+  ``{"type": "error", "error": {"type": ..., "message": ...}}``
+- other ``/v1/*`` — OpenAI shape:
+  ``{"error": {"message": ..., "type": ..., "param": ..., "code": ...}}``
+- everything else (``/netllm/*``, ``/health``, ...) keeps FastAPI's
+  ``{"detail": ...}``.
+
+Status codes are preserved exactly as raised — routes that forward
+upstream statuses (429/401/404) keep doing so; only the body is shaped.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request
+from fastapi.exception_handlers import http_exception_handler
+from fastapi.responses import JSONResponse, Response
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+_ANTHROPIC_ERROR_TYPES = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    413: "request_too_large",
+    429: "rate_limit_error",
+    500: "api_error",
+    529: "overloaded_error",
+}
+
+_OPENAI_ERROR_TYPES = {
+    400: ("invalid_request_error", None),
+    401: ("authentication_error", None),
+    403: ("permission_error", None),
+    404: ("invalid_request_error", "not_found"),
+    405: ("invalid_request_error", "method_not_allowed"),
+    413: ("invalid_request_error", "request_too_large"),
+    429: ("rate_limit_error", "rate_limit_exceeded"),
+}
+
+
+def anthropic_error_body(status_code: int, message: str) -> dict[str, object]:
+    default = "api_error" if status_code >= 500 else "invalid_request_error"
+    return {
+        "type": "error",
+        "error": {
+            "type": _ANTHROPIC_ERROR_TYPES.get(status_code, default),
+            "message": message,
+        },
+    }
+
+
+def openai_error_body(status_code: int, message: str) -> dict[str, object]:
+    default = (
+        ("api_error", None) if status_code >= 500 else ("invalid_request_error", None)
+    )
+    err_type, code = _OPENAI_ERROR_TYPES.get(status_code, default)
+    return {
+        "error": {
+            "message": message,
+            "type": err_type,
+            "param": None,
+            "code": code,
+        }
+    }
+
+
+def _is_messages_path(path: str) -> bool:
+    return path == "/v1/messages" or path.startswith("/v1/messages/")
+
+
+def install_error_handlers(app: FastAPI) -> None:
+    @app.exception_handler(StarletteHTTPException)
+    async def _surface_shaped_http_exception(
+        request: Request, exc: StarletteHTTPException
+    ) -> Response:
+        path = request.url.path
+        if not path.startswith("/v1/"):
+            return await http_exception_handler(request, exc)
+        message = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        if _is_messages_path(path):
+            body = anthropic_error_body(exc.status_code, message)
+        else:
+            body = openai_error_body(exc.status_code, message)
+        return JSONResponse(body, status_code=exc.status_code, headers=exc.headers)

--- a/packages/netllm-agent/src/netllm_agent/service.py
+++ b/packages/netllm-agent/src/netllm_agent/service.py
@@ -22,10 +22,12 @@ from netllm_core.cloud_providers import get_provider_spec
 from netllm_core.models import (
     ANTHROPIC_CLOUD_BASE_URL,
     BACKEND_PIN_HEADER,
+    DEFAULT_SOURCE_ID,
     HOPS_HEADER,
     LOCAL_ONLY_HEADER,
     MAX_FORWARD_HOPS,
     OPENAI_CLOUD_BASE_URL,
+    SOURCE_HEADER,
     STRATEGY_HEADER,
     Backend,
     BackendHealth,
@@ -82,6 +84,14 @@ logger = logging.getLogger(__name__)
 # clients are never cached, because their credential can come from the
 # calling request (docs/architecture/07-findings-register.md F-04).
 LEGACY_CLOUD_BACKEND_IDS = frozenset({"openai-cloud", "anthropic-cloud"})
+
+
+def _token_count(value: Any) -> int:
+    """Backend-supplied usage values are untrusted; never raise mid-stream."""
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
 
 
 class SourceCapacityExceeded(Exception):
@@ -165,11 +175,11 @@ class AgentService:
         usage = result.get("usage")
         if not isinstance(usage, dict):
             return 0, 0
-        prompt = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
-        completion = int(
-            usage.get("completion_tokens") or usage.get("output_tokens") or 0
+        prompt = _token_count(usage.get("prompt_tokens") or usage.get("input_tokens"))
+        completion = _token_count(
+            usage.get("completion_tokens") or usage.get("output_tokens")
         )
-        return max(0, prompt), max(0, completion)
+        return prompt, completion
 
     def _record_success_telemetry(
         self,
@@ -195,6 +205,75 @@ class AgentService:
             prefill_duration=prefill_dur,
             generation_duration=gen_dur if completion else 0.0,
         )
+
+    @staticmethod
+    def _usage_from_sse_chunk(chunk: str) -> tuple[int, int]:
+        """Token usage carried by one SSE chunk, if any.
+
+        Understands both wire formats a streaming wrapper can see:
+        Anthropic (message_start's message.usage / message_delta's usage,
+        input_tokens/output_tokens) and OpenAI (the stream_options
+        include_usage chunk, prompt_tokens/completion_tokens).
+        """
+        prompt = completion = 0
+        for line in chunk.split("\n"):
+            if not line.startswith("data:"):
+                continue
+            data = line[5:].strip()
+            if not data or data == "[DONE]":
+                continue
+            try:
+                obj = json.loads(data)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict):
+                continue
+            usage = obj.get("usage")
+            if not isinstance(usage, dict):
+                message = obj.get("message")
+                usage = message.get("usage") if isinstance(message, dict) else None
+            if not isinstance(usage, dict):
+                continue
+            prompt = max(
+                prompt,
+                _token_count(usage.get("input_tokens") or usage.get("prompt_tokens")),
+            )
+            completion = max(
+                completion,
+                _token_count(
+                    usage.get("output_tokens") or usage.get("completion_tokens")
+                ),
+            )
+        return prompt, completion
+
+    def _record_stream_success(
+        self,
+        *,
+        backend: Backend,
+        model: str,
+        latency_s: float,
+        prompt_tokens: int,
+        completion_tokens: int,
+    ) -> None:
+        """Success accounting for a completed stream — the streaming twin
+        of _record_success_telemetry (F-33)."""
+        self.pool.mark_success(backend, latency_s * 1000)
+        REQUESTS_TOTAL.labels(backend=backend.base_url, model=model, status="ok").inc()
+        REQUEST_LATENCY.labels(backend=backend.base_url).observe(latency_s)
+        if prompt_tokens or completion_tokens:
+            PROMPT_TOKENS_TOTAL.labels(backend=backend.base_url, model=model).inc(
+                prompt_tokens
+            )
+            COMPLETION_TOKENS_TOTAL.labels(backend=backend.base_url, model=model).inc(
+                completion_tokens
+            )
+        self.telemetry.record_usage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            prefill_duration=latency_s * 0.3 if prompt_tokens else 0.0,
+            generation_duration=latency_s * 0.7 if completion_tokens else 0.0,
+        )
+        self._request_count += 1
 
     async def refresh_local_backends(
         self,
@@ -648,9 +727,8 @@ class AgentService:
                 for line in chunk.split("\n")
             )
 
-    @staticmethod
     def _peer_forward_headers(
-        backend: Backend, incoming: Mapping[str, str] | None = None
+        self, backend: Backend, incoming: Mapping[str, str] | None = None
     ) -> dict[str, str] | None:
         """Loop guard: agent-hop forwards must terminate at the peer.
 
@@ -658,15 +736,25 @@ class AgentService:
         (round_robin, least_load, ...) could bounce the request back,
         ping-ponging it across the mesh. The hop counter is a second
         line of defense should the local-only header ever be dropped.
+
+        The resolved source id also rides along (F-47) so per-source
+        telemetry on the serving peer attributes mesh traffic to the real
+        caller instead of "default". Attribution-only: the receiving peer
+        re-resolves the header itself, and resolve_source never grants a
+        secret-gated identity from a bare header — only a virtual key
+        carrying the correct secret does.
         """
         if backend.id.startswith("peer:"):
-            hops = AgentService._incoming_hops(
-                AgentService._normalize_headers(incoming)
-            )
-            return {
+            hdrs = self._normalize_headers(incoming)
+            hops = self._incoming_hops(hdrs)
+            out = {
                 LOCAL_ONLY_HEADER: "1",
                 HOPS_HEADER: str(hops + 1),
             }
+            resolved = resolve_source(headers=hdrs, sources=self.config.routing.sources)
+            if resolved.id != DEFAULT_SOURCE_ID:
+                out[SOURCE_HEADER] = resolved.id
+            return out
         return None
 
     def _upstream_api_key(self, backend: Backend) -> str:
@@ -1361,7 +1449,10 @@ class AgentService:
         key = headers.get("x-api-key", "")
         if key and not is_netllm_placeholder_key(key):
             return key
-        return os.environ.get("ANTHROPIC_API_KEY", "")
+        env_key = os.environ.get("ANTHROPIC_API_KEY", "")
+        if env_key and not is_netllm_placeholder_key(env_key):
+            return env_key
+        return ""
 
     @staticmethod
     def _openai_api_key(headers: Mapping[str, str]) -> str:
@@ -1901,17 +1992,36 @@ class AgentService:
                 BACKEND_IN_FLIGHT.labels(backend=backend.base_url).set(
                     backend.in_flight
                 )
+                t0 = time.monotonic()
+                prompt_tokens = completion_tokens = 0
                 try:
                     async for chunk in self._messages_stream_on_backend(
                         backend, payload, model, hdrs, api_key
                     ):
+                        if '"usage"' in chunk:
+                            p, c = self._usage_from_sse_chunk(chunk)
+                            prompt_tokens = max(prompt_tokens, p)
+                            completion_tokens = max(completion_tokens, c)
                         yielded_any = True
                         yield chunk
+                    # Same success accounting as _stream_with_metrics —
+                    # streamed Messages traffic must not be invisible to
+                    # the pool and telemetry (F-33).
+                    self._record_stream_success(
+                        backend=backend,
+                        model=model,
+                        latency_s=time.monotonic() - t0,
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                    )
                     return
                 except (AnthropicUpstreamError, OpenAIUpstreamError) as exc:
                     last_error = exc
                     tried.add(backend.id)
                     self._mark_backend_failure(backend, exc)
+                    REQUESTS_TOTAL.labels(
+                        backend=backend.base_url, model=model, status="error"
+                    ).inc()
                     logger.warning(
                         "messages stream backend %s failed (attempt %s): %s",
                         backend.base_url,
@@ -2025,16 +2135,23 @@ class AgentService:
         shard: ShardContext | None = None,
     ) -> AsyncIterator[str]:
         t0 = time.monotonic()
+        prompt_tokens = completion_tokens = 0
         try:
             async for chunk in client.chat_completion_stream(payload):
+                if '"usage"' in chunk:
+                    # Present only when the caller asked for
+                    # stream_options.include_usage; zero otherwise.
+                    p, c = self._usage_from_sse_chunk(chunk)
+                    prompt_tokens = max(prompt_tokens, p)
+                    completion_tokens = max(completion_tokens, c)
                 yield chunk
-            latency = time.monotonic() - t0
-            self.pool.mark_success(backend, latency * 1000)
-            REQUESTS_TOTAL.labels(
-                backend=backend.base_url, model=model, status="ok"
-            ).inc()
-            REQUEST_LATENCY.labels(backend=backend.base_url).observe(latency)
-            self.telemetry.record_request()
+            self._record_stream_success(
+                backend=backend,
+                model=model,
+                latency_s=time.monotonic() - t0,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+            )
             self._mark_shard_success(shard)
         except OpenAIUpstreamError as exc:
             self._mark_backend_failure(backend, exc)

--- a/packages/netllm-agent/src/netllm_agent/telemetry.py
+++ b/packages/netllm-agent/src/netllm_agent/telemetry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
+import os
 import time
 from collections import deque
 from dataclasses import dataclass, field
@@ -12,6 +14,8 @@ from typing import Any
 
 from netllm_core.models import default_config_path
 from netllm_discovery.local import probe_omlx_telemetry
+
+logger = logging.getLogger(__name__)
 
 _HISTORY_LEN = 60
 # All-time counters are flushed at most this often instead of once per
@@ -116,16 +120,33 @@ class TelemetryService:
             data = json.loads(self._stats_path.read_text(encoding="utf-8"))
             if isinstance(data, dict):
                 self._alltime = _RouterCounters.from_dict(data)
-        except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        except json.JSONDecodeError as exc:
+            # A partial file means the process died mid-write (or the file
+            # was hand-edited); starting fresh is fine, doing so silently
+            # is not (docs/architecture/09-follow-up-audit-2026-07-31.md
+            # F-48).
+            logger.warning(
+                "corrupt stats file %s (%s); all-time counters reset",
+                self._stats_path,
+                exc,
+            )
+            return
+        except (OSError, TypeError, ValueError):
             return
 
     def _save_alltime(self) -> None:
+        # Write-then-rename: os.replace is atomic on POSIX and Windows, so
+        # a crash mid-write can never leave a truncated stats.json (F-48).
+        # The tmp file lives in the same directory to stay on the same
+        # filesystem.
+        tmp_path = self._stats_path.with_name(self._stats_path.name + ".tmp")
         try:
             self._stats_path.parent.mkdir(parents=True, exist_ok=True)
-            self._stats_path.write_text(
+            tmp_path.write_text(
                 json.dumps(self._alltime.persist_dict(), indent=2) + "\n",
                 encoding="utf-8",
             )
+            os.replace(tmp_path, self._stats_path)
         except OSError:
             return
         self._alltime_dirty = False

--- a/packages/netllm-cli/src/netllm_cli/main.py
+++ b/packages/netllm-cli/src/netllm_cli/main.py
@@ -1472,6 +1472,19 @@ def doctor(
             "`netllm swarm-token --create` or Settings on untrusted networks."
         )
 
+    if (
+        cfg.cloud.enabled
+        and cfg.cloud.fallback_enabled
+        and cfg.cloud.fallback == "local"
+    ):
+        # F-46: the value names the fallback *tier*, so "local" reads
+        # local-first but means cloud-first. Make the resulting order loud.
+        notes.append(
+            "cloud.fallback = 'local': cloud is tried FIRST and the local "
+            "mesh is the fallback. For local-first routing run "
+            "`netllm cloud fallback local-first`."
+        )
+
     if cfg.agent.role == "gateway" and not cfg.agent.advertise:
         issues.append(
             (
@@ -1864,18 +1877,36 @@ def cloud_set_key(
     console.print(f"[green]Key stored[/] for cloud provider {provider!r}.")
 
 
+# The stored `cloud.fallback` value names the fallback *tier*, but users
+# read it as the priority (F-46): `fallback=local` is cloud-first. The
+# aliases say what the user means; the stored values stay unchanged for
+# config compat.
+_FALLBACK_ALIASES = {"local-first": "cloud", "cloud-first": "local"}
+
+
+def _fallback_order_line(fallback: str, fallback_enabled: bool) -> str:
+    """One explicit sentence stating the resulting try order."""
+    if not fallback_enabled or fallback == "none":
+        return "Order: local mesh only — no automatic cloud fallback."
+    if fallback == "local":
+        return "Order: cloud tried FIRST, local mesh is the fallback."
+    return "Order: local mesh tried FIRST, cloud is the fallback."
+
+
 @cloud_app.command("fallback")
 def cloud_fallback(
     mode: str = typer.Argument(
         ...,
-        help="cloud | local | none | on | off — direction, or on/off for the "
-        "fallback toggle",
+        help="local-first | cloud-first | cloud | local | none | on | off — "
+        "direction (local-first stores 'cloud': cloud is the fallback tier; "
+        "cloud-first stores 'local'), or on/off for the fallback toggle",
     ),
     config: Path | None = typer.Option(None, "--config"),
 ) -> None:
     """Set the cloud fallback direction, or toggle it on/off."""
     cfg_path = _config_path_option(config)
     cfg = load_config(cfg_path)
+    mode = _FALLBACK_ALIASES.get(mode, mode)
     if mode in ("on", "off"):
         cfg.cloud.fallback_enabled = mode == "on"
     elif mode in ("cloud", "local", "none"):
@@ -1883,7 +1914,8 @@ def cloud_fallback(
     else:
         print_error(
             "Invalid fallback mode",
-            f"{mode!r} — expected cloud, local, none, on, or off.",
+            f"{mode!r} — expected local-first, cloud-first, cloud, local, "
+            "none, on, or off.",
         )
         raise typer.Exit(1)
     save_config(cfg, cfg_path)
@@ -1891,6 +1923,7 @@ def cloud_fallback(
         f"[green]Cloud fallback[/] = {cfg.cloud.fallback} "
         f"({'on' if cfg.cloud.fallback_enabled else 'off'})"
     )
+    console.print(_fallback_order_line(cfg.cloud.fallback, cfg.cloud.fallback_enabled))
 
 
 @cloud_app.command("test")
@@ -2060,9 +2093,10 @@ def sources_toggle(
     config: Path | None = typer.Option(None, "--config"),
 ) -> None:
     """Register (if new) and enable a source, or flip its `enabled` state."""
-    from fastapi import HTTPException
-    from netllm_agent.admin import apply_config_patch
+    from netllm_core.config_guards import ConfigGuardError, apply_config_guards
+    from netllm_core.config_merge import apply_config_patch
     from netllm_core.known_harnesses import get_known_harness
+    from netllm_discovery.lan import own_agent_urls
 
     cfg_path = _config_path_option(config)
     cfg = load_config(cfg_path)
@@ -2081,10 +2115,16 @@ def sources_toggle(
         entries.append({"id": id, "enabled": True, "known_id": known_id})
         new_enabled = True
 
+    # Same merge + guard pair as `netllm config import` (config_json.py)
+    # and the agent's admin save path — see F-02 / F-43 in
+    # docs/architecture/07-findings-register.md.
+    updated = apply_config_patch(cfg, {"routing": {"sources": entries}})
     try:
-        updated = apply_config_patch(cfg, {"routing": {"sources": entries}})
-    except HTTPException as exc:
-        print_error(f"Could not toggle source {id!r}", str(exc.detail))
+        apply_config_guards(
+            updated, own_agent_urls=own_agent_urls(updated.agent.listen)
+        )
+    except ConfigGuardError as exc:
+        print_error(f"Could not toggle source {id!r}", str(exc))
         raise typer.Exit(1) from exc
 
     save_config(updated, cfg_path)

--- a/packages/netllm-core/src/netllm_core/health.py
+++ b/packages/netllm-core/src/netllm_core/health.py
@@ -211,32 +211,6 @@ async def diagnose_backend(
     return result
 
 
-async def probe_anthropic_compat(
-    base_url: str,
-    client: httpx.AsyncClient,
-    *,
-    api_key: str | None = None,
-    timeout_s: float = DEFAULT_TIMEOUT,
-) -> dict[str, Any]:
-    """Reachability check for Anthropic Messages API backends."""
-    messages_url = _anthropic_messages_url(base_url)
-    headers: dict[str, str] = {"content-type": "application/json"}
-    if api_key:
-        headers["x-api-key"] = api_key
-    payload = {
-        "model": "claude-3-5-haiku-20241022",
-        "max_tokens": 1,
-        "messages": [{"role": "user", "content": "hi"}],
-    }
-    try:
-        resp = await client.post(
-            messages_url, json=payload, headers=headers, timeout=timeout_s
-        )
-        return _anthropic_probe_status(resp)
-    except Exception as exc:
-        return status_from_exception(exc, timeout_s)
-
-
 def probe_anthropic_compat_sync(
     base_url: str,
     *,

--- a/packages/netllm-core/src/netllm_core/openai_responses_bridge.py
+++ b/packages/netllm-core/src/netllm_core/openai_responses_bridge.py
@@ -296,6 +296,21 @@ async def translate_chat_stream_to_responses(
                         },
                     },
                 )
+                yield _sse_event(
+                    "response.content_part.added",
+                    {
+                        "type": "response.content_part.added",
+                        "sequence_number": seq(),
+                        "item_id": text_item_id,
+                        "output_index": 0,
+                        "content_index": 0,
+                        "part": {
+                            "type": "output_text",
+                            "text": "",
+                            "annotations": [],
+                        },
+                    },
+                )
             text_buffer += delta["content"]
             yield _sse_event(
                 "response.output_text.delta",
@@ -373,17 +388,39 @@ async def translate_chat_stream_to_responses(
                 "text": text_buffer,
             },
         )
-        output.append(
+        final_part = {
+            "type": "output_text",
+            "text": text_buffer,
+            "annotations": [],
+        }
+        yield _sse_event(
+            "response.content_part.done",
             {
-                "id": text_item_id,
-                "type": "message",
-                "status": "completed",
-                "role": "assistant",
-                "content": [
-                    {"type": "output_text", "text": text_buffer, "annotations": []}
-                ],
-            }
+                "type": "response.content_part.done",
+                "sequence_number": seq(),
+                "item_id": text_item_id,
+                "output_index": 0,
+                "content_index": 0,
+                "part": final_part,
+            },
         )
+        message_item = {
+            "id": text_item_id,
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [final_part],
+        }
+        yield _sse_event(
+            "response.output_item.done",
+            {
+                "type": "response.output_item.done",
+                "sequence_number": seq(),
+                "output_index": 0,
+                "item": message_item,
+            },
+        )
+        output.append(message_item)
 
     for idx in sorted(tool_calls):
         state = tool_calls[idx]
@@ -397,16 +434,24 @@ async def translate_chat_stream_to_responses(
                 "arguments": state["arguments"],
             },
         )
-        output.append(
+        function_call_item = {
+            "id": state["item_id"],
+            "type": "function_call",
+            "status": "completed",
+            "call_id": state["call_id"],
+            "name": state["name"],
+            "arguments": state["arguments"] or "{}",
+        }
+        yield _sse_event(
+            "response.output_item.done",
             {
-                "id": state["item_id"],
-                "type": "function_call",
-                "status": "completed",
-                "call_id": state["call_id"],
-                "name": state["name"],
-                "arguments": state["arguments"] or "{}",
-            }
+                "type": "response.output_item.done",
+                "sequence_number": seq(),
+                "output_index": idx + 1,
+                "item": function_call_item,
+            },
         )
+        output.append(function_call_item)
 
     status = "incomplete" if finish_reason == "length" else "completed"
     yield _sse_event(

--- a/packages/netllm-sdk-anthropic/src/netllm_sdk_anthropic/client.py
+++ b/packages/netllm-sdk-anthropic/src/netllm_sdk_anthropic/client.py
@@ -54,9 +54,14 @@ class AnthropicUpstream:
         self,
         payload: dict[str, Any],
     ) -> AsyncIterator[str]:
-        payload = {**payload, "stream": True}
+        # Use create(stream=True), not the .stream() helper: the helper takes
+        # no "stream" kwarg and yields SDK-synthesized events ("text", ...)
+        # that are not Anthropic wire-protocol events; downstream consumers
+        # forward these SSE strings verbatim to clients.
+        payload = {k: v for k, v in payload.items() if k != "stream"}
         try:
-            async with self._client.messages.stream(**payload) as stream:
+            stream = await self._client.messages.create(**payload, stream=True)
+            async with stream:
                 async for event in stream:
                     if hasattr(event, "model_dump"):
                         data = event.model_dump()

--- a/packages/netllm-sdk-anthropic/tests/test_client_contract.py
+++ b/packages/netllm-sdk-anthropic/tests/test_client_contract.py
@@ -71,40 +71,13 @@ async def test_messages_stream_sse_format(mock_cls: MagicMock) -> None:
     event.type = "content_block_delta"
     event.model_dump.return_value = {"type": "content_block_delta", "index": 0}
 
-    async def stream_ctx(**_kwargs):
-        class Ctx:
-            async def __aenter__(self):
-                return self
-
-            async def __aexit__(self, *args):
-                return None
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                raise StopAsyncIteration
-
-        ctx = Ctx()
-        ctx.__aiter__ = lambda: iter([event])  # type: ignore[method-assign]
-        return ctx
-
-    mock_stream = MagicMock()
-
-    async def _aiter():
-        yield event
-
-    mock_stream.__aenter__ = AsyncMock(return_value=mock_stream)
-    mock_stream.__aexit__ = AsyncMock(return_value=None)
-
-    class StreamMgr:
+    class _Stream:
         async def __aenter__(self):
-            return _Stream()
+            return self
 
         async def __aexit__(self, *args):
             return None
 
-    class _Stream:
         def __aiter__(self):
             return self
 
@@ -114,13 +87,16 @@ async def test_messages_stream_sse_format(mock_cls: MagicMock) -> None:
                 return event
             raise StopAsyncIteration
 
-    mock_client.messages.stream = MagicMock(return_value=StreamMgr())
+    # F-30: streaming goes through messages.create(stream=True) — the
+    # .stream() helper rejects a "stream" kwarg and emits non-wire events.
+    mock_client.messages.create = AsyncMock(return_value=_Stream())
 
     upstream = AnthropicUpstream("sk-test")
     payload = {
         "model": "claude-3-5-haiku-20241022",
         "max_tokens": 10,
         "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
     }
     lines = []
     async for line in upstream.messages_stream(payload):
@@ -128,3 +104,6 @@ async def test_messages_stream_sse_format(mock_cls: MagicMock) -> None:
     assert lines
     assert lines[0].startswith("event: content_block_delta")
     assert "data: " in lines[0]
+    kwargs = mock_client.messages.create.await_args.kwargs
+    assert kwargs["stream"] is True
+    assert kwargs["model"] == payload["model"]

--- a/packages/netllm-sdk-anthropic/tests/test_messages_stream_f30.py
+++ b/packages/netllm-sdk-anthropic/tests/test_messages_stream_f30.py
@@ -1,0 +1,147 @@
+"""F-30 regression: streaming to anthropic-format backends must not pass an
+invalid ``stream`` kwarg into the real Anthropic SDK.
+
+These tests drive ``AnthropicUpstream.messages_stream`` through the *real*
+``anthropic`` SDK class with an httpx transport stub — the SDK's own method
+signatures are exercised, so a bad kwarg fails here exactly as it does in
+production (a mocked ``AsyncAnthropic`` cannot catch that class of bug).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import httpx
+import pytest
+from anthropic.resources.messages import AsyncMessages
+from netllm_sdk_anthropic.client import AnthropicUpstream
+
+# A minimal but wire-accurate Anthropic Messages SSE stream.
+_SSE_EVENTS: list[tuple[str, dict]] = [
+    (
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_stream_1",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-3-5-haiku-20241022",
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 3, "output_tokens": 1},
+            },
+        },
+    ),
+    (
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+    ),
+    (
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "hi"},
+        },
+    ),
+    ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+    (
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 2},
+        },
+    ),
+    ("message_stop", {"type": "message_stop"}),
+]
+
+
+def _sse_body() -> bytes:
+    return b"".join(
+        f"event: {name}\ndata: {json.dumps(data)}\n\n".encode()
+        for name, data in _SSE_EVENTS
+    )
+
+
+def _upstream_with_stub_transport(
+    captured: list[httpx.Request],
+) -> AnthropicUpstream:
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=_sse_body(),
+        )
+
+    upstream = AnthropicUpstream("sk-test", base_url="https://upstream.test")
+    # Swap only the transport; the real SDK request/stream machinery still
+    # runs. Clear proxy mounts so env HTTPS_PROXY cannot bypass the stub.
+    inner = upstream._client._client
+    inner._transport = httpx.MockTransport(handler)
+    inner._mounts = {}
+    return upstream
+
+
+PAYLOAD = {
+    "model": "claude-3-5-haiku-20241022",
+    "max_tokens": 16,
+    "messages": [{"role": "user", "content": "hi"}],
+}
+
+
+def test_f30_sdk_stream_helper_rejects_stream_kwarg() -> None:
+    """Documents the F-30 root cause: ``messages.stream()`` has no ``stream``
+    parameter, so any implementation forwarding one dies with TypeError."""
+    sig = inspect.signature(AsyncMessages.stream)
+    assert "stream" not in sig.parameters
+    assert not any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_f30_messages_stream_reaches_wire_and_yields_raw_sse() -> None:
+    """Pre-fix this raised before any I/O (TypeError wrapped as
+    AnthropicUpstreamError); post-fix the request hits the wire with
+    ``"stream": true`` in the JSON body and yields raw Anthropic SSE."""
+    captured: list[httpx.Request] = []
+    upstream = _upstream_with_stub_transport(captured)
+
+    chunks = [chunk async for chunk in upstream.messages_stream(dict(PAYLOAD))]
+
+    assert captured, "request never reached the transport"
+    body = json.loads(captured[0].content)
+    assert body["stream"] is True
+    assert body["model"] == PAYLOAD["model"]
+
+    event_names = [c.split("\n", 1)[0].removeprefix("event: ") for c in chunks]
+    assert event_names == [name for name, _ in _SSE_EVENTS]
+    # Only raw wire events — no SDK helper-synthesized types ("text", ...).
+    for chunk in chunks:
+        event_line, data_line, trailer = chunk.split("\n", 2)
+        assert trailer == "\n"
+        data = json.loads(data_line.removeprefix("data: "))
+        assert data["type"] == event_line.removeprefix("event: ")
+
+
+@pytest.mark.asyncio
+async def test_f30_caller_supplied_stream_key_is_not_duplicated() -> None:
+    """The agent forwards payloads that may already carry ``stream: true``
+    (client.py must not turn that into a duplicate/invalid SDK kwarg)."""
+    captured: list[httpx.Request] = []
+    upstream = _upstream_with_stub_transport(captured)
+
+    payload = {**PAYLOAD, "stream": True}
+    chunks = [chunk async for chunk in upstream.messages_stream(payload)]
+
+    assert chunks
+    assert json.loads(captured[0].content)["stream"] is True

--- a/packages/netllm-sdk-openai/AGENTS.md
+++ b/packages/netllm-sdk-openai/AGENTS.md
@@ -8,12 +8,23 @@ Isolated OpenAI Python SDK adapter. Only package that imports `openai`; upstream
 
 ## Ownership
 
-Key module: `client.py`. Contract tests: `tests/test_openai_upstream_contract.py`.
+Key modules: `client.py` (SDK adapter), `payload.py` (wire-payload
+normalization). Contract tests: `tests/test_openai_upstream_contract.py`,
+`tests/test_payload_adaptation.py`, `tests/test_sdk_param_drift.py`.
 
 ## Local Contracts
 
 - One SDK bump per PR: edit dep → `uv sync` → update sdk-versions doc → `./scripts/ci.sh sdk`
 - Adapter changes follow upstream changelog; see sdk-versions.md change layers
+- **Payload contract** (`payload.py`): every wire payload is normalized before
+  the SDK call — client `extra_body` is flattened to top level, SDK control
+  kwargs (`extra_headers`, `extra_query`, `timeout`) are stripped entirely
+  (never forwarded), and field aliases are mapped (`repeat_penalty` →
+  `repetition_penalty` for OpenAI-format backends). Fields typed on the pinned
+  SDK method pass as-is; everything else is routed via `extra_body`, which the
+  SDK merges into the top-level HTTP JSON (so vLLM/Ollama/LM Studio see e.g.
+  `top_k`, `min_p` where they expect them). The typed-param sets are
+  drift-checked against the pinned SDK in `tests/test_sdk_param_drift.py`.
 
 ## Work Guidance
 

--- a/packages/netllm-sdk-openai/src/netllm_sdk_openai/client.py
+++ b/packages/netllm-sdk-openai/src/netllm_sdk_openai/client.py
@@ -8,7 +8,10 @@ from typing import Any
 
 from openai import AsyncOpenAI, OpenAI
 
-from netllm_sdk_openai.payload import adapt_chat_payload_for_sdk
+from netllm_sdk_openai.payload import (
+    adapt_chat_payload_for_sdk,
+    adapt_embeddings_payload_for_sdk,
+)
 
 
 class OpenAIUpstreamError(Exception):
@@ -78,7 +81,8 @@ class OpenAIUpstream:
 
     async def embeddings(self, payload: dict[str, Any]) -> dict[str, Any]:
         try:
-            resp = await self._async.embeddings.create(**payload)
+            sdk_payload = adapt_embeddings_payload_for_sdk(payload)
+            resp = await self._async.embeddings.create(**sdk_payload)
             return resp.model_dump()
         except Exception as exc:
             raise _wrap(exc) from exc

--- a/packages/netllm-sdk-openai/src/netllm_sdk_openai/payload.py
+++ b/packages/netllm-sdk-openai/src/netllm_sdk_openai/payload.py
@@ -1,16 +1,26 @@
-"""Map OpenAI-compatible chat payloads onto the official OpenAI Python SDK."""
+"""Map OpenAI-compatible wire payloads onto the official OpenAI Python SDK."""
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
-# Parameters accepted by openai.resources.chat.Completions.create (excluding self).
+logger = logging.getLogger(__name__)
+
+# SDK per-call *control* kwargs (client-level transport knobs). A wire payload
+# must never set these: extra_headers would let a request body inject arbitrary
+# upstream HTTP headers, extra_query rewrites the URL, timeout overrides ours.
+# They are stripped entirely in normalize_client_payload (F-42) — not routed
+# into extra_body — so they never reach the upstream in any form.
+_SDK_CONTROL_PARAMS = frozenset({"extra_headers", "extra_query", "timeout"})
+
+# Body parameters accepted by openai.resources.chat.completions.
+# AsyncCompletions.create (excluding self and _SDK_CONTROL_PARAMS).
+# Drift-checked against the pinned SDK in tests/test_sdk_param_drift.py (F-36).
 _SDK_CHAT_PARAMS = frozenset(
     {
         "audio",
         "extra_body",
-        "extra_headers",
-        "extra_query",
         "frequency_penalty",
         "function_call",
         "functions",
@@ -39,7 +49,6 @@ _SDK_CHAT_PARAMS = frozenset(
         "stream",
         "stream_options",
         "temperature",
-        "timeout",
         "tool_choice",
         "tools",
         "top_logprobs",
@@ -50,6 +59,20 @@ _SDK_CHAT_PARAMS = frozenset(
     }
 )
 
+# Body parameters accepted by openai.resources.embeddings.AsyncEmbeddings.create
+# (excluding self and _SDK_CONTROL_PARAMS). Drift-checked alongside the chat
+# set (F-36).
+_SDK_EMBEDDINGS_PARAMS = frozenset(
+    {
+        "dimensions",
+        "encoding_format",
+        "extra_body",
+        "input",
+        "model",
+        "user",
+    }
+)
+
 # Ollama / LM Studio names → vLLM OpenAI-compat field names.
 _FIELD_ALIASES: dict[str, str] = {
     "repeat_penalty": "repetition_penalty",
@@ -57,7 +80,7 @@ _FIELD_ALIASES: dict[str, str] = {
 
 
 def normalize_client_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Flatten client ``extra_body`` and map cross-provider field aliases."""
+    """Flatten client ``extra_body``, strip SDK controls, map field aliases."""
     normalized = dict(payload)
 
     nested = normalized.pop("extra_body", None)
@@ -71,6 +94,13 @@ def normalize_client_payload(payload: dict[str, Any]) -> dict[str, Any]:
                     normalized[key] = {**value, **existing}
                 else:
                     normalized[key] = value
+    elif nested is not None:
+        # Malformed on the wire (extra_body must be an object): drop it (F-37).
+        logger.debug("dropping non-dict extra_body of type %s", type(nested).__name__)
+
+    # Runs after flattening so controls smuggled inside extra_body go too.
+    for key in _SDK_CONTROL_PARAMS:
+        normalized.pop(key, None)
 
     for src, dst in _FIELD_ALIASES.items():
         if src in normalized and dst not in normalized:
@@ -79,13 +109,15 @@ def normalize_client_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
-def adapt_chat_payload_for_sdk(payload: dict[str, Any]) -> dict[str, Any]:
-    """Split provider-specific fields into ``extra_body`` for upstream SDK calls.
+def _adapt_payload_for_sdk(
+    payload: dict[str, Any], allowed: frozenset[str]
+) -> dict[str, Any]:
+    """Split fields not typed on the SDK method into ``extra_body``.
 
-    Clients (Ollama, vLLM, LM Studio, Cursor, Buzz agents) often send sampling
-    knobs like ``top_k`` that are valid on the wire but not typed on the OpenAI
-    SDK. The SDK merges ``extra_body`` into the HTTP JSON; vLLM expects those
-    fields at the top level, not nested under a literal ``extra_body`` key.
+    Clients (Ollama, vLLM, LM Studio, Cursor, Buzz agents) often send knobs
+    like ``top_k`` that are valid on the wire but not typed on the OpenAI SDK.
+    The SDK merges ``extra_body`` into the HTTP JSON; vLLM expects those fields
+    at the top level, not nested under a literal ``extra_body`` key.
     """
     if not payload:
         return payload
@@ -95,7 +127,7 @@ def adapt_chat_payload_for_sdk(payload: dict[str, Any]) -> dict[str, Any]:
     extensions: dict[str, Any] = {}
 
     for key, value in payload.items():
-        if key in _SDK_CHAT_PARAMS:
+        if key in allowed:
             out[key] = value
         else:
             extensions[key] = value
@@ -106,11 +138,18 @@ def adapt_chat_payload_for_sdk(payload: dict[str, Any]) -> dict[str, Any]:
     existing = out.pop("extra_body", None)
     if isinstance(existing, dict):
         merged = {**extensions, **existing}
-    elif existing is None:
-        merged = extensions
     else:
         merged = extensions
-        out["extra_body"] = existing
 
     out["extra_body"] = merged
     return out
+
+
+def adapt_chat_payload_for_sdk(payload: dict[str, Any]) -> dict[str, Any]:
+    """Adapt a wire chat-completions payload for the SDK call."""
+    return _adapt_payload_for_sdk(payload, _SDK_CHAT_PARAMS)
+
+
+def adapt_embeddings_payload_for_sdk(payload: dict[str, Any]) -> dict[str, Any]:
+    """Adapt a wire embeddings payload for the SDK call (F-35)."""
+    return _adapt_payload_for_sdk(payload, _SDK_EMBEDDINGS_PARAMS)

--- a/packages/netllm-sdk-openai/tests/test_openai_upstream_contract.py
+++ b/packages/netllm-sdk-openai/tests/test_openai_upstream_contract.py
@@ -129,6 +129,51 @@ async def test_embeddings_passes_payload(mock_cls: MagicMock) -> None:
 
 @pytest.mark.asyncio
 @patch("netllm_sdk_openai.client.AsyncOpenAI")
+async def test_embeddings_moves_extension_fields_to_extra_body(
+    mock_cls: MagicMock,
+) -> None:
+    """F-35: client.embeddings() applies the extension-field adaptation."""
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_resp = MagicMock()
+    mock_resp.model_dump.return_value = {"object": "list", "data": []}
+    mock_client.embeddings.create = AsyncMock(return_value=mock_resp)
+
+    upstream = OpenAIUpstream("http://127.0.0.1:11434/v1")
+    payload = {"model": "nomic-embed-text", "input": "hi", "truncate": True}
+    await upstream.embeddings(payload)
+    call_kwargs = mock_client.embeddings.create.await_args.kwargs
+    assert "truncate" not in call_kwargs
+    assert call_kwargs["extra_body"] == {"truncate": True}
+
+
+@pytest.mark.asyncio
+@patch("netllm_sdk_openai.client.AsyncOpenAI")
+async def test_chat_completion_strips_sdk_control_kwargs(mock_cls: MagicMock) -> None:
+    """F-42: wire extra_headers/extra_query/timeout never become SDK kwargs."""
+    mock_client = MagicMock()
+    mock_cls.return_value = mock_client
+    mock_resp = MagicMock()
+    mock_resp.model_dump.return_value = {"id": "c1", "object": "chat.completion"}
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
+
+    upstream = OpenAIUpstream("http://127.0.0.1:11434/v1")
+    payload = {
+        "model": "llama3",
+        "messages": [{"role": "user", "content": "hi"}],
+        "extra_headers": {"Authorization": "Bearer stolen"},
+        "extra_query": {"debug": "1"},
+        "timeout": 0.001,
+    }
+    await upstream.chat_completion(payload)
+    call_kwargs = mock_client.chat.completions.create.await_args.kwargs
+    assert "extra_headers" not in call_kwargs
+    assert "extra_query" not in call_kwargs
+    assert "timeout" not in call_kwargs
+
+
+@pytest.mark.asyncio
+@patch("netllm_sdk_openai.client.AsyncOpenAI")
 async def test_embeddings_wraps_errors(mock_cls: MagicMock) -> None:
     mock_client = MagicMock()
     mock_cls.return_value = mock_client

--- a/packages/netllm-sdk-openai/tests/test_openai_upstream_contract.py
+++ b/packages/netllm-sdk-openai/tests/test_openai_upstream_contract.py
@@ -90,7 +90,10 @@ async def test_chat_completion_moves_top_k_to_extra_body(mock_cls: MagicMock) ->
     mock_client = MagicMock()
     mock_cls.return_value = mock_client
     mock_resp = MagicMock()
-    mock_resp.model_dump.return_value = {"id": "chatcmpl-1", "object": "chat.completion"}
+    mock_resp.model_dump.return_value = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion",
+    }
     mock_client.chat.completions.create = AsyncMock(return_value=mock_resp)
 
     upstream = OpenAIUpstream("http://127.0.0.1:8012/v1")

--- a/packages/netllm-sdk-openai/tests/test_payload_adaptation.py
+++ b/packages/netllm-sdk-openai/tests/test_payload_adaptation.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from netllm_sdk_openai.payload import adapt_chat_payload_for_sdk
+from netllm_sdk_openai.payload import (
+    adapt_chat_payload_for_sdk,
+    adapt_embeddings_payload_for_sdk,
+)
 
 
 def test_top_k_moves_to_extra_body() -> None:
@@ -82,3 +85,90 @@ def test_sdk_fields_unchanged() -> None:
         "presence_penalty": 0.1,
     }
     assert adapt_chat_payload_for_sdk(payload) == payload
+
+
+def test_non_dict_extra_body_dropped() -> None:
+    """F-37: a non-dict extra_body is discarded explicitly, not dead-stored."""
+    payload = {
+        "model": "qwen3-next-80b",
+        "messages": [],
+        "extra_body": "not-a-dict",
+        "top_k": 40,
+    }
+    adapted = adapt_chat_payload_for_sdk(payload)
+    assert adapted["extra_body"] == {"top_k": 40}
+
+    no_extensions = adapt_chat_payload_for_sdk(
+        {"model": "qwen3-next-80b", "messages": [], "extra_body": [1, 2]}
+    )
+    assert "extra_body" not in no_extensions
+
+
+def test_sdk_control_kwargs_stripped_from_chat() -> None:
+    """F-42: wire payloads must not steer SDK controls (headers/query/timeout)."""
+    payload = {
+        "model": "qwen3-next-80b",
+        "messages": [],
+        "extra_headers": {"X-Evil": "1"},
+        "extra_query": {"debug": "1"},
+        "timeout": 0.001,
+    }
+    adapted = adapt_chat_payload_for_sdk(payload)
+    assert "extra_headers" not in adapted
+    assert "extra_query" not in adapted
+    assert "timeout" not in adapted
+    # Stripped entirely: they must not reappear inside extra_body either.
+    assert "extra_headers" not in adapted.get("extra_body", {})
+    assert "extra_query" not in adapted.get("extra_body", {})
+
+
+def test_sdk_control_kwargs_stripped_even_when_nested() -> None:
+    """F-42: controls smuggled inside client extra_body are also stripped."""
+    payload = {
+        "model": "qwen3-next-80b",
+        "messages": [],
+        "extra_body": {"extra_headers": {"X-Evil": "1"}, "top_k": 5},
+    }
+    adapted = adapt_chat_payload_for_sdk(payload)
+    assert "extra_headers" not in adapted
+    assert adapted["extra_body"] == {"top_k": 5}
+
+
+def test_embeddings_extension_fields_move_to_extra_body() -> None:
+    """F-35: embeddings payloads get the same extension-field adaptation as chat."""
+    payload = {
+        "model": "nomic-embed-text",
+        "input": "hello",
+        "truncate": True,
+        "dimensions": 256,
+    }
+    adapted = adapt_embeddings_payload_for_sdk(payload)
+    assert adapted["model"] == "nomic-embed-text"
+    assert adapted["dimensions"] == 256
+    assert "truncate" not in adapted
+    assert adapted["extra_body"] == {"truncate": True}
+
+
+def test_embeddings_sdk_fields_unchanged() -> None:
+    """F-35: typed embeddings params pass through untouched."""
+    payload = {
+        "model": "text-embedding-3-small",
+        "input": ["a", "b"],
+        "encoding_format": "float",
+        "user": "u1",
+    }
+    assert adapt_embeddings_payload_for_sdk(payload) == payload
+
+
+def test_embeddings_control_kwargs_stripped() -> None:
+    """F-42: embeddings payloads cannot set SDK controls either."""
+    payload = {
+        "model": "nomic-embed-text",
+        "input": "hi",
+        "extra_headers": {"X-Evil": "1"},
+        "timeout": 1,
+    }
+    adapted = adapt_embeddings_payload_for_sdk(payload)
+    assert "extra_headers" not in adapted
+    assert "timeout" not in adapted
+    assert "extra_body" not in adapted

--- a/packages/netllm-sdk-openai/tests/test_sdk_param_drift.py
+++ b/packages/netllm-sdk-openai/tests/test_sdk_param_drift.py
@@ -1,0 +1,36 @@
+"""F-36: detect drift between the pinned OpenAI SDK signatures and our mirrors.
+
+`_SDK_CHAT_PARAMS` / `_SDK_EMBEDDINGS_PARAMS` are hand-maintained copies of the
+pinned SDK method signatures. An SDK bump that adds or removes typed params
+would otherwise silently break the extension-field split (TypeError -> 502s, or
+new typed params detouring through extra_body). These asserts fail loudly on
+the bump instead.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from netllm_sdk_openai.payload import (
+    _SDK_CHAT_PARAMS,
+    _SDK_CONTROL_PARAMS,
+    _SDK_EMBEDDINGS_PARAMS,
+)
+from openai.resources.chat.completions import AsyncCompletions
+from openai.resources.embeddings import AsyncEmbeddings
+
+
+def test_chat_params_match_pinned_sdk_signature() -> None:
+    sig_params = set(inspect.signature(AsyncCompletions.create).parameters) - {"self"}
+    # Control kwargs (F-42) are deliberately excluded from the settable set.
+    assert sig_params == _SDK_CHAT_PARAMS | _SDK_CONTROL_PARAMS
+
+
+def test_embeddings_params_match_pinned_sdk_signature() -> None:
+    sig_params = set(inspect.signature(AsyncEmbeddings.create).parameters) - {"self"}
+    assert sig_params == _SDK_EMBEDDINGS_PARAMS | _SDK_CONTROL_PARAMS
+
+
+def test_control_params_are_disjoint_from_settable_sets() -> None:
+    assert not _SDK_CONTROL_PARAMS & _SDK_CHAT_PARAMS
+    assert not _SDK_CONTROL_PARAMS & _SDK_EMBEDDINGS_PARAMS

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -873,16 +873,17 @@ def test_peer_forward_headers_loop_guard() -> None:
     )
     from netllm_core.models import HOPS_HEADER
 
-    assert AgentService._peer_forward_headers(peer) == {
+    service = AgentService(NetllmConfig())
+    assert service._peer_forward_headers(peer) == {
         LOCAL_ONLY_HEADER: "1",
         HOPS_HEADER: "1",
     }
     # Incoming hop count is propagated and incremented.
-    assert AgentService._peer_forward_headers(peer, {HOPS_HEADER: "1"}) == {
+    assert service._peer_forward_headers(peer, {HOPS_HEADER: "1"}) == {
         LOCAL_ONLY_HEADER: "1",
         HOPS_HEADER: "2",
     }
-    assert AgentService._peer_forward_headers(local) is None
+    assert service._peer_forward_headers(local) is None
 
 
 @patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -84,7 +84,8 @@ def test_embeddings_unknown_model_404_lists_embedding_models(
             json={"model": "not-a-model", "input": "x"},
         )
     assert resp.status_code == 404
-    detail = resp.json()["detail"]
+    # F-38: /v1/* errors render the OpenAI error envelope, not {"detail"}.
+    detail = resp.json()["error"]["message"]
     assert "not-a-model" in detail
     # Embedding-capable models are listed first for embeddings requests.
     assert "nomic-embed-text" in detail
@@ -109,7 +110,7 @@ def test_chat_request_to_embedding_model_is_rejected_400(
             },
         )
     assert resp.status_code == 400
-    detail = resp.json()["detail"]
+    detail = resp.json()["error"]["message"]
     assert "embedding" in detail
     assert "/v1/embeddings" in detail
 

--- a/tests/test_followup_batch_c.py
+++ b/tests/test_followup_batch_c.py
@@ -1,0 +1,295 @@
+"""Regression tests for follow-up audit batch C (F-33, F-45, F-47, F-48).
+
+Findings: docs/architecture/09-follow-up-audit-2026-07-31.md.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from netllm_agent.metrics import REQUESTS_TOTAL
+from netllm_agent.service import AgentService
+from netllm_agent.telemetry import TelemetryService
+from netllm_core.models import (
+    HOPS_HEADER,
+    LOCAL_ONLY_HEADER,
+    SOURCE_HEADER,
+    Backend,
+    NetllmConfig,
+    SourceConfig,
+)
+from netllm_core.source_identity import resolve_source
+
+
+def _service(sources: list[SourceConfig] | None = None) -> AgentService:
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    if sources is not None:
+        cfg.routing.sources = sources
+    return AgentService(cfg)
+
+
+def _backend(local: bool = True) -> Backend:
+    return Backend(
+        id="omlx:http://127.0.0.1:8080/v1" if local else "peer:remote-agent",
+        base_url=(
+            "http://127.0.0.1:8080/v1" if local else "http://192.168.1.11:11400/v1"
+        ),
+        provider="omlx" if local else "custom",
+        local=local,
+    )
+
+
+def _requests_total_ok(backend: Backend, model: str) -> float:
+    return REQUESTS_TOTAL.labels(
+        backend=backend.base_url, model=model, status="ok"
+    )._value.get()
+
+
+# ---------------------------------------------------------------------------
+# F-33 — streamed Messages traffic must record success accounting
+# ---------------------------------------------------------------------------
+
+
+ANTHROPIC_SSE_CHUNKS = [
+    'event: message_start\ndata: {"type": "message_start", "message": '
+    '{"id": "msg_1", "usage": {"input_tokens": 25, "output_tokens": 1}}}\n\n',
+    'event: content_block_delta\ndata: {"type": "content_block_delta", '
+    '"delta": {"type": "text_delta", "text": "hi"}}\n\n',
+    'event: message_delta\ndata: {"type": "message_delta", '
+    '"usage": {"output_tokens": 50}}\n\n',
+    'event: message_stop\ndata: {"type": "message_stop"}\n\n',
+]
+
+
+async def test_f33_proxy_messages_stream_records_success_accounting() -> None:
+    """F-33: proxy_messages_stream must mark_success, count the request,
+    observe latency, and capture token usage from the SSE stream."""
+    service = _service()
+    backend = _backend()
+    service.pool.backends.append(backend)
+    model = "llama3"
+
+    async def fake_stream(*args: Any, **kwargs: Any) -> AsyncIterator[str]:
+        for chunk in ANTHROPIC_SSE_CHUNKS:
+            yield chunk
+
+    ok_before = _requests_total_ok(backend, model)
+    with (
+        patch.object(service, "refresh_local_backends", AsyncMock(return_value=[])),
+        patch.object(
+            service, "_offload_if_probing", AsyncMock(side_effect=[backend, None])
+        ),
+        patch.object(service, "_messages_stream_on_backend", fake_stream),
+        patch.object(
+            service.pool, "mark_success", wraps=service.pool.mark_success
+        ) as mark_success,
+    ):
+        chunks = [
+            c
+            async for c in service.proxy_messages_stream(
+                {"model": model, "messages": [], "stream": True}
+            )
+        ]
+
+    assert chunks == ANTHROPIC_SSE_CHUNKS
+    mark_success.assert_called_once()
+    assert _requests_total_ok(backend, model) == ok_before + 1
+    assert service.telemetry._session.requests == 1
+    assert service.telemetry._session.prompt_tokens == 25
+    assert service.telemetry._session.completion_tokens == 50
+
+
+async def test_f33_chat_stream_wrapper_captures_openai_usage_chunk() -> None:
+    """F-33: _stream_with_metrics must parse the stream_options
+    include_usage chunk (when present) into token telemetry."""
+    service = _service()
+    backend = _backend()
+    model = "llama3"
+
+    chat_chunks = [
+        'data: {"choices": [{"delta": {"content": "hi"}}]}\n\n',
+        'data: {"choices": [], "usage": '
+        '{"prompt_tokens": 7, "completion_tokens": 3}}\n\n',
+        "data: [DONE]\n\n",
+    ]
+
+    class FakeClient:
+        async def chat_completion_stream(
+            self, payload: dict[str, Any]
+        ) -> AsyncIterator[str]:
+            for chunk in chat_chunks:
+                yield chunk
+
+    ok_before = _requests_total_ok(backend, model)
+    out = [
+        c
+        async for c in service._stream_with_metrics(
+            FakeClient(), {"model": model}, backend, model
+        )
+    ]
+    assert out == chat_chunks
+    assert _requests_total_ok(backend, model) == ok_before + 1
+    assert service.telemetry._session.requests == 1
+    assert service.telemetry._session.prompt_tokens == 7
+    assert service.telemetry._session.completion_tokens == 3
+
+
+# ---------------------------------------------------------------------------
+# F-45 — _anthropic_api_key env fallback must reject placeholder keys
+# ---------------------------------------------------------------------------
+
+
+def test_f45_anthropic_env_fallback_rejects_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-45: a netllm-* placeholder in ANTHROPIC_API_KEY must never be
+    forwarded upstream, mirroring the OpenAI twin."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "netllm-local")
+    assert AgentService._anthropic_api_key({}) == ""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "netllm-claude-code.s3cret")
+    assert AgentService._anthropic_api_key({}) == ""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-real")
+    assert AgentService._anthropic_api_key({}) == "sk-ant-real"
+
+
+def test_f45_openai_env_fallback_rejects_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "netllm-local")
+    assert AgentService._openai_api_key({}) == ""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real")
+    assert AgentService._openai_api_key({}) == "sk-real"
+
+
+# ---------------------------------------------------------------------------
+# F-47 — peer hops must forward the resolved source id (attribution only)
+# ---------------------------------------------------------------------------
+
+
+def test_f47_peer_forward_headers_carry_resolved_source() -> None:
+    """F-47: x-netllm-source rides along on peer hops so serving-node
+    telemetry attributes mesh traffic to the real source."""
+    service = _service(sources=[SourceConfig(id="cursor")])
+    peer = _backend(local=False)
+    fwd = service._peer_forward_headers(peer, {SOURCE_HEADER: "cursor"})
+    assert fwd == {
+        LOCAL_ONLY_HEADER: "1",
+        HOPS_HEADER: "1",
+        SOURCE_HEADER: "cursor",
+    }
+
+
+def test_f47_peer_forward_headers_omit_default_and_unresolved() -> None:
+    service = _service(sources=[SourceConfig(id="cursor")])
+    peer = _backend(local=False)
+    local = _backend(local=True)
+    # No source signal: loop-guard headers only, no default attribution.
+    assert service._peer_forward_headers(peer, {}) == {
+        LOCAL_ONLY_HEADER: "1",
+        HOPS_HEADER: "1",
+    }
+    assert service._peer_forward_headers(peer, None) == {
+        LOCAL_ONLY_HEADER: "1",
+        HOPS_HEADER: "1",
+    }
+    # Hop count still propagates.
+    assert service._peer_forward_headers(peer, {HOPS_HEADER: "1"}) == {
+        LOCAL_ONLY_HEADER: "1",
+        HOPS_HEADER: "2",
+    }
+    assert service._peer_forward_headers(local, {SOURCE_HEADER: "cursor"}) is None
+
+
+def test_f47_secret_gated_source_not_claimable_by_bare_forwarded_header() -> None:
+    """F-47 security constraint: the receiving peer must not grant a
+    secret-gated identity from the bare forwarded header; a plain source
+    still attributes."""
+    sources = [
+        SourceConfig(id="buzz", secret="s3cret"),
+        SourceConfig(id="cursor"),
+    ]
+    # What the receiving peer sees: just the forwarded attribution header
+    # (peer hops authenticate with the cluster token, not the secret).
+    gated = resolve_source(headers={SOURCE_HEADER: "buzz"}, sources=sources)
+    assert gated.id == "default"
+    assert gated.authenticated is False
+    plain = resolve_source(headers={SOURCE_HEADER: "cursor"}, sources=sources)
+    assert plain.id == "cursor"
+
+    # And the sending side never forwards an identity the caller did not
+    # prove: a bare secret-gated header resolves to default, so nothing
+    # is forwarded.
+    service = _service(sources=sources)
+    peer = _backend(local=False)
+    fwd = service._peer_forward_headers(peer, {SOURCE_HEADER: "buzz"})
+    assert fwd == {LOCAL_ONLY_HEADER: "1", HOPS_HEADER: "1"}
+    # A caller that did prove the secret forwards attribution only.
+    fwd = service._peer_forward_headers(peer, {"x-api-key": "netllm-buzz.s3cret"})
+    assert fwd == {
+        LOCAL_ONLY_HEADER: "1",
+        HOPS_HEADER: "1",
+        SOURCE_HEADER: "buzz",
+    }
+
+
+# ---------------------------------------------------------------------------
+# F-48 — stats.json durability
+# ---------------------------------------------------------------------------
+
+
+def test_f48_corrupt_stats_json_warns_and_resets(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """F-48: a partial/corrupt stats.json must log a warning instead of
+    silently zeroing the all-time counters."""
+    stats_path = tmp_path / "stats.json"
+    stats_path.write_text('{"requests": 12, "prompt_tok', encoding="utf-8")
+    with caplog.at_level(logging.WARNING, logger="netllm_agent.telemetry"):
+        svc = TelemetryService(stats_path=stats_path)
+    assert svc._alltime.requests == 0  # graceful reset, service still up
+    assert any(
+        "stats" in rec.message and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    )
+
+
+def test_f48_save_alltime_is_atomic(tmp_path: Path) -> None:
+    """F-48: the save path must write a tmp file in the same directory and
+    os.replace it over stats.json — never truncate the live file."""
+    stats_path = tmp_path / "stats.json"
+    svc = TelemetryService(stats_path=stats_path)
+    svc.record_usage(prompt_tokens=10, completion_tokens=5)
+
+    with patch("netllm_agent.telemetry.os.replace", wraps=os.replace) as replace:
+        svc._save_alltime()
+
+    replace.assert_called_once()
+    src, dst = replace.call_args.args[:2]
+    assert Path(dst) == stats_path
+    assert Path(src).parent == stats_path.parent  # same dir → same filesystem
+    assert not Path(src).exists()  # tmp file consumed by the rename
+    data = json.loads(stats_path.read_text(encoding="utf-8"))
+    assert data["requests"] == 1
+    assert data["prompt_tokens"] == 10
+
+
+def test_usage_parsers_tolerate_non_numeric_values() -> None:
+    """Verifier follow-up: malformed backend usage must not raise mid-stream."""
+    from netllm_agent.service import AgentService
+
+    chunk = (
+        'data: {"usage": {"input_tokens": "not-a-number", "output_tokens": null}}\n\n'
+    )
+    assert AgentService._usage_from_sse_chunk(chunk) == (0, 0)
+    assert AgentService._usage_from_response(
+        {"usage": {"prompt_tokens": {"nested": 1}, "completion_tokens": "9"}}
+    ) == (0, 9)

--- a/tests/test_followup_batch_e.py
+++ b/tests/test_followup_batch_e.py
@@ -1,0 +1,227 @@
+"""Follow-up audit batch E regressions: F-43, F-44, F-46.
+
+See docs/architecture/09-follow-up-audit-2026-07-31.md.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+
+import netllm_cli.main as cli_main
+import pytest
+from netllm_core.models import (
+    NetllmConfig,
+    SourceConfig,
+    is_lan_listen,
+    load_config,
+    save_config,
+)
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _cfg_path(tmp_path: Path, cfg: NetllmConfig | None = None) -> Path:
+    path = tmp_path / "config.toml"
+    save_config(cfg or NetllmConfig(), path)
+    return path
+
+
+# --- F-43: sources_toggle must not reach into netllm_agent / fastapi -------
+
+
+def test_f43_sources_toggle_does_not_import_agent_or_fastapi() -> None:
+    """The CLI config write path goes through netllm_core (config_merge +
+    config_guards), like `netllm config import` — not through the agent's
+    HTTP admin layer. Importing netllm_agent.admin drags FastAPI into a
+    plain CLI command and re-breaks the layering the F-02 fix established."""
+    src = inspect.getsource(cli_main.sources_toggle)
+    assert "netllm_agent" not in src
+    assert "fastapi" not in src
+
+
+def test_f43_sources_toggle_round_trip_preserves_behavior(tmp_path: Path) -> None:
+    """Toggle round-trip on a temp config: register, disable, re-enable —
+    exact user-facing behavior (messages, exit codes) preserved."""
+    cfg_path = _cfg_path(tmp_path)
+
+    result = runner.invoke(
+        cli_main.app, ["sources", "toggle", "codex", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Enabled" in result.output and "codex" in result.output
+    cfg = load_config(cfg_path)
+    assert cfg.routing.sources[0].id == "codex"
+    assert cfg.routing.sources[0].known_id == "codex"
+    assert cfg.routing.sources[0].enabled is True
+
+    result = runner.invoke(
+        cli_main.app, ["sources", "toggle", "codex", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Disabled" in result.output
+    assert load_config(cfg_path).routing.sources[0].enabled is False
+
+    result = runner.invoke(
+        cli_main.app, ["sources", "toggle", "codex", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Enabled" in result.output
+    assert load_config(cfg_path).routing.sources[0].enabled is True
+
+
+def test_f43_sources_toggle_guard_rejection_still_exits_1(tmp_path: Path) -> None:
+    """The shared config_guards still gate the write: an elevated source
+    without a secret on a LAN listen is rejected, exit code 1, disk untouched."""
+    cfg = NetllmConfig()
+    cfg.agent.listen = "0.0.0.0:11400"
+    assert is_lan_listen(cfg.agent.listen)
+    cfg.routing.sources = [
+        SourceConfig(id="codex", known_id="codex", allow_cloud=True, secret="")
+    ]
+    cfg_path = _cfg_path(tmp_path, cfg)
+
+    result = runner.invoke(
+        cli_main.app, ["sources", "toggle", "codex", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 1
+    assert "Could not toggle source" in result.output
+    assert load_config(cfg_path).routing.sources[0].enabled is True
+
+
+# --- F-44: dead async probe_anthropic_compat (pre-F-07 billable probe) ------
+
+
+def test_f44_dead_async_billable_anthropic_probe_removed() -> None:
+    """The async twin of probe_anthropic_compat_sync had zero callers and
+    still POSTed a billable 1-token Messages request against a hardcoded
+    model id — the exact bug F-07 fixed in the sync path. It must be gone
+    (or, if ever revived, mirror the free GET /v1/models-first sync logic)."""
+    import netllm_core.health as health
+
+    assert not hasattr(health, "probe_anthropic_compat"), (
+        "async probe_anthropic_compat still exists; it embodies the pre-F-07 "
+        "billable-probe bug"
+    )
+    src = Path(health.__file__).read_text()
+    assert "async def probe_anthropic_compat" not in src
+
+
+# --- F-46: cloud fallback direction UX trap ---------------------------------
+
+
+def test_f46_local_first_alias_maps_to_stored_cloud(tmp_path: Path) -> None:
+    """`local-first` says what the user means; it stores the compat value
+    `cloud` (cloud is the fallback tier)."""
+    cfg_path = _cfg_path(tmp_path)
+    result = runner.invoke(
+        cli_main.app, ["cloud", "fallback", "local-first", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert load_config(cfg_path).cloud.fallback == "cloud"
+
+
+def test_f46_cloud_first_alias_maps_to_stored_local(tmp_path: Path) -> None:
+    cfg_path = _cfg_path(tmp_path)
+    result = runner.invoke(
+        cli_main.app, ["cloud", "fallback", "cloud-first", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert load_config(cfg_path).cloud.fallback == "local"
+
+
+def test_f46_fallback_local_prints_cloud_first_warning(tmp_path: Path) -> None:
+    """fallback=local names the fallback *tier* but reads like the priority.
+    Every change must print one explicit line stating the resulting order."""
+    cfg_path = _cfg_path(tmp_path)
+    result = runner.invoke(
+        cli_main.app, ["cloud", "fallback", "local", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "cloud tried FIRST" in result.output
+    assert "local mesh is the fallback" in result.output
+
+
+def test_f46_fallback_cloud_prints_local_first_explanation(tmp_path: Path) -> None:
+    cfg_path = _cfg_path(tmp_path)
+    result = runner.invoke(
+        cli_main.app, ["cloud", "fallback", "cloud", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "local mesh tried FIRST" in result.output
+    assert "cloud is the fallback" in result.output
+
+
+def test_f46_fallback_none_and_off_print_no_fallback_explanation(
+    tmp_path: Path,
+) -> None:
+    cfg_path = _cfg_path(tmp_path)
+    result = runner.invoke(
+        cli_main.app, ["cloud", "fallback", "none", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "no automatic cloud fallback" in result.output
+
+    result = runner.invoke(
+        cli_main.app, ["cloud", "fallback", "off", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "no automatic cloud fallback" in result.output
+
+
+def test_f46_fallback_on_prints_resulting_order(tmp_path: Path) -> None:
+    """Re-enabling the toggle must restate the direction currently stored."""
+    cfg = NetllmConfig()
+    cfg.cloud.fallback = "local"
+    cfg.cloud.fallback_enabled = False
+    cfg_path = _cfg_path(tmp_path, cfg)
+    result = runner.invoke(
+        cli_main.app, ["cloud", "fallback", "on", "--config", str(cfg_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "cloud tried FIRST" in result.output
+
+
+def test_f46_stored_values_unchanged_for_plain_modes(tmp_path: Path) -> None:
+    """Compat: the stored config values keep their existing names."""
+    cfg_path = _cfg_path(tmp_path)
+    for mode, stored in (("cloud", "cloud"), ("local", "local"), ("none", "none")):
+        result = runner.invoke(
+            cli_main.app, ["cloud", "fallback", mode, "--config", str(cfg_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert load_config(cfg_path).cloud.fallback == stored
+
+
+def test_f46_doctor_notes_cloud_first_when_fallback_is_local(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def _one_online(cfg: NetllmConfig) -> list[dict[str, Any]]:
+        return [{"name": "ollama", "status": "online", "models": ["m"]}]
+
+    monkeypatch.setattr(cli_main, "scan_local_providers", _one_online)
+    monkeypatch.setattr("netllm_discovery.runtime.check_listen_port", lambda _cfg: None)
+
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    cfg.cloud.fallback = "local"
+    cfg_path = _cfg_path(tmp_path, cfg)
+
+    result = runner.invoke(
+        cli_main.app, ["doctor", "--json", "--config", str(cfg_path)]
+    )
+    payload = json.loads(result.stdout)
+    assert any("cloud" in n and "FIRST" in n for n in payload.get("notes", [])), payload
+
+    # And no such note when the default local-first order is configured.
+    cfg.cloud.fallback = "cloud"
+    save_config(cfg, cfg_path)
+    result = runner.invoke(
+        cli_main.app, ["doctor", "--json", "--config", str(cfg_path)]
+    )
+    payload = json.loads(result.stdout)
+    assert not any("FIRST" in n for n in payload.get("notes", []))

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -194,7 +194,8 @@ def test_unknown_model_returns_404_with_catalog(
             },
         )
     assert resp.status_code == 404
-    detail = resp.json()["detail"]
+    # F-38: /v1/* errors render the OpenAI error envelope, not {"detail"}.
+    detail = resp.json()["error"]["message"]
     assert "gpt-imaginary" in detail
     assert "qwen2" in detail
 

--- a/tests/test_responses_bridge_f39.py
+++ b/tests/test_responses_bridge_f39.py
@@ -1,0 +1,138 @@
+"""F-39 regression: Responses streaming bridge lifecycle-event completeness.
+
+The audit (docs/architecture/09-follow-up-audit-2026-07-31.md, F-39) found
+translate_chat_stream_to_responses never closed output items or content
+parts: no response.content_part.added before text deltas, no
+response.content_part.done after response.output_text.done, no
+response.output_item.done for either the message or function_call items,
+and response.completed carried whatever the partial bookkeeping produced.
+This test replays a synthetic Chat Completions SSE transcript (text plus a
+function call, the Codex tool-loop shape) and asserts the exact ordered
+event-type sequence per the OpenAI Responses SSE spec, plus the fully
+populated final output array and monotonic sequence numbers.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from netllm_core.openai_responses_bridge import translate_chat_stream_to_responses
+
+
+def _chat_chunk(delta: dict, finish_reason: str | None = None) -> str:
+    choice: dict = {"delta": delta}
+    if finish_reason is not None:
+        choice["finish_reason"] = finish_reason
+    return f"data: {json.dumps({'choices': [choice]})}\n\n"
+
+
+async def _achunks(*raws: str):
+    for raw in raws:
+        yield raw
+
+
+def _event_type(sse_event: str) -> str:
+    for line in sse_event.splitlines():
+        if line.startswith("event: "):
+            return line[len("event: ") :]
+    raise AssertionError(f"no event line in {sse_event!r}")
+
+
+def _event_data(sse_event: str) -> dict:
+    for line in sse_event.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line[len("data: ") :])
+    raise AssertionError(f"no data line in {sse_event!r}")
+
+
+@pytest.mark.asyncio
+async def test_f39_stream_emits_complete_lifecycle_event_sequence() -> None:
+    """F-39: exact event ordering for a text + tool-call stream, including
+    content_part bracketing and output_item.done for every opened item."""
+    chunks = _achunks(
+        _chat_chunk({"content": "Hel"}),
+        _chat_chunk({"content": "lo"}),
+        _chat_chunk(
+            {
+                "tool_calls": [
+                    {
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {"name": "shell", "arguments": ""},
+                    }
+                ]
+            }
+        ),
+        _chat_chunk(
+            {"tool_calls": [{"index": 0, "function": {"arguments": '{"cmd":'}}]}
+        ),
+        _chat_chunk({"tool_calls": [{"index": 0, "function": {"arguments": '"ls"}'}}]}),
+        _chat_chunk({}, finish_reason="tool_calls"),
+        "data: [DONE]\n\n",
+    )
+    events = [e async for e in translate_chat_stream_to_responses(chunks, model="m")]
+    types = [_event_type(e) for e in events]
+
+    assert types == [
+        "response.created",
+        "response.output_item.added",  # message item opens
+        "response.content_part.added",  # F-39: part opens before text deltas
+        "response.output_text.delta",
+        "response.output_text.delta",
+        "response.output_item.added",  # function_call item opens
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.delta",
+        "response.output_text.done",
+        "response.content_part.done",  # F-39: part closes after text done
+        "response.output_item.done",  # F-39: message item closes
+        "response.function_call_arguments.done",
+        "response.output_item.done",  # F-39: function_call item closes
+        "response.completed",
+    ]
+
+    datas = [_event_data(e) for e in events]
+
+    # sequence_number stays strictly monotonic across every event.
+    seqs = [d["sequence_number"] for d in datas]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs)
+
+    by_type: dict[str, list[dict]] = {}
+    for t, d in zip(types, datas):
+        by_type.setdefault(t, []).append(d)
+
+    part_added = by_type["response.content_part.added"][0]
+    assert part_added["output_index"] == 0
+    assert part_added["content_index"] == 0
+    assert part_added["part"]["type"] == "output_text"
+    assert part_added["part"]["text"] == ""
+
+    part_done = by_type["response.content_part.done"][0]
+    assert part_done["part"] == {
+        "type": "output_text",
+        "text": "Hello",
+        "annotations": [],
+    }
+    assert part_done["item_id"] == part_added["item_id"]
+
+    msg_done, fc_done = by_type["response.output_item.done"]
+    assert msg_done["item"]["type"] == "message"
+    assert msg_done["item"]["status"] == "completed"
+    assert msg_done["item"]["content"] == [
+        {"type": "output_text", "text": "Hello", "annotations": []}
+    ]
+    assert fc_done["item"]["type"] == "function_call"
+    assert fc_done["item"]["status"] == "completed"
+    assert fc_done["item"]["call_id"] == "call_1"
+    assert fc_done["item"]["name"] == "shell"
+    assert fc_done["item"]["arguments"] == '{"cmd":"ls"}'
+
+    # response.completed carries the fully-populated output array, matching
+    # the items exactly as closed by their output_item.done events.
+    completed = by_type["response.completed"][0]
+    assert completed["response"]["status"] == "completed"
+    assert completed["response"]["output"] == [
+        msg_done["item"],
+        fc_done["item"],
+    ]

--- a/tests/test_route_layer_hardening.py
+++ b/tests/test_route_layer_hardening.py
@@ -1,0 +1,233 @@
+"""Route-layer hardening regressions (batch D of the 2026-07-31 follow-up audit).
+
+Covers:
+- F-40: /netllm/v1/client-env gated by the cluster token like sibling reads.
+- F-41: /metrics gated by the cluster token, open when none is configured.
+- F-38: /v1/* errors rendered in the OpenAI / Anthropic error envelopes;
+  /netllm/* keeps FastAPI's {"detail": ...}.
+- F-32: streaming requests surface pre-stream failures as real HTTP status
+  codes (429 capacity, 502 no-backend) instead of HTTP 200 + aborted body.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from netllm_agent.app import create_app
+from netllm_agent.service import SourceCapacityExceeded
+from netllm_core.models import NetllmConfig
+
+REMOTE = ("10.9.9.9", 5555)
+
+
+def _base_cfg() -> NetllmConfig:
+    cfg = NetllmConfig()
+    cfg.swarm.mdns = False
+    cfg.agent.advertise = False
+    return cfg
+
+
+def _token_cfg() -> NetllmConfig:
+    cfg = _base_cfg()
+    cfg.agent.listen = "0.0.0.0:11400"
+    cfg.swarm.cluster_token = "cluster-tok"
+    return cfg
+
+
+# --- F-40: /netllm/v1/client-env -------------------------------------------
+
+
+def test_f40_client_env_requires_token_from_remote_client() -> None:
+    with TestClient(create_app(_token_cfg()), client=REMOTE) as client:
+        assert client.get("/netllm/v1/client-env").status_code == 401
+        ok = client.get(
+            "/netllm/v1/client-env",
+            headers={"Authorization": "Bearer cluster-tok"},
+        )
+        assert ok.status_code == 200
+        assert "vars" in ok.json()
+
+
+def test_f40_client_env_open_when_no_token_configured() -> None:
+    cfg = _token_cfg()
+    cfg.swarm.cluster_token = ""
+    with TestClient(create_app(cfg), client=REMOTE) as client:
+        assert client.get("/netllm/v1/client-env").status_code == 200
+
+
+# --- F-41: /metrics ---------------------------------------------------------
+
+
+def test_f41_metrics_requires_token_from_remote_client() -> None:
+    with TestClient(create_app(_token_cfg()), client=REMOTE) as client:
+        assert client.get("/metrics").status_code == 401
+        ok = client.get("/metrics", headers={"Authorization": "Bearer cluster-tok"})
+        assert ok.status_code == 200
+        assert b"netllm_requests_total" in ok.content
+
+
+def test_f41_metrics_open_when_no_token_configured() -> None:
+    cfg = _token_cfg()
+    cfg.swarm.cluster_token = ""
+    with TestClient(create_app(cfg), client=REMOTE) as client:
+        resp = client.get("/metrics")
+        assert resp.status_code == 200
+        assert b"netllm_requests_total" in resp.content
+
+
+def test_f41_metrics_open_for_local_client_even_with_token() -> None:
+    with TestClient(create_app(_token_cfg())) as client:
+        assert client.get("/metrics").status_code == 200
+
+
+# --- F-38: per-surface error envelopes --------------------------------------
+
+_CHAT_BODY = {
+    "model": "test-model",
+    "messages": [{"role": "user", "content": "hi"}],
+}
+_MESSAGES_BODY = {
+    "model": "test-model",
+    "max_tokens": 10,
+    "messages": [{"role": "user", "content": "hi"}],
+}
+
+
+@patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)
+def test_f38_openai_shape_on_no_backend_502(mock_scan: AsyncMock) -> None:
+    mock_scan.return_value = []
+    with TestClient(create_app(_base_cfg())) as client:
+        resp = client.post("/v1/chat/completions", json=_CHAT_BODY)
+    assert resp.status_code == 502
+    body = resp.json()
+    assert "detail" not in body
+    err = body["error"]
+    assert set(err) == {"message", "type", "param", "code"}
+    assert err["type"] == "api_error"
+    assert "backend" in err["message"].lower()
+
+
+@patch(
+    "netllm_agent.service.AgentService._source_admit",
+    side_effect=SourceCapacityExceeded("cli", 1),
+)
+def test_f38_openai_shape_on_capacity_429(_mock_admit: object) -> None:
+    with TestClient(create_app(_base_cfg())) as client:
+        resp = client.post("/v1/chat/completions", json=_CHAT_BODY)
+    assert resp.status_code == 429
+    err = resp.json()["error"]
+    assert err["type"] == "rate_limit_error"
+    assert err["code"] == "rate_limit_exceeded"
+    assert "cli" in err["message"]
+
+
+@patch(
+    "netllm_agent.service.AgentService._source_admit",
+    side_effect=SourceCapacityExceeded("cli", 1),
+)
+def test_f38_anthropic_shape_on_capacity_429(_mock_admit: object) -> None:
+    with TestClient(create_app(_base_cfg())) as client:
+        resp = client.post("/v1/messages", json=_MESSAGES_BODY)
+    assert resp.status_code == 429
+    body = resp.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "rate_limit_error"
+    assert "cli" in body["error"]["message"]
+
+
+def test_f38_openai_shape_on_auth_401() -> None:
+    cfg = _token_cfg()
+    cfg.swarm.require_token_for_inference = True
+    with TestClient(create_app(cfg), client=REMOTE) as client:
+        resp = client.get("/v1/models")
+    assert resp.status_code == 401
+    err = resp.json()["error"]
+    assert err["type"] == "authentication_error"
+
+
+def test_f38_netllm_routes_keep_fastapi_detail() -> None:
+    with TestClient(create_app(_token_cfg()), client=REMOTE) as client:
+        resp = client.get("/netllm/v1/status")
+    assert resp.status_code == 401
+    assert "detail" in resp.json()
+    assert "error" not in resp.json()
+
+
+# --- F-32: streaming pre-flight status codes --------------------------------
+
+
+@patch(
+    "netllm_agent.service.AgentService._source_admit",
+    side_effect=SourceCapacityExceeded("cli", 1),
+)
+def test_f32_stream_capacity_exceeded_is_http_429(_mock_admit: object) -> None:
+    """stream=true + admission failure must be a real 429, not a 200 with an
+    aborted body (F-32: async generators run nothing until first iteration)."""
+    with TestClient(create_app(_base_cfg())) as client:
+        resp = client.post("/v1/chat/completions", json={**_CHAT_BODY, "stream": True})
+    assert resp.status_code == 429
+    assert resp.json()["error"]["type"] == "rate_limit_error"
+
+
+@patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)
+def test_f32_stream_no_backend_is_http_5xx(mock_scan: AsyncMock) -> None:
+    mock_scan.return_value = []
+    with TestClient(create_app(_base_cfg())) as client:
+        resp = client.post("/v1/chat/completions", json={**_CHAT_BODY, "stream": True})
+    assert resp.status_code != 200
+    assert resp.status_code == 502
+    assert resp.json()["error"]["type"] == "api_error"
+
+
+@patch(
+    "netllm_agent.service.AgentService._source_admit",
+    side_effect=SourceCapacityExceeded("cli", 1),
+)
+def test_f32_messages_stream_capacity_exceeded_is_http_429(
+    _mock_admit: object,
+) -> None:
+    with TestClient(create_app(_base_cfg())) as client:
+        resp = client.post("/v1/messages", json={**_MESSAGES_BODY, "stream": True})
+    assert resp.status_code == 429
+    body = resp.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "rate_limit_error"
+
+
+@patch("netllm_agent.service.scan_local_providers", new_callable=AsyncMock)
+def test_f32_responses_stream_no_backend_is_http_5xx(mock_scan: AsyncMock) -> None:
+    mock_scan.return_value = []
+    with TestClient(create_app(_base_cfg())) as client:
+        resp = client.post(
+            "/v1/responses",
+            json={"model": "test-model", "input": "hi", "stream": True},
+        )
+    assert resp.status_code == 502
+    assert resp.json()["error"]["type"] == "api_error"
+
+
+async def _fake_chat_stream(*_args, **_kwargs):
+    yield 'data: {"choices":[{"delta":{"content":"he"}}]}\n\n'
+    yield 'data: {"choices":[{"delta":{"content":"llo"}}]}\n\n'
+    yield "data: [DONE]\n\n"
+
+
+@patch(
+    "netllm_agent.service.AgentService.proxy_chat_completion_stream",
+    side_effect=_fake_chat_stream,
+)
+def test_f32_successful_stream_still_delivers_all_chunks(_mock: object) -> None:
+    """The pre-flight first-chunk pull must not drop or reorder stream data."""
+    with TestClient(create_app(_base_cfg())) as client:
+        resp = client.post("/v1/chat/completions", json={**_CHAT_BODY, "stream": True})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert '"he"' in resp.text
+    assert '"llo"' in resp.text
+    assert "[DONE]" in resp.text
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Two stages on this branch:

**1. Audit** — `docs/architecture/09-follow-up-audit-2026-07-31.md`: product-outward, top-down audit of `main` @ `c9bd30a` (six parallel dimensions, every finding adversarially re-verified against its cited `file:line`; 24 deduplicated findings F-30…F-53 continuing the register's append-only namespace).

**2. Remediation** — 21 of 24 findings fixed on this branch in seven file-disjoint batches, each fix proven **red→green** (finding-targeted regression test written first, shown failing, then passing) and checked by an independent verification pass (4 PASS, 3 PASS_WITH_NOTES, 0 FAIL):

- `fix(anthropic-sdk)` — **F-30 (S1)**: streamed Messages to anthropic-format backends no longer raise; un-mocked real-SDK regression test.
- `fix(openai-sdk)` — F-35/36/37/42: embeddings payload adaptation, SDK-signature drift tests, dead-store removal, control-kwarg stripping (wire payloads can no longer inject `extra_headers` upstream).
- `fix(agent)` — F-32/33/38/40/41/45/47/48: streamed error pre-flight (429/502 instead of 200+abort), streamed-Messages success/token accounting, per-surface OpenAI/Anthropic-native error envelopes, `/metrics` + `client-env` read gates, placeholder-key guard parity, peer-hop source attribution, atomic stats.json writes.
- `fix(cli,core)` — F-43/44/46: CLI layering restored (no `netllm_agent`/`fastapi` imports), dead billable probe deleted, cloud-fallback UX trap disarmed with explicit try-order output.
- `fix(core)` — F-39: full Responses SSE lifecycle events with fixture-replay test (live-Codex check deliberately deferred).
- `docs` — F-31 (quickstart `--secure` flow), F-50–F-53.

**Deferred with reasons noted in the register:** F-34 (Windows service host design — multi-env workspace), F-39 live-Codex verification, F-49 (folded into the upcoming F-24/F-25/F-26 consolidation refactor, which is scoped separately with a judged implementation plan and will land on its own branch/PR).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation only (audit register + doc corrections)

## Platforms

- [x] macOS / Linux / Windows (CLI / agent)
- [x] Not platform-specific

## Test plan

```bash
./scripts/ci.sh lint    # All checks passed
uv run pytest -q        # 699 passed, 4 skipped  (baseline 647)
```

- [x] Tests added or updated for behavior changes (+52 finding-targeted regression tests)
- [x] Docs updated (README, AGENTS.md, telemetry-api, editor-integration, config.example.toml, architecture register)

## Checklist

- [x] PR is focused: audit + its remediation
- [x] Conventional commit message(s)
- [x] No secrets, API keys, or `.cursor/mcp.json` committed
- [ ] Agent skills synced — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLckW3wvNgHevF3mnwQtpR