### PR TITLE
fix(security): never serialize Backend.api_key (F-59)

### DIFF
--- a/packages/netllm-core/src/netllm_core/models.py
+++ b/packages/netllm-core/src/netllm_core/models.py
@@ -7,7 +7,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 from netllm_core.cloud_providers import CloudProviderId
 from netllm_core.platform import (
@@ -509,7 +509,16 @@ class Backend(BaseModel):
     base_url: str
     provider: ProviderId = "custom"
     api_format: ApiFormat = "openai"
-    api_key: str = ""
+    # [F-59] Never serialized. Every payload that dumps a Backend --
+    # GET /netllm/v1/backends, the status body, and the heartbeat that
+    # body is gossiped as -- would otherwise carry the raw key, and
+    # require_read_access is a no-op while swarm.cluster_token is empty
+    # (the default even on a LAN bind). The field stays readable in
+    # process for resolve_api_key(); `api_key_set` is the wire-visible
+    # form, matching _backend_override_export's existing convention.
+    # Safe on the write path: config_merge treats keys as write-only, so
+    # an omitted key preserves the stored one rather than blanking it.
+    api_key: str = Field(default="", exclude=True)
     enabled: bool = True
     local: bool = True
     agent_id: str = ""
@@ -529,6 +538,12 @@ class Backend(BaseModel):
     # anyone but its own config. For a local/manual row it comes from
     # BackendOverride.max_concurrency.
     max_concurrency: int = Field(default=0, ge=0)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def api_key_set(self) -> bool:
+        """Wire-visible replacement for the redacted key (F-59)."""
+        return bool(self.api_key)
 
     def cache_key(self) -> str:
         return f"{self.provider}:{self.base_url}"

--- a/tests/test_backend_key_redaction.py
+++ b/tests/test_backend_key_redaction.py
@@ -1,0 +1,111 @@
+"""F-59: a Backend must never serialize its API key.
+
+Every payload that dumps a Backend — ``GET /netllm/v1/backends``, the status
+body, and the heartbeat that body is gossiped as — carried the raw key, while
+``require_read_access`` is a no-op whenever ``swarm.cluster_token`` is empty,
+which is the default even on a LAN bind. Any host on the network could read
+every configured backend and cloud credential in plaintext.
+
+The key stays readable in-process (``resolve_api_key``); only the wire form
+changes, and ``api_key_set`` replaces it — the convention
+``_backend_override_export`` already used for the config view.
+"""
+
+from __future__ import annotations
+
+import json
+
+from netllm_core.models import Backend, BackendHealth
+
+SECRET = "sk-do-not-leak-me"
+
+
+def _backend(**kw) -> Backend:
+    return Backend(
+        id=kw.pop("id", "b1"),
+        base_url=kw.pop("base_url", "http://10.0.0.5:1234/v1"),
+        provider=kw.pop("provider", "custom"),
+        **kw,
+    )
+
+
+def test_api_key_is_absent_from_every_dump_mode() -> None:
+    b = _backend(api_key=SECRET)
+    for dumped in (b.model_dump(), b.model_dump(mode="json")):
+        assert "api_key" not in dumped
+        assert SECRET not in json.dumps(dumped)
+
+
+def test_api_key_set_reports_presence_without_the_value() -> None:
+    assert _backend(api_key=SECRET).model_dump()["api_key_set"] is True
+    assert _backend().model_dump()["api_key_set"] is False
+
+
+def test_key_is_still_usable_in_process() -> None:
+    """Redaction is a serialization concern; routing must be unaffected."""
+    assert _backend(api_key=SECRET).resolve_api_key() == SECRET
+
+
+def test_dumped_backend_still_revalidates() -> None:
+    """Round-trip must not break: peers re-parse these rows from heartbeats."""
+    b = _backend(api_key=SECRET, health=BackendHealth(models=["m1"]))
+    again = Backend.model_validate(b.model_dump(mode="json"))
+    assert again.id == b.id
+    assert again.base_url == b.base_url
+    assert again.health.models == ["m1"]
+    # The receiving node gets no credential — by design.
+    assert again.api_key == ""
+
+
+def test_master_to_spoke_routing_never_needed_the_key() -> None:
+    """A peer row is reached at its own agent surface, not with its keys.
+
+    ``SwarmRegistry.peer_agent_backends`` builds peer rows with no api_key at
+    all — a spoke authenticates the hop with the cluster token. This pins that
+    property, so redaction cannot be blamed for a mesh regression later.
+    """
+    from netllm_core.models import NetllmConfig
+    from netllm_discovery.swarm import PeerRecord, SwarmRegistry
+
+    cfg = NetllmConfig()
+    cfg.agent.agent_id = "master"
+    registry = SwarmRegistry(cfg)
+    registry.register_peer(
+        PeerRecord(
+            agent_id="spoke-1",
+            listen_url="http://10.0.0.9:11400",
+            role="peer",
+            hostname="spoke",
+            backends=[{"id": "remote", "base_url": "http://x/v1", "api_key": SECRET}],
+        )
+    )
+    rows = registry.peer_agent_backends()
+    assert rows, "expected the spoke to be routable from the master"
+    for row in rows:
+        assert row.api_key == ""
+        assert row.base_url.endswith("/v1")
+
+
+def test_a_redacted_payload_does_not_blank_a_stored_key() -> None:
+    """The read-modify-write path stays safe.
+
+    A dashboard/Settings save round-trips what it read. Because config_merge
+    treats keys as write-only, an omitted key preserves the stored one — this
+    is what makes redaction non-breaking rather than destructive.
+    """
+    from netllm_core.config_merge import apply_config_patch
+    from netllm_core.models import BackendOverride, NetllmConfig
+
+    cfg = NetllmConfig()
+    cfg.routing.backends = [
+        BackendOverride(base_url="http://10.0.0.5:1234/v1", api_key=SECRET)
+    ]
+    # The client GETs a redacted view, edits an unrelated field, POSTs it back.
+    patch = {
+        "routing": {
+            "backends": [{"base_url": "http://10.0.0.5:1234/v1", "enabled": False}]
+        }
+    }
+    merged = apply_config_patch(cfg, patch)
+    assert merged.routing.backends[0].api_key == SECRET
+    assert merged.routing.backends[0].enabled is False


### PR DESCRIPTION
## Summary

`GET /netllm/v1/backends` returned `b.model_dump(mode="json")` for every pool row (`app.py:271`) and `Backend.api_key` carried no `exclude`, so the raw key was in the payload. Reproduced:

```
api_key present in model_dump()?  True -> sk-SECRET-123
field declares exclude?           None
```

`require_read_access` is a **no-op whenever `swarm.cluster_token` is empty** — the default even on a LAN bind. So on the documented `netllm serve --host 0.0.0.0` swarm setup, any host on the network could read every configured backend and cloud credential in plaintext, and the same rows gossip to peers on every heartbeat.

`api_key` is now `exclude=True`, with a computed `api_key_set` carrying presence on the wire — the convention `_backend_override_export` already used for the config view. The field stays readable in-process, so `resolve_api_key()` and routing are untouched.

## Why this is non-breaking — traced, not assumed

I followed the call graph before changing anything:

- **Every consumer of `Backend.api_key` is local**: `resolve_api_key()` (`models.py:94`), `service/backends.py:124` (setting it *from* config), `service/cloud.py:189` (comparison), `admin.py:93,168` (existence checks). None reads it from a *received* payload.
- **Master → spoke routing never needed it.** `SwarmRegistry.peer_agent_backends()` (`swarm.py:110-143`) builds peer rows with **no `api_key` at all**; a spoke is reached at its own `/v1` agent surface and the hop is authenticated with the cluster token. The mesh is already credential-isolated — each node uses its own keys for its own backends.
- **Read-modify-write is safe.** `config_merge.py:206-209` treats keys as **write-only**: an omitted or empty key preserves the stored one rather than blanking it. That is what stops a redacted `GET` → edit → `POST` round-trip from destroying credentials, and it is the property that makes redaction viable at all rather than a data-loss bug.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Platforms

- [x] Not platform-specific

## Test plan

```bash
uv run pytest -q       # exit 0 — 1119 passed, 4 skipped (was 1113)
./scripts/ci.sh lint   # exit 0
git status --short tests/contract/vectors   # empty — zero golden-vector diffs
```

Six regression tests (`tests/test_backend_key_redaction.py`) pin each property above, including:

- the key is absent from **both** dump modes and from the serialized JSON;
- `api_key_set` reports presence without the value;
- the key still resolves in-process (redaction is a serialization concern, not a routing change);
- a dumped row **still revalidates** — peers re-parse these from heartbeats;
- **the master/spoke property**, so redaction cannot be blamed for a mesh regression later;
- **the round-trip**, proving a redacted payload does not blank a stored key.

## Context

Found by the 2026-08-08 audit and recorded as **F-59** in [`docs/architecture/10-audit-2026-08-08.md`](docs/architecture/10-audit-2026-08-08.md) (that register lands on a separate branch). Pulled out independently of the extensibility-program work because it is a live credential exposure, small, and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLckW3wvNgHevF3mnwQtpR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLckW3wvNgHevF3mnwQtpR)_