### PR TITLE
feat: Phases 1, 3 and 4 — provider registries, conformance kits, generation rail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
           REBUILD_DONOR: force
       - name: Install menubar test dependencies
         run: brew install ripgrep
+      # The Swift test target existed but ran nowhere: `swift test` appeared
+      # only in scripts/verify-before-pr.sh, a local pre-push helper. So the
+      # app was COMPILED in CI (build.sh runs `swift build -c release`) while
+      # its assertions -- including the Keychain bootstrap roster check --
+      # never executed. The toolchain and checkout are already here.
+      - name: Swift unit tests
+        run: swift test --package-path apps/netllm-mac
       - run: bash scripts/test-menubar-e2e.sh
       - run: bash scripts/test-menubar-lifecycle.sh
 

--- a/apps/netllm-mac/Sources/AppView/SettingsViewModel.swift
+++ b/apps/netllm-mac/Sources/AppView/SettingsViewModel.swift
@@ -92,6 +92,34 @@ final class SettingsViewModel {
         "least_load", "latency_weighted", "batch_shard",
     ]
     static let providers = ["omlx", "ollama", "lmstudio", "vllm"]
+
+    /// Display label and first scan port per discovery provider.
+    ///
+    /// Mirrors `netllm_core.local_providers.LOCAL_PROVIDERS` and is pinned to
+    /// it by `tests/conformance/kit_local.py`, so drift fails CI rather than
+    /// reaching a user. It replaces two things that were wrong: `.capitalized`
+    /// rendered "Omlx"/"Lmstudio"/"Vllm", and the prefill URL was built by a
+    /// ternary that gave every provider except oMLX and Ollama port 1234 --
+    /// so vLLM was prefilled on LM Studio's port.
+    ///
+    /// A bootstrap, not the source of truth: the agent serves the same facts
+    /// at GET /netllm/v1/local-providers, the local twin of
+    /// /netllm/v1/cloud/providers.
+    static let localProviderBootstrap: [(id: String, label: String, port: Int)] = [
+        (id: "omlx", label: "oMLX", port: 8080),
+        (id: "ollama", label: "Ollama", port: 11434),
+        (id: "lmstudio", label: "LM Studio", port: 1234),
+        (id: "vllm", label: "vLLM", port: 8000),
+    ]
+
+    static func localProviderLabel(_ id: String) -> String {
+        localProviderBootstrap.first { $0.id == id }?.label ?? id
+    }
+
+    static func localProviderDefaultURL(_ id: String) -> String {
+        let port = localProviderBootstrap.first { $0.id == id }?.port ?? 8080
+        return "http://127.0.0.1:\(port)/v1"
+    }
     static let roles = ["peer", "gateway"]
 
     // Offline-only fallback (agent unreachable / GET /netllm/v1/cloud/providers

--- a/apps/netllm-mac/Sources/AppView/SettingsWindowView.swift
+++ b/apps/netllm-mac/Sources/AppView/SettingsWindowView.swift
@@ -400,14 +400,12 @@ struct SettingsWindowView: View {
                 .foregroundStyle(.secondary)
             ForEach(SettingsViewModel.providers, id: \.self) { provider in
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(provider.capitalized)
+                    Text(SettingsViewModel.localProviderLabel(provider))
                         .font(.caption.weight(.medium))
                     EditableStringList(
                         items: model.providerURLBinding(provider),
-                        placeholder: "http://127.0.0.1:8088/v1",
-                        defaultNew: provider == "omlx"
-                            ? "http://127.0.0.1:8088/v1"
-                            : "http://127.0.0.1:\(provider == "ollama" ? "11434" : "1234")/v1"
+                        placeholder: SettingsViewModel.localProviderDefaultURL(provider),
+                        defaultNew: SettingsViewModel.localProviderDefaultURL(provider)
                     )
                 }
             }

--- a/apps/netllm-mac/Sources/Config/KeychainStore.swift
+++ b/apps/netllm-mac/Sources/Config/KeychainStore.swift
@@ -48,7 +48,9 @@ enum KeychainStore {
         /// beyond this arrives through the registry, so remembered ∪ bootstrap
         /// is a complete cover of what the Keychain can be holding.
         static let bootstrapProviderIDs = [
+            // netllm:generated:begin:cloud-provider-ids
             "moonshot", "zai", "openai", "anthropic", "openrouter", "dashscope",
+            // netllm:generated:end:cloud-provider-ids
         ]
 
         static func remember(_ providers: [CloudProviderInfo]) {

--- a/apps/netllm-mac/Sources/Config/KeychainStore.swift
+++ b/apps/netllm-mac/Sources/Config/KeychainStore.swift
@@ -4,30 +4,22 @@ import Security
 enum KeychainStore {
     private static let service = "netllm"
 
-    enum Account {
-        static let anthropicAPIKey = "anthropic_api_key"
-        static let openaiAPIKey = "openai_api_key"
-        static let moonshotAPIKey = "moonshot_api_key"
-        static let zaiAPIKey = "zai_api_key"
-        static let openrouterAPIKey = "openrouter_api_key"
-        static let dashscopeAPIKey = "dashscope_api_key"
-    }
-
     /// Maps a cloud provider registry id (from netllm_core.cloud_providers,
     /// served at GET /netllm/v1/cloud/providers) to its Keychain account.
     /// The single place this mapping lives — AgentAPI.cloudProviderRegistry
     /// and SettingsViewModel.cloudProviders (offline bootstrap) both use it
     /// instead of hand-rolling their own id -> account switch.
+    ///
+    /// Every provider's account is `<id>_api_key`. There used to be one
+    /// `case` per provider above the default arm, and all six returned
+    /// exactly what the default arm computes -- so the switch could only ever
+    /// drift, never disagree usefully. Deleted in Phase 4; the registry now
+    /// carries `keychain_account` for a provider that ever needs to deviate,
+    /// and `tests/conformance/kit_cloud.py` pins the convention. The six
+    /// `Account` constants went with it — nothing referenced them once the
+    /// switch was gone.
     static func accountForCloudProvider(_ providerId: String) -> String {
-        switch providerId {
-        case "anthropic": return Account.anthropicAPIKey
-        case "openai": return Account.openaiAPIKey
-        case "moonshot": return Account.moonshotAPIKey
-        case "zai": return Account.zaiAPIKey
-        case "openrouter": return Account.openrouterAPIKey
-        case "dashscope": return Account.dashscopeAPIKey
-        default: return "\(providerId)_api_key"
-        }
+        "\(providerId)_api_key"
     }
 
     /// Which environment variable each stored key has to be exported as when

--- a/apps/netllm-mac/Sources/Config/NetllmConfigDocument.swift
+++ b/apps/netllm-mac/Sources/Config/NetllmConfigDocument.swift
@@ -42,6 +42,14 @@ struct NetllmConfigDocument: Codable, Sendable {
         var prefer_provider: String?
         var allow_cloud: Bool = false
         var enabled: Bool = true
+        // Scopes the policy to one caller (a `[[routing.sources]]` id).
+        // Policies have no identity key, so config_merge rebuilds each row
+        // from RoutingPolicy() defaults plus whatever the patch sends -- a
+        // field this struct does not carry is therefore not "left alone" on
+        // Save, it is ERASED. Omitting `source` silently widened a
+        // source-scoped policy to every caller: F-01 reintroduced through the
+        // Swift surface. Guarded by tests/conformance/kit_config_surfaces.py.
+        var source: String?
     }
 
     struct RoutingSection: Codable, Sendable {

--- a/config.example.toml
+++ b/config.example.toml
@@ -19,7 +19,9 @@ advertise = true
 [discovery]
 # macOS default (netllm init): omlx, ollama, lmstudio, vllm
 # Linux/Windows default (netllm init): ollama, lmstudio, vllm (no omlx)
+# netllm:generated:begin:local-provider-ids
 providers = ["omlx", "ollama", "lmstudio", "vllm"]
+# netllm:generated:end:local-provider-ids
 custom_endpoints = []
 # Per-machine overrides (tried before default port scan). Example desktop node with oMLX on 8088:
 # [discovery.provider_urls]

--- a/docs/extending/README.md
+++ b/docs/extending/README.md
@@ -92,7 +92,7 @@ so this is derivable today. No Swift test covers it.
 | Axis | Files to add one | Duplicated facts | Enforcement | Verdict |
 |---|---|---|---|---|
 | **A** cloud provider | 13 (measured, `08946b6` DashScope) | 8 fact-classes | 3 roster tests trip; Swift + docs unguarded | Medium friction, one sharp edge |
-| **B** local backend | ~14 (no example exists) | **11 parallel maps** on the same id | **zero tests** reference `KNOWN_PROVIDERS` | **Worst axis** |
+| **B** local backend | ~14 (no example exists) | ~~11 parallel maps~~ → **1 registry** | ~~zero tests~~ → `kit_local` (Phase 3) | **RESOLVED** |
 | **C** API surface | 1–3 for a dialect bridge | 4 escaped `Surface` branches | real AST gate in CI | **Cleanest by a wide margin** |
 | **D** CLI + control plane | 32 (measured, `bf67238`) | 3-surface parity manual | per-surface tests; **no parity test** | High volume, mostly genuine work |
 | **E** config evolution | 1–6 | 2 hand-maintained allowlists | strong schema tests; **no version, no migration** | Structurally missing |

--- a/docs/extending/extension-cost-map.md
+++ b/docs/extending/extension-cost-map.md
@@ -131,7 +131,28 @@ Plus client mirrors: `dashboard.js:3` (`const PROVIDERS`), `SettingsViewModel.sw
 
 **Payload adaptation needs no work at all.** `packages/netllm-sdk-openai/src/netllm_sdk_openai/payload.py` is provider-agnostic: `_adapt_payload_for_sdk` splits on an allowlist of SDK-typed params (`_SDK_CHAT_PARAMS`, `_SDK_EMBEDDINGS_PARAMS`) and routes everything else to `extra_body`. The only provider-shaped item is `_FIELD_ALIASES = {"repeat_penalty": "repetition_penalty"}` (`payload.py:74-77`). Capability detection (`netllm_core/capabilities.py:53-62`) is token-based on the model id, not provider-based. **A new provider costs zero lines in both.**
 
-**Verdict: Axis B is the real friction.** Highest duplication of any axis, and the only axis with literally zero registry tests.
+**Verdict: Axis B is the real friction.** Highest duplication of any axis, and the
+only axis with literally zero registry tests.
+
+> **RESOLVED in Phase 3.** The maps below collapsed into
+> `netllm_core/local_providers.py` (`LocalProviderSpec`), and
+> `tests/conformance/kit_local.py` parameterizes over it. The inventory is kept
+> as the *measurement that justified the work*, not as a description of the
+> current tree.
+>
+> Two corrections to the count, recorded because an inflated number is its own
+> defect. By this table's own numbering, **10 of 11** collapsed: item #6, the
+> `ProviderId` Literal, is retained by design (a derived Literal blinds
+> basedpyright) and is asserted by `kit_local` instead. This table also missed a
+> map — `admin.py`'s doctor env-var hints — so the true pre-refactor count was
+> **12**, of which 11 collapsed.
+>
+> The consolidation is complete on the **Python** side only. `dashboard.js`,
+> `config.example.toml`, `AppConfig.swift` and `SettingsViewModel.swift` still
+> hand-mirror the roster; those are ledgered in
+> `tests/conformance/ledgers/mirrors.toml` and close in Phase 4, which needs a
+> server-side local-provider registry route the Swift app can fetch — there is
+> no such endpoint in `routes.json` today.
 
 ---
 

--- a/packages/netllm-agent/src/netllm_agent/admin.py
+++ b/packages/netllm-agent/src/netllm_agent/admin.py
@@ -13,6 +13,7 @@ from netllm_core.cloud_providers import CLOUD_PROVIDERS, get_provider_spec
 from netllm_core.config_report import unknown_cloud_provider_issues
 from netllm_core.harness_detection import detect as detect_harness
 from netllm_core.known_harnesses import KNOWN_HARNESSES
+from netllm_core.local_providers import api_key_env_for
 from netllm_core.models import (
     NetllmConfig,
     is_lan_listen,
@@ -92,13 +93,11 @@ def doctor_payload(cfg: NetllmConfig, service: AgentService) -> dict[str, Any]:
 
     for b in enabled:
         if b.health.http_status in (401, 403) and not b.api_key:
-            env_hints = {
-                "lmstudio": "LMSTUDIO_API_KEY",
-                "omlx": "OMLX_API_KEY",
-                "ollama": "OLLAMA_API_KEY",
-                "vllm": "VLLM_API_KEY",
-            }
-            hint = env_hints.get(b.provider, "")
+            # Empty for `custom`, `peer:*` and cloud ids, which must fall
+            # through to the generic message rather than be told to set a
+            # CUSTOM_API_KEY nothing reads. That miss is why this map was
+            # never derivable from `provider.upper()_API_KEY` alone.
+            hint = api_key_env_for(b.provider)
             fix = (
                 f"Set {hint} or add api_key under [[routing.backends]] for {b.base_url}"
                 if hint

--- a/packages/netllm-agent/src/netllm_agent/admin.py
+++ b/packages/netllm-agent/src/netllm_agent/admin.py
@@ -223,6 +223,39 @@ def _cloud_provider_export(cfg: NetllmConfig) -> dict[str, Any]:
     return out
 
 
+def local_provider_registry_payload() -> list[dict[str, Any]]:
+    """Static registry data for every discoverable local provider.
+
+    The local-side twin of `cloud_provider_registry_payload`. It did not
+    exist, and its absence was the whole reason the clients hand-mirrored the
+    roster: the cloud tab could derive itself from
+    `GET /netllm/v1/cloud/providers`, while the discovery tab had nothing to
+    fetch, so `dashboard.js`, `SettingsViewModel.swift`, `AppConfig.swift` and
+    `SettingsWindowView.swift` each kept their own copy. Those copies had
+    already drifted -- the Swift app prefilled vLLM on :1234, which is LM
+    Studio's port -- and `.capitalized` rendered "Omlx"/"Lmstudio"/"Vllm".
+
+    Serving the facts is what lets those copies become a degraded-mode
+    fallback rather than the source of truth (PROGRAM.md Axis B / Phase 4).
+    """
+    from netllm_core.local_providers import LOCAL_PROVIDERS
+
+    return [
+        {
+            "id": spec.id,
+            "display_name": spec.display_name,
+            "short_label": spec.short_label,
+            "default_ports": list(spec.default_ports),
+            "platforms": list(spec.platforms),
+            "port_env": spec.port_env,
+            "api_key_env": spec.api_key_env,
+            "host_env": spec.host_env,
+            "offline_hint": spec.offline_hint,
+        }
+        for spec in LOCAL_PROVIDERS.values()
+    ]
+
+
 def cloud_provider_registry_payload() -> list[dict[str, Any]]:
     """Static registry data for every pre-configured cloud provider.
 
@@ -332,10 +365,17 @@ def config_summary(cfg: NetllmConfig) -> dict[str, Any]:
             "sources": _source_export(cfg),
             "source_count": len(cfg.routing.sources),
         },
+        # Every UiConfig field, not a hand-picked three. The dashboard renders
+        # this section straight from the schema, so a field the schema
+        # declares but this export omits rendered against `undefined`: the six
+        # menubar_* toggles showed CHECKED against a stored False, and
+        # touching the model_favorites editor POSTed [] -- which, because
+        # lists are full-replace, wiped favourites set from the macOS app.
+        # Derived from model_fields so a new UiConfig field cannot be
+        # forgotten here; log_dir keeps its resolved-path substitution.
         "ui": {
-            "auto_start_on_launch": cfg.ui.auto_start_on_launch,
+            **cfg.ui.model_dump(mode="json"),
             "log_dir": cfg.ui.log_dir or str(cfg.resolved_log_dir()),
-            "check_for_updates_automatically": cfg.ui.check_for_updates_automatically,
         },
         "cloud": {
             "enabled": cfg.cloud.enabled,

--- a/packages/netllm-agent/src/netllm_agent/app.py
+++ b/packages/netllm-agent/src/netllm_agent/app.py
@@ -26,6 +26,7 @@ from netllm_agent.admin import (
     config_summary,
     doctor_payload,
     harness_registry_payload,
+    local_provider_registry_payload,
     logs_payload,
     peers_scan_payload,
     require_admin_access,
@@ -313,6 +314,16 @@ def create_app(
         admin.cloud_provider_registry_payload)."""
         require_admin_access(request, cfg)
         return {"providers": cloud_provider_registry_payload()}
+
+    @app.get("/netllm/v1/local-providers")
+    async def netllm_local_providers(request: Request) -> dict[str, Any]:
+        """Registry metadata for the discoverable local providers — the twin
+        of /netllm/v1/cloud/providers, and the thing whose absence forced the
+        dashboard and macOS app to hand-mirror the roster (and to drift:
+        vLLM was prefilled on LM Studio's port). See
+        admin.local_provider_registry_payload."""
+        require_admin_access(request, cfg)
+        return {"providers": local_provider_registry_payload()}
 
     @app.get("/netllm/v1/harnesses")
     async def netllm_harnesses(request: Request) -> dict[str, Any]:

--- a/packages/netllm-agent/src/netllm_agent/static/dashboard.js
+++ b/packages/netllm-agent/src/netllm_agent/static/dashboard.js
@@ -1,6 +1,31 @@
 /* llm-swarm-router web dashboard — native Settings parity */
 
-const PROVIDERS = ["omlx", "ollama", "lmstudio", "vllm"];
+// Degraded-mode fallback only. The live roster comes from
+// GET /netllm/v1/local-providers (the local twin of /netllm/v1/cloud/providers,
+// added in Phase 4); this list is what renders before that call returns or if
+// the agent is unreachable. Pinned to netllm_core.local_providers by
+// tests/conformance/kit_local.py, so drift fails CI rather than silently
+// omitting a provider from the discovery checkboxes.
+const PROVIDERS_BOOTSTRAP = ["omlx", "ollama", "lmstudio", "vllm"];
+let PROVIDERS = [...PROVIDERS_BOOTSTRAP];
+/** Provider id -> display label, filled from the registry once fetched. */
+let PROVIDER_LABELS = {};
+
+async function loadLocalProviderRegistry() {
+  try {
+    const res = await fetch("/netllm/v1/local-providers");
+    if (!res.ok) return;
+    const rows = (await res.json()).providers || [];
+    if (!rows.length) return;
+    PROVIDERS = rows.map((r) => r.id);
+    PROVIDER_LABELS = Object.fromEntries(
+      rows.map((r) => [r.id, r.short_label || r.display_name || r.id])
+    );
+  } catch (err) {
+    // Keep the bootstrap roster; the discovery tab still works offline.
+    console.warn("local-provider registry unavailable, using bootstrap", err);
+  }
+}
 // STRATEGIES was hand-maintained here; routing.default_strategy's options
 // now come from the schema's Literal introspection (phase 3) instead.
 const ROLES = ["peer", "gateway"];
@@ -1753,7 +1778,7 @@ function renderDiscoveryTab() {
   const card = el("div", "card");
   PROVIDERS.forEach((p) => {
     card.appendChild(
-      checkboxRow(p, (state.configDraft.discovery.providers || []).includes(p), (v) => {
+      checkboxRow(PROVIDER_LABELS[p] || p, (state.configDraft.discovery.providers || []).includes(p), (v) => {
         const list = new Set(state.configDraft.discovery.providers || []);
         if (v) list.add(p);
         else list.delete(p);
@@ -2702,6 +2727,7 @@ async function refresh() {
     loadHarnessRegistry(),
   ]);
   render();
+  renderDrainButton();
 }
 
 function startUpdatePolling() {
@@ -2803,6 +2829,44 @@ document.getElementById("btn-env").addEventListener("click", async () => {
 
 document.getElementById("btn-save").addEventListener("click", saveConfig);
 
+// Drain: POST /netllm/v1/admin/drain was shipped, surfaced in the status
+// payload as `draining`, and reachable from `netllm drain` -- but no UI
+// control existed on either surface, so the only way to take an agent out of
+// rotation from the dashboard was to stop it, killing in-flight requests.
+const btnDrain = document.getElementById("btn-drain");
+function renderDrainButton() {
+  if (!btnDrain) return;
+  const draining = Boolean(state.status && state.status.draining);
+  btnDrain.textContent = draining ? "Undrain" : "Drain";
+  btnDrain.classList.toggle("danger", draining);
+  btnDrain.title = draining
+    ? "Rejoin routing: peers will send this agent work again."
+    : "Stop peers routing new work here. In-flight requests finish; "
+      + "nothing is cancelled. Runtime-only, resets on restart.";
+}
+if (btnDrain) {
+  btnDrain.addEventListener("click", async () => {
+    const next = !(state.status && state.status.draining);
+    btnDrain.disabled = true;
+    try {
+      const res = await fetch("/netllm/v1/admin/drain", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ draining: next }),
+      });
+      if (!res.ok) throw new Error("HTTP " + res.status + " from /admin/drain");
+      showToast(next ? "Draining — peers will stop routing here" : "Rejoined routing");
+      await refresh();
+    } catch (err) {
+      setBanner("Drain failed — " + err.message, "error");
+      showToast(err.message);
+    } finally {
+      btnDrain.disabled = false;
+      renderDrainButton();
+    }
+  });
+}
+
 document.addEventListener("visibilitychange", () => {
   if (document.visibilityState === "visible") {
     startPolling();
@@ -2815,7 +2879,11 @@ document.addEventListener("visibilitychange", () => {
   }
 });
 
-refresh()
+// Fetch the local-provider registry before the first render so the discovery
+// tab shows the agent's real roster and labels rather than the bootstrap.
+// Failure is non-fatal -- loadLocalProviderRegistry keeps the bootstrap.
+loadLocalProviderRegistry()
+  .then(refresh)
   .then(() => {
     startPolling();
     startUpdatePolling();

--- a/packages/netllm-agent/src/netllm_agent/static/dashboard.js
+++ b/packages/netllm-agent/src/netllm_agent/static/dashboard.js
@@ -6,7 +6,14 @@
 // the agent is unreachable. Pinned to netllm_core.local_providers by
 // tests/conformance/kit_local.py, so drift fails CI rather than silently
 // omitting a provider from the discovery checkboxes.
-const PROVIDERS_BOOTSTRAP = ["omlx", "ollama", "lmstudio", "vllm"];
+const PROVIDERS_BOOTSTRAP = [
+  // netllm:generated:begin:local-provider-ids
+  "omlx",
+  "ollama",
+  "lmstudio",
+  "vllm",
+  // netllm:generated:end:local-provider-ids
+];
 let PROVIDERS = [...PROVIDERS_BOOTSTRAP];
 /** Provider id -> display label, filled from the registry once fetched. */
 let PROVIDER_LABELS = {};
@@ -35,12 +42,14 @@ const ROLES = ["peer", "gateway"];
 // single source of truth for the provider set + all display metadata —
 // see admin.cloud_provider_registry_payload / GET /netllm/v1/cloud/providers).
 const CLOUD_PROVIDER_IDS_BOOTSTRAP = [
+  // netllm:generated:begin:cloud-provider-ids
   "moonshot",
   "zai",
   "openai",
   "anthropic",
   "openrouter",
   "dashscope",
+  // netllm:generated:end:cloud-provider-ids
 ];
 
 const state = {

--- a/packages/netllm-agent/src/netllm_agent/static/index.html
+++ b/packages/netllm-agent/src/netllm_agent/static/index.html
@@ -60,8 +60,9 @@
         <div class="topbar-actions">
           <button type="button" id="btn-discover">Discover</button>
           <button type="button" class="secondary" id="btn-env">Copy client env</button>
-          <a class="btn secondary" id="btn-status-json" href="/" target="_blank" rel="noopener">Status JSON</a>
+          <a class="btn secondary" id="btn-status-json" href="/netllm/v1/status" target="_blank" rel="noopener">Status JSON</a>
           <a class="btn secondary" id="btn-omlx-admin" href="http://127.0.0.1:8080/admin" target="_blank" rel="noopener">oMLX Admin</a>
+          <button type="button" class="secondary" id="btn-drain">Drain</button>
           <button type="button" class="secondary" id="btn-refresh">Refresh</button>
           <button type="button" id="btn-save" disabled>Save</button>
         </div>

--- a/packages/netllm-cli/src/netllm_cli/ui.py
+++ b/packages/netllm-cli/src/netllm_cli/ui.py
@@ -6,6 +6,11 @@ import sys
 from typing import Any
 
 import httpx
+from netllm_core.local_providers import (
+    LOCAL_PROVIDERS,
+    NON_DISCOVERABLE_LABELS,
+    get_local_provider_spec,
+)
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -13,12 +18,14 @@ from rich.text import Text
 
 console = Console()
 
+# Derived from the single roster (PROGRAM.md Axis B). Note the asymmetry that
+# is real rather than an oversight: `custom` is labelled here but is not a
+# discoverable provider -- it has no ports, no probe and no key -- so labels
+# parameterize over LOCAL_PROVIDERS | NON_DISCOVERABLE_LABELS while port and
+# probe logic parameterizes over LOCAL_PROVIDERS alone.
 _PROVIDER_LABELS: dict[str, str] = {
-    "omlx": "oMLX",
-    "ollama": "Ollama",
-    "lmstudio": "LM Studio",
-    "vllm": "vLLM",
-    "custom": "custom endpoints",
+    **{spec.id: spec.short_label for spec in LOCAL_PROVIDERS.values()},
+    **NON_DISCOVERABLE_LABELS,
 }
 
 
@@ -33,9 +40,22 @@ def enabled_provider_summary(providers: list[str]) -> str:
 
 
 def default_provider_port_hint() -> str:
-    if sys.platform == "darwin":
-        return "Start oMLX (:8080), Ollama (:11434), LM Studio (:1234), or vLLM (:8000)"
-    return "Start Ollama (:11434), LM Studio (:1234), or vLLM (:8000)"
+    """ "Start X (:port), Y (:port), or Z (:port)" for this platform.
+
+    Derived from the roster, so the platform branch and the four hardcoded
+    port numbers are both gone -- they were two of Axis B's eleven maps, and
+    the ports were free to drift from the ones actually scanned.
+    """
+    parts = [
+        f"{spec.short_label} (:{spec.hint_port()})"
+        for spec in LOCAL_PROVIDERS.values()
+        if sys.platform in spec.platforms
+    ]
+    if not parts:
+        return "Start a local inference server"
+    if len(parts) == 1:
+        return f"Start {parts[0]}"
+    return "Start " + ", ".join(parts[:-1]) + f", or {parts[-1]}"
 
 
 def mdns_platform_hint() -> str:
@@ -215,39 +235,35 @@ def providers_table(results: list[dict[str, Any]], *, title: str) -> None:
 
 
 def offline_provider_hints(results: list[dict[str, Any]]) -> list[str]:
+    """One "here is how to start it" line per offline provider.
+
+    Was a four-arm `elif` chain, each arm restating the provider's label, its
+    env var and (for oMLX) its default ports -- three more of Axis B's
+    parallel maps, and the port list was free to drift from the one actually
+    scanned. The prose now comes from `spec.offline_hint`; everything around
+    it is derived, so a fifth provider gets a correct hint for free.
+    """
     hints: list[str] = []
     offline = [r for r in results if r.get("status") != "online"]
     if not offline:
         return hints
     for r in offline:
-        pid = r.get("id", "")
-        if pid == "omlx" and sys.platform != "darwin":
+        spec = get_local_provider_spec(str(r.get("id", "")))
+        if spec is None or sys.platform not in spec.platforms:
             continue
-        if pid == "omlx":
-            probed = r.get("probed_urls") or []
-            port_hint = ", ".join(
-                str(u).split(":")[-1].split("/")[0] for u in probed[:4]
-            )
-            hints.append(
-                "oMLX: start the server or set "
-                "[cyan]discovery.provider_urls.omlx[/] in config "
-                f"(scanned ports: {port_hint or '8080, 8088, 8081'})"
-            )
-        elif pid == "ollama":
-            hints.append(
-                "Ollama: run [cyan]ollama serve[/] or set "
-                "[cyan]OLLAMA_HOST[/] / [cyan]discovery.provider_urls.ollama[/]"
-            )
-        elif pid == "lmstudio":
-            hints.append(
-                "LM Studio: enable the local API server or set "
-                "[cyan]discovery.provider_urls.lmstudio[/]"
-            )
-        elif pid == "vllm":
-            hints.append(
-                "vLLM: run [cyan]vllm serve --host 0.0.0.0 --port 8000[/] or set "
-                "[cyan]discovery.provider_urls.vllm[/] / [cyan]VLLM_PORT[/]"
-            )
+        pointers = [f"[cyan]discovery.provider_urls.{spec.id}[/]"]
+        if spec.host_env:
+            pointers.insert(0, f"[cyan]{spec.host_env}[/]")
+        elif spec.port_env:
+            pointers.append(f"[cyan]{spec.port_env}[/]")
+        line = f"{spec.short_label}: {spec.offline_hint} or set " + " / ".join(pointers)
+        probed = r.get("probed_urls") or []
+        ports = ", ".join(str(u).split(":")[-1].split("/")[0] for u in probed[:4])
+        if not ports:
+            ports = ", ".join(str(p) for p in spec.default_ports)
+        if len(spec.default_ports) > 1:
+            line += f" (scanned ports: {ports})"
+        hints.append(line)
     return list(dict.fromkeys(hints))
 
 

--- a/packages/netllm-cli/src/netllm_cli/ui.py
+++ b/packages/netllm-cli/src/netllm_cli/ui.py
@@ -257,10 +257,14 @@ def offline_provider_hints(results: list[dict[str, Any]]) -> list[str]:
         elif spec.port_env:
             pointers.append(f"[cyan]{spec.port_env}[/]")
         line = f"{spec.short_label}: {spec.offline_hint} or set " + " / ".join(pointers)
-        probed = r.get("probed_urls") or []
-        ports = ", ".join(str(u).split(":")[-1].split("/")[0] for u in probed[:4])
-        if not ports:
-            ports = ", ".join(str(p) for p in spec.default_ports)
+        # Dedupe: every port is probed on BOTH 127.0.0.1 and localhost, so a
+        # naive slice of probed_urls renders "1234, 1234, 41334, 41334".
+        seen: list[str] = []
+        for url in r.get("probed_urls") or []:
+            port = str(url).split(":")[-1].split("/")[0]
+            if port and port not in seen:
+                seen.append(port)
+        ports = ", ".join(seen[:4]) or ", ".join(str(p) for p in spec.default_ports)
         if len(spec.default_ports) > 1:
             line += f" (scanned ports: {ports})"
         hints.append(line)

--- a/packages/netllm-core/src/netllm_core/cloud_providers.py
+++ b/packages/netllm-core/src/netllm_core/cloud_providers.py
@@ -39,6 +39,18 @@ class CloudProviderSpec:
     models_endpoint: bool
     static_models: tuple[str, ...] = ()
     notes: str = ""
+    keychain_account: str = ""
+    """macOS Keychain account holding this provider's key.
+
+    Empty means the convention `f"{id}_api_key"`, which every provider uses
+    today. Declared rather than hardcoded so a provider that must deviate (a
+    renamed account, a shared credential) is a registry edit instead of a new
+    branch in KeychainStore -- whose per-provider switch cases were deleted in
+    Phase 4 because all six were byte-identical to the default arm.
+    """
+
+    def resolved_keychain_account(self) -> str:
+        return self.keychain_account or f"{self.id}_api_key"
 
     def default_region(self) -> str:
         return next(iter(self.endpoints))

--- a/packages/netllm-core/src/netllm_core/config_merge.py
+++ b/packages/netllm-core/src/netllm_core/config_merge.py
@@ -86,9 +86,17 @@ def deep_merge(base: dict[str, Any], patch: dict[str, Any]) -> dict[str, Any]:
 # marked read_only in the schema document, so a patch echoing it back must
 # not be able to retag a hand-authored row.
 _BACKEND_CLIENT_SET_EXCLUDED = frozenset({"api_key", "cloud_provider"})
-# api_key_env has no editor on any surface today; it is preserved from the
-# prior row rather than accepted from a patch (unchanged behavior).
-_BACKEND_PRESERVE_ONLY = frozenset({"api_key_env"})
+# Fields preserved from the prior row rather than accepted from a patch.
+#
+# This used to hold `api_key_env` on the stated grounds that it "has no editor
+# on any surface today". That was false: SettingsWindowView.swift renders a
+# `TextField("API key env", ...)` bound straight to it, so a user could type a
+# new env var name, press Save, and watch it silently revert -- with no error,
+# and with the UI still showing the typed value because save() does not reload
+# from disk. It is an ordinary editable field and is now treated as one; the
+# empty set is kept so the distinction stays visible rather than the concept
+# being deleted.
+_BACKEND_PRESERVE_ONLY: frozenset[str] = frozenset()
 
 
 def _merge_backends(cfg: NetllmConfig, entries: list[Any]) -> list[dict[str, Any]]:

--- a/packages/netllm-core/src/netllm_core/local_providers.py
+++ b/packages/netllm-core/src/netllm_core/local_providers.py
@@ -1,0 +1,185 @@
+"""The local inference providers netllm can discover, stated once.
+
+Lives in **core**, not discovery, because `models.py`, the CLI's `ui.py` and
+`platform.py` all need these facts and discovery already depends on core --
+putting it in discovery would invert that edge.
+
+Before this module the same provider id was keyed in eleven parallel maps
+across five files (`docs/extending/extension-cost-map.md`, Axis B). Nothing
+referenced the roster in a test, so adding a provider meant finding all
+eleven by archaeology and silently half-working if you missed one -- the
+defect shape both audits kept producing (D17, F-35, F-45).
+
+The rule (`docs/extending/PROGRAM.md` §1): a fact is stated once here, and
+everything downstream derives it, generates it with `--check`, or is
+projection-tested. `tests/conformance/kit_local.py` parameterizes over
+`LOCAL_PROVIDERS`, so a new entry acquires its whole suite with no test edit.
+
+`ProviderId` deliberately stays a hand-written `Literal` in `models.py`
+(basedpyright is configured; a derived Literal blinds it) with a `get_args`
+equality assertion in the kit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class LocalProviderSpec:
+    """Everything netllm knows about one local inference server."""
+
+    id: str
+    display_name: str
+    """Long form, used by discovery result rows (`local.py`'s `name`)."""
+
+    short_label: str
+    """Compact form for CLI tables. Differs from `display_name` for oMLX,
+    which carries an "(Apple Silicon)" qualifier that is noise in a table."""
+
+    default_ports: tuple[int, ...]
+    """Scanned on both 127.0.0.1 and localhost, in order, after config
+    overrides and env vars."""
+
+    platforms: tuple[str, ...]
+    """`sys.platform` values where this provider is enabled by default.
+    oMLX is Apple-Silicon only, which is why `default_discovery_providers()`
+    had a darwin branch."""
+
+    port_env: str = ""
+    """Env var holding a comma/semicolon separated port list. Empty means the
+    provider has none."""
+
+    api_key_env: str = ""
+    """Env var holding the API key. Every current entry is
+    `f"{id.upper()}_API_KEY"`, but this is declared rather than derived: the
+    lookup must *miss* for non-registry providers like `custom` and `peer:*`,
+    which must produce no hint rather than a `CUSTOM_API_KEY` nothing reads."""
+
+    default_api_key: str = ""
+    """Key used when neither config nor env supplies one. Only oMLX has one
+    (`omlx-local`), which is also the sentinel its auth hint reports."""
+
+    host_env: str = ""
+    """Env var holding a full host, `host:port`, `:port`, or URL. This is the
+    Ollama case; declaring it removes `local.py`'s `if provider_id ==
+    "ollama"` special case in favour of a generic candidate builder."""
+
+    default_host_port: int = 0
+    """Port assumed when `host_env` names a bare host with no port."""
+
+    offline_hint_port: int = 0
+    """Port quoted in the CLI's "nothing found" hint. Defaults to the first
+    entry of `default_ports` when unset."""
+
+    offline_hint: str = ""
+    """How an operator starts this server, in imperative prose, for the CLI's
+    "nothing found" output. Genuinely per-provider content rather than a copy
+    of the roster -- `ollama serve` and `vllm serve --host 0.0.0.0` are not
+    derivable from an id -- which is exactly why it belongs on the spec
+    instead of an `elif` chain in `ui.py`."""
+
+    aliases: tuple[str, ...] = field(default_factory=tuple)
+    """Alternative ids accepted from config. None today; present so adding
+    one is a registry edit rather than a new map."""
+
+    def env_port_names(self) -> tuple[str, ...]:
+        return (self.port_env,) if self.port_env else ()
+
+    def hint_port(self) -> int:
+        if self.offline_hint_port:
+            return self.offline_hint_port
+        return self.default_ports[0] if self.default_ports else 0
+
+
+LOCAL_PROVIDERS: dict[str, LocalProviderSpec] = {
+    "omlx": LocalProviderSpec(
+        id="omlx",
+        display_name="oMLX (Apple Silicon)",
+        short_label="oMLX",
+        default_ports=(8080, 8088, 8081),
+        platforms=("darwin",),
+        port_env="OMLX_PORT",
+        api_key_env="OMLX_API_KEY",
+        default_api_key="omlx-local",
+        offline_hint="start the server",
+    ),
+    "ollama": LocalProviderSpec(
+        id="ollama",
+        display_name="Ollama",
+        short_label="Ollama",
+        default_ports=(11434,),
+        platforms=("darwin", "linux", "win32"),
+        port_env="OLLAMA_PORT",
+        api_key_env="OLLAMA_API_KEY",
+        host_env="OLLAMA_HOST",
+        default_host_port=11434,
+        offline_hint="run [cyan]ollama serve[/]",
+    ),
+    "lmstudio": LocalProviderSpec(
+        id="lmstudio",
+        display_name="LM Studio",
+        short_label="LM Studio",
+        default_ports=(1234, 41334),
+        platforms=("darwin", "linux", "win32"),
+        port_env="LMSTUDIO_PORT",
+        api_key_env="LMSTUDIO_API_KEY",
+        offline_hint="enable the local API server",
+    ),
+    "vllm": LocalProviderSpec(
+        id="vllm",
+        display_name="vLLM",
+        short_label="vLLM",
+        default_ports=(8000, 8001),
+        platforms=("darwin", "linux", "win32"),
+        port_env="VLLM_PORT",
+        api_key_env="VLLM_API_KEY",
+        offline_hint="run [cyan]vllm serve --host 0.0.0.0 --port 8000[/]",
+    ),
+}
+
+# `custom` is not a discoverable provider -- it has no ports, no probe and no
+# key -- but it IS a routing provider id and the CLI labels it alongside the
+# real ones. `ui.py` therefore parameterizes over LOCAL_PROVIDERS | this,
+# while port/probe logic parameterizes over LOCAL_PROVIDERS alone. The
+# asymmetry is real; naming it here stops it being rediscovered as a bug.
+NON_DISCOVERABLE_LABELS: dict[str, str] = {"custom": "custom endpoints"}
+
+
+def get_local_provider_spec(provider_id: str) -> LocalProviderSpec | None:
+    """Spec for an id, or None. None is meaningful: `custom`, `peer:*` and
+    cloud ids all legitimately miss, and callers must stay silent for them
+    rather than synthesizing a default."""
+    spec = LOCAL_PROVIDERS.get(provider_id)
+    if spec is not None:
+        return spec
+    for candidate in LOCAL_PROVIDERS.values():
+        if provider_id in candidate.aliases:
+            return candidate
+    return None
+
+
+def local_provider_ids() -> tuple[str, ...]:
+    return tuple(LOCAL_PROVIDERS)
+
+
+def api_key_env_for(provider_id: str) -> str:
+    """Env var holding this provider's key, or "" when it has none.
+
+    The empty return is load-bearing -- `netllm doctor` uses it to decide
+    whether to name an env var in a 401 fix hint, and a `custom` backend must
+    get the generic message.
+    """
+    spec = get_local_provider_spec(provider_id)
+    return spec.api_key_env if spec else ""
+
+
+def default_api_key_for(provider_id: str) -> str:
+    spec = get_local_provider_spec(provider_id)
+    return spec.default_api_key if spec else ""
+
+
+def providers_for_platform(sys_platform: str) -> list[str]:
+    return [
+        spec.id for spec in LOCAL_PROVIDERS.values() if sys_platform in spec.platforms
+    ]

--- a/packages/netllm-core/src/netllm_core/local_providers.py
+++ b/packages/netllm-core/src/netllm_core/local_providers.py
@@ -179,7 +179,39 @@ def default_api_key_for(provider_id: str) -> str:
     return spec.default_api_key if spec else ""
 
 
+def _is_platform_exclusive(spec: LocalProviderSpec) -> bool:
+    """True when a provider runs on exactly one platform (oMLX today).
+
+    Such a provider must never be offered on an unknown platform; a
+    cross-platform one is a better guess than an empty list.
+    """
+    return len(spec.platforms) == 1
+
+
 def providers_for_platform(sys_platform: str) -> list[str]:
-    return [
+    """Providers enabled by default on `sys_platform`.
+
+    The fallback matters. `platforms` is an allowlist, but the behaviour it
+    replaced was "everything except oMLX unless darwin" -- an else-branch that
+    covered *any* platform, including ones nobody enumerated (freebsd, aix,
+    cygwin). A bare allowlist silently returns nothing there, which turns an
+    unusual platform from "works, minus oMLX" into "discovers nothing at all".
+    Anything not enumerated therefore gets the cross-platform providers.
+    """
+    enabled = [
         spec.id for spec in LOCAL_PROVIDERS.values() if sys_platform in spec.platforms
     ]
+    if enabled:
+        return enabled
+    return [
+        spec.id for spec in LOCAL_PROVIDERS.values() if not _is_platform_exclusive(spec)
+    ]
+
+
+def _is_platform_exclusive(spec: LocalProviderSpec) -> bool:
+    """True when a provider runs on exactly one platform (oMLX today).
+
+    Such a provider must never be offered on an unknown platform; a
+    cross-platform one is a better guess than an empty list.
+    """
+    return len(spec.platforms) == 1

--- a/packages/netllm-core/src/netllm_core/models.py
+++ b/packages/netllm-core/src/netllm_core/models.py
@@ -608,13 +608,9 @@ class Backend(BaseModel):
     def resolve_api_key(self) -> str:
         if self.api_key:
             return self.api_key
-        env_map = {
-            "omlx": "OMLX_API_KEY",
-            "ollama": "OLLAMA_API_KEY",
-            "lmstudio": "LMSTUDIO_API_KEY",
-            "vllm": "VLLM_API_KEY",
-        }
-        env_name = env_map.get(self.provider, "")
+        from netllm_core.local_providers import api_key_env_for, default_api_key_for
+
+        env_name = api_key_env_for(self.provider)
         if not env_name and self.cloud_provider:
             from netllm_core.cloud_providers import get_provider_spec
 
@@ -625,8 +621,7 @@ class Backend(BaseModel):
             from_env = os.environ.get(env_name, "")
             if from_env:
                 return from_env
-        defaults: dict[str, str] = {"omlx": "omlx-local"}
-        return defaults.get(self.provider, "")
+        return default_api_key_for(self.provider)
 
 
 DEFAULT_AGENT_PORT = 11400

--- a/packages/netllm-core/src/netllm_core/platform.py
+++ b/packages/netllm-core/src/netllm_core/platform.py
@@ -60,6 +60,13 @@ def default_log_dir() -> Path:
 
 
 def default_discovery_providers() -> list[str]:
-    if is_darwin():
-        return ["omlx", "ollama", "lmstudio", "vllm"]
-    return ["ollama", "lmstudio", "vllm"]
+    """Providers enabled by default on this platform.
+
+    Derived from each spec's `platforms` (PROGRAM.md Axis B). The darwin
+    branch this replaced existed solely because oMLX is Apple-Silicon only;
+    that fact now lives on the oMLX spec, so a provider with different
+    platform support costs a registry field rather than a branch here.
+    """
+    from netllm_core.local_providers import providers_for_platform
+
+    return providers_for_platform(sys.platform)

--- a/packages/netllm-discovery/src/netllm_discovery/local.py
+++ b/packages/netllm-discovery/src/netllm_discovery/local.py
@@ -10,18 +10,28 @@ from urllib.parse import urlparse
 
 import httpx
 from netllm_core.health import diagnose_backend, probe_openai_compat
+from netllm_core.local_providers import (
+    LOCAL_PROVIDERS,
+    api_key_env_for,
+    default_api_key_for,
+    get_local_provider_spec,
+)
 from netllm_core.models import Backend, BackendHealth, NetllmConfig, infer_api_format
 
 # Display name + default scan ports (localhost); config provider_urls are tried first.
+#
+# Derived from netllm_core.local_providers -- the single roster (PROGRAM.md
+# Axis B). Kept as a module-level name because it is this package's public
+# shape and external callers import it; the *facts* now live in one place.
 KNOWN_PROVIDERS: list[tuple[str, str, list[int]]] = [
-    ("omlx", "oMLX (Apple Silicon)", [8080, 8088, 8081]),
-    ("ollama", "Ollama", [11434]),
-    ("lmstudio", "LM Studio", [1234, 41334]),
-    ("vllm", "vLLM", [8000, 8001]),
+    (spec.id, spec.display_name, list(spec.default_ports))
+    for spec in LOCAL_PROVIDERS.values()
 ]
 
 DEFAULT_API_KEYS: dict[str, str] = {
-    "omlx": "omlx-local",
+    spec.id: spec.default_api_key
+    for spec in LOCAL_PROVIDERS.values()
+    if spec.default_api_key
 }
 
 
@@ -78,32 +88,38 @@ def _dedupe_preserve_order(urls: list[str]) -> list[str]:
     return out
 
 
-def _ollama_env_candidates() -> list[str]:
-    raw = os.environ.get("OLLAMA_HOST", "").strip()
+def _host_env_candidates(provider_id: str) -> list[str]:
+    """Candidates from a provider's `host_env` (today only `OLLAMA_HOST`).
+
+    Was `_ollama_env_candidates` plus an `if provider_id == "ollama"` at the
+    call site. Declaring `host_env` on the spec makes it generic, so a second
+    provider with the same convention costs a registry field rather than
+    another branch here.
+    """
+    spec = get_local_provider_spec(provider_id)
+    if spec is None or not spec.host_env:
+        return []
+    raw = os.environ.get(spec.host_env, "").strip()
     if not raw:
         return []
     if raw.startswith("http://") or raw.startswith("https://"):
         return [normalize_openai_base_url(raw)]
     host = "127.0.0.1"
-    port = "11434"
+    port = str(spec.default_host_port)
     if raw.startswith(":"):
         port = raw.lstrip(":") or port
     elif ":" in raw:
         host, port = raw.split(":", 1)
         host = host or "127.0.0.1"
-        port = port or "11434"
+        port = port or str(spec.default_host_port)
     else:
         host = raw
     return _urls_for_host_port(host, int(port))
 
 
 def _env_port_candidates(provider_id: str) -> list[str]:
-    env_name = {
-        "omlx": "OMLX_PORT",
-        "ollama": "OLLAMA_PORT",
-        "lmstudio": "LMSTUDIO_PORT",
-        "vllm": "VLLM_PORT",
-    }.get(provider_id, "")
+    spec = get_local_provider_spec(provider_id)
+    env_name = spec.port_env if spec else ""
     if not env_name:
         return []
     raw = os.environ.get(env_name, "").strip()
@@ -122,16 +138,13 @@ def candidate_urls_for_provider(provider_id: str, config: NetllmConfig) -> list[
     """Build probe list: saved overrides, env, then default port scan."""
     urls: list[str] = []
     urls.extend(config.discovery.provider_urls.get(provider_id, []))
-    if provider_id == "ollama":
-        urls.extend(_ollama_env_candidates())
+    urls.extend(_host_env_candidates(provider_id))
     urls.extend(_env_port_candidates(provider_id))
-    for _pid, _name, ports in KNOWN_PROVIDERS:
-        if _pid != provider_id:
-            continue
-        for port in ports:
+    spec = get_local_provider_spec(provider_id)
+    if spec is not None:
+        for port in spec.default_ports:
             urls.extend(_urls_for_host_port("127.0.0.1", port))
             urls.extend(_urls_for_host_port("localhost", port))
-        break
     return _dedupe_preserve_order(urls)
 
 
@@ -156,20 +169,28 @@ def merge_discovered_provider_urls(
     return config
 
 
+def _auth_hint(provider_id: str, api_key: str) -> str:
+    """How the discovery row describes the credential it used.
+
+    A provider still on its own built-in default reports that default by name
+    (oMLX's `omlx-local`) rather than "configured", so the table does not
+    imply the operator supplied a key they never set.
+    """
+    default = default_api_key_for(provider_id)
+    if default and api_key == default:
+        return default
+    return "configured" if api_key else "none"
+
+
 def _api_key_for_provider(provider_id: str, config: NetllmConfig) -> str:
     for override in config.routing.backends:
         if override.provider == provider_id:
             return override.resolve_api_key()
-    env_map = {
-        "omlx": "OMLX_API_KEY",
-        "ollama": "OLLAMA_API_KEY",
-        "lmstudio": "LMSTUDIO_API_KEY",
-        "vllm": "VLLM_API_KEY",
-    }
-    env_name = env_map.get(provider_id, "")
+    env_name = api_key_env_for(provider_id)
+    default = default_api_key_for(provider_id)
     if env_name:
-        return os.environ.get(env_name, DEFAULT_API_KEYS.get(provider_id, ""))
-    return DEFAULT_API_KEYS.get(provider_id, "")
+        return os.environ.get(env_name, default)
+    return default
 
 
 async def _probe_url(
@@ -226,11 +247,7 @@ async def _probe_provider(
             "name": display_name,
             "base_url": url,
             "api_key": api_key,
-            "auth_hint": (
-                "omlx-local"
-                if provider_id == "omlx" and api_key == "omlx-local"
-                else ("configured" if api_key else "none")
-            ),
+            "auth_hint": _auth_hint(provider_id, api_key),
             **hit,
         }
     return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
 asyncio_mode = "auto"
 # tests/contract/scenarios_*.py hold the contract-vector suites; without this
 # they are silently uncollected and the corpus never runs.
-python_files = ["test_*.py", "scenarios_*.py"]
+python_files = ["test_*.py", "scenarios_*.py", "kit_*.py"]
 testpaths = [
     "tests",
     "packages/netllm-sdk-openai/tests",

--- a/scripts/check-registry-mirrors.py
+++ b/scripts/check-registry-mirrors.py
@@ -89,16 +89,73 @@ def _hits(path: Path, ids: list[str]) -> list[tuple[int, str]]:
     """Quoted occurrences of any id, as ``(line_number, id)``.
 
     Quotes are the whole heuristic and that is deliberate: a bare word in a
-    comment is prose, ``"ollama"`` is a fact. No AST, because four of the nine
-    scanned files are not Python.
+    comment is prose, ``"ollama"`` is a fact. No AST for the general case,
+    because four of the scanned files are not Python.
+
+    Python files get one refinement: comments and docstrings are blanked
+    first. A docstring explaining *why* a special case was removed quotes the
+    id it removed, and flagging that is a false positive -- which is worse
+    than useless, because the cheapest way to silence it is a ledger entry,
+    and the ledger is supposed to mean "a real mirror lives here". Prose about
+    a fact is not a copy of it.
     """
     pattern = re.compile("|".join(f"[\"']{re.escape(i)}[\"']" for i in sorted(ids)))
-    found: list[tuple[int, str]] = []
     text = path.read_text(encoding="utf-8")
+    if path.suffix == ".py":
+        text = _blank_python_prose(text)
+    found: list[tuple[int, str]] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
         for match in pattern.finditer(line):
             found.append((lineno, match.group(0)[1:-1]))
     return found
+
+
+def _blank_python_prose(text: str) -> str:
+    """Replace comments and docstrings with blanks, preserving line numbers.
+
+    Uses ``tokenize`` rather than a regex so an id inside a normal string
+    literal still counts -- only COMMENT tokens and STRING tokens standing
+    alone as an expression statement (i.e. docstrings) are removed.
+    """
+    import io
+    import tokenize
+
+    lines = text.splitlines(keepends=True)
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return text  # unparseable: scan it verbatim rather than skip it
+
+    spans: list[tuple[int, int, int, int]] = []
+    prev_meaningful: int | None = None
+    for tok in tokens:
+        if tok.type == tokenize.COMMENT:
+            spans.append((*tok.start, *tok.end))
+            continue
+        if tok.type == tokenize.STRING and prev_meaningful in (
+            None,
+            tokenize.INDENT,
+            tokenize.NEWLINE,
+            tokenize.NL,
+        ):
+            spans.append((*tok.start, *tok.end))
+        if tok.type not in (
+            tokenize.NL,
+            tokenize.COMMENT,
+            tokenize.INDENT,
+            tokenize.DEDENT,
+        ):
+            prev_meaningful = tok.type
+
+    for srow, scol, erow, ecol in spans:
+        for row in range(srow, erow + 1):
+            line = lines[row - 1]
+            start = scol if row == srow else 0
+            end = ecol if row == erow else len(line.rstrip("\n"))
+            keep_nl = "\n" if line.endswith("\n") else ""
+            body = line.rstrip("\n")
+            lines[row - 1] = body[:start] + " " * (end - start) + body[end:] + keep_nl
+    return "".join(lines)
 
 
 def main() -> int:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -32,6 +32,7 @@ run_lint() {
   # No-new-mirrors gate (docs/extending/PROGRAM.md §2): a provider id may not
   # appear in a file the ledger does not already name.
   python3 scripts/check-registry-mirrors.py
+  python3 scripts/generate-registry-artifacts.py --check
   # Instructional docs may not point at paths that do not exist.
   python3 scripts/check-doc-paths.py
   # The three checked-in skill copies must match .agents/skills/.

--- a/scripts/generate-registry-artifacts.py
+++ b/scripts/generate-registry-artifacts.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Generate the registry rosters that clients cannot import (PROGRAM.md §1).
+
+Four surfaces need a provider roster and none of them can `import
+netllm_core`: the dashboard's JavaScript, two Swift bootstrap lists, and the
+example TOML. Each kept a hand-written copy, and the copies drifted — that is
+Axis A/B's whole cost story.
+
+The middle rung of PROGRAM.md's ladder (derive > **generate with --check** >
+projection-test > mirror) applies: the block between the markers is written
+from the registry, and `--check` in `run_lint` fails when it is stale. The
+lists stay real literals in the file, so the dashboard still renders offline
+and the Swift app still compiles with no network.
+
+    python3 scripts/generate-registry-artifacts.py           # rewrite
+    python3 scripts/generate-registry-artifacts.py --check   # exit 1 if stale
+
+No imports of the workspace packages: this runs under bare python3 in lint,
+alongside the other gates, so the registries are read by AST exactly as
+check-registry-mirrors.py reads them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLOUD_REGISTRY = ROOT / "packages/netllm-core/src/netllm_core/cloud_providers.py"
+LOCAL_REGISTRY = ROOT / "packages/netllm-core/src/netllm_core/local_providers.py"
+
+BEGIN = "netllm:generated:begin"
+END = "netllm:generated:end"
+
+
+def _dict_keys(source: Path, name: str) -> list[str]:
+    tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+    for node in tree.body:
+        target = None
+        value = None
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target, value = node.target.id, node.value
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            first = node.targets[0]
+            if isinstance(first, ast.Name):
+                target, value = first.id, node.value
+        if target != name or not isinstance(value, ast.Dict):
+            continue
+        return [
+            key.value
+            for key in value.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        ]
+    raise SystemExit(f"generate-registry-artifacts: {source}: no dict named {name}")
+
+
+@dataclass(frozen=True)
+class Block:
+    """One generated region, addressed by a marker id inside a file."""
+
+    path: Path
+    marker: str
+    render: str
+
+    def rewrite(self, text: str) -> str:
+        begin = f"{BEGIN}:{self.marker}"
+        end = f"{END}:{self.marker}"
+        start_at = text.find(begin)
+        end_at = text.find(end)
+        if start_at == -1 or end_at == -1:
+            raise SystemExit(
+                f"generate-registry-artifacts: {self.path.relative_to(ROOT)}: "
+                f"missing marker pair for {self.marker!r}. Add\n"
+                f"  <comment> {begin}\n  ...\n  <comment> {end}"
+            )
+        line_end = text.index("\n", start_at) + 1
+        return text[:line_end] + self.render + text[text.rindex("\n", 0, end_at) + 1 :]
+
+
+def _blocks() -> list[Block]:
+    cloud = _dict_keys(CLOUD_REGISTRY, "CLOUD_PROVIDERS")
+    local = _dict_keys(LOCAL_REGISTRY, "LOCAL_PROVIDERS")
+
+    def js_array(ids: list[str], indent: str = "  ") -> str:
+        return "".join(f'{indent}"{i}",\n' for i in ids)
+
+    def swift_array(ids: list[str], indent: str = "            ") -> str:
+        return indent + ", ".join(f'"{i}"' for i in ids) + ",\n"
+
+    return [
+        Block(
+            ROOT / "packages/netllm-agent/src/netllm_agent/static/dashboard.js",
+            "cloud-provider-ids",
+            js_array(cloud),
+        ),
+        Block(
+            ROOT / "packages/netllm-agent/src/netllm_agent/static/dashboard.js",
+            "local-provider-ids",
+            js_array(local),
+        ),
+        Block(
+            ROOT / "apps/netllm-mac/Sources/Config/KeychainStore.swift",
+            "cloud-provider-ids",
+            swift_array(cloud),
+        ),
+        Block(
+            ROOT / "config.example.toml",
+            "local-provider-ids",
+            "providers = [" + ", ".join(f'"{i}"' for i in local) + "]\n",
+        ),
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if any generated block is stale, without rewriting",
+    )
+    args = parser.parse_args()
+
+    stale: list[str] = []
+    by_path: dict[Path, str] = {}
+    for block in _blocks():
+        text = by_path.get(block.path)
+        if text is None:
+            text = block.path.read_text(encoding="utf-8")
+        updated = block.rewrite(text)
+        if updated != text:
+            stale.append(f"{block.path.relative_to(ROOT)} [{block.marker}]")
+        by_path[block.path] = updated
+
+    if args.check:
+        if stale:
+            print(
+                "generate-registry-artifacts: generated blocks are stale:\n  "
+                + "\n  ".join(stale)
+                + "\n\nRun: python3 scripts/generate-registry-artifacts.py",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"OK: generate-registry-artifacts — {len(_blocks())} generated blocks "
+            "match the registries"
+        )
+        return 0
+
+    for path, text in by_path.items():
+        path.write_text(text, encoding="utf-8")
+    if stale:
+        print("regenerated:\n  " + "\n  ".join(stale))
+    else:
+        print("already up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conformance/kit_cloud.py
+++ b/tests/conformance/kit_cloud.py
@@ -1,0 +1,176 @@
+"""Axis A conformance kit: the contract every cloud provider must satisfy.
+
+Parameterized over `CLOUD_PROVIDERS`, so a new provider acquires this suite
+with no test-file edits — the same deal `kit_local` gives Axis B.
+
+Axis A was already the better-behaved axis: `cloud_provider_registry_payload`
+is a real runtime projection, and the Swift app fetches it rather than
+hardcoding. What it lacked was a *contract* — three roster tests tripped, but
+nothing asserted that a spec was internally coherent, that its declared
+default region actually existed, or that the Keychain and env-var conventions
+held. `08946b6` (DashScope) touched 13 files; the kit is what makes the next
+one loud where it is incomplete rather than silent.
+"""
+
+from __future__ import annotations
+
+import pytest
+from netllm_core.cloud_providers import CLOUD_PROVIDERS, CloudProviderSpec
+
+from conformance.projections import REPO_ROOT, string_array_after
+
+SPECS = list(CLOUD_PROVIDERS.values())
+IDS = [spec.id for spec in SPECS]
+
+
+@pytest.fixture(params=SPECS, ids=IDS)
+def spec(request: pytest.FixtureRequest) -> CloudProviderSpec:
+    return request.param
+
+
+# --- spec coherence -------------------------------------------------------
+
+
+def test_spec_is_well_formed(spec: CloudProviderSpec) -> None:
+    assert spec.id and spec.id.islower()
+    assert spec.display_name
+    assert spec.endpoints, "a provider with no endpoint cannot be routed to"
+    assert spec.auth_modes
+    assert spec.api_key_env
+    assert spec.default_api_format in ("openai", "anthropic")
+
+
+def test_registry_key_matches_spec_id() -> None:
+    for key, value in CLOUD_PROVIDERS.items():
+        assert key == value.id, f"registry key {key!r} != spec id {value.id!r}"
+
+
+def test_default_region_resolves_to_a_real_endpoint(spec: CloudProviderSpec) -> None:
+    """`default_region()` returns the first endpoint key; if that key were
+    ever removed while a stale default lingered, every unqualified request to
+    the provider would resolve to the wrong base URL."""
+    assert spec.default_region() in spec.endpoints
+    assert spec.endpoint(spec.default_region()) is spec.endpoints[spec.default_region()]
+
+
+def test_an_unknown_region_falls_back_rather_than_raising(
+    spec: CloudProviderSpec,
+) -> None:
+    """A config naming a region this build does not know must degrade to the
+    default, not KeyError — Phase 2 made unknown config keys survivable, and
+    this is the same contract one level down."""
+    assert spec.endpoint("no-such-region") is spec.endpoints[spec.default_region()]
+
+
+def test_static_models_exist_when_there_is_no_live_catalog(
+    spec: CloudProviderSpec,
+) -> None:
+    """The Z.ai invariant. A provider with `models_endpoint=False` cannot be
+    probed for its catalog, so without `static_models` it materializes zero
+    models and is silently unusable."""
+    if spec.models_endpoint:
+        pytest.skip(f"{spec.id} serves a live /models catalog")
+    assert spec.static_models, (
+        f"{spec.id} has no /models endpoint and no static_models, so it can "
+        "never offer a model"
+    )
+
+
+# --- conventions the clients rely on --------------------------------------
+
+
+def test_api_key_env_follows_the_derivable_convention(spec: CloudProviderSpec) -> None:
+    """Swift derives this as `id.uppercased()_API_KEY` when the registry has
+    not been fetched yet (KeychainStore.CloudKeyEnv.defaultEnvVar). A spec
+    that deviates would be injected under the wrong variable in degraded
+    mode, so the deviation has to be deliberate and visible here."""
+    assert spec.api_key_env == f"{spec.id.upper()}_API_KEY", (
+        f"{spec.id} deviates from the derivable env-var convention; the Swift "
+        "degraded-mode fallback computes the derived name and would inject "
+        "the key under the wrong variable"
+    )
+
+
+def test_keychain_account_follows_the_convention(spec: CloudProviderSpec) -> None:
+    """KeychainStore.accountForCloudProvider is now a one-liner returning
+    `<id>_api_key`; its six per-provider switch cases were deleted in Phase 4
+    because every one returned exactly that. This pins the convention so the
+    deletion stays safe."""
+    assert spec.resolved_keychain_account() == f"{spec.id}_api_key"
+
+
+def test_registry_payload_carries_every_spec(spec: CloudProviderSpec) -> None:
+    """The runtime projection the macOS app and dashboard both consume."""
+    from netllm_agent.admin import cloud_provider_registry_payload
+
+    rows = {row["id"]: row for row in cloud_provider_registry_payload()}
+    assert spec.id in rows, f"{spec.id} is absent from the served registry"
+    row = rows[spec.id]
+    assert row["display_name"] == spec.display_name
+    assert row["regions"] == list(spec.endpoints)
+    assert row["api_key_env"] == spec.api_key_env
+    assert row["default_api_format"] == spec.default_api_format
+
+
+def test_config_round_trip_preserves_the_provider(spec: CloudProviderSpec) -> None:
+    """load -> save -> load must not drop a `[cloud.providers.<id>]` subtree.
+
+    This is `models.py`'s old filtering validator as a test: it dropped any
+    provider id the running build did not know, which deleted a newer
+    release's provider from an older agent's config on the next save.
+    """
+    from netllm_core.config_merge import apply_config_patch
+    from netllm_core.models import CloudProviderConfig, NetllmConfig
+
+    cfg = NetllmConfig()
+    cfg.cloud.providers = {
+        spec.id: CloudProviderConfig(enabled=True, region=spec.default_region())
+    }
+    merged = apply_config_patch(cfg, {"cloud": {"enabled": True}})
+    assert spec.id in merged.cloud.providers, (
+        f"{spec.id} was dropped by a config round-trip"
+    )
+    assert merged.cloud.providers[spec.id].enabled is True
+    assert merged.cloud.providers[spec.id].region == spec.default_region()
+
+
+# --- client projections ---------------------------------------------------
+
+
+def test_swift_bootstrap_covers_every_provider() -> None:
+    """The macOS degraded-mode roster: what Settings can render before it has
+    ever reached an agent. A provider missing here can have its key typed and
+    stored but never injected — it 401s against a credential the UI shows as
+    saved."""
+    found = string_array_after(
+        "apps/netllm-mac/Sources/Config/KeychainStore.swift",
+        "static let bootstrapProviderIDs",
+    )
+    found.assert_exactly(set(CLOUD_PROVIDERS))
+
+
+def test_dashboard_bootstrap_covers_every_provider() -> None:
+    found = string_array_after(
+        "packages/netllm-agent/src/netllm_agent/static/dashboard.js",
+        "CLOUD_PROVIDER_IDS_BOOTSTRAP",
+    )
+    found.assert_exactly(set(CLOUD_PROVIDERS))
+
+
+def test_no_literal_api_key_table_survives_in_pythonruntime() -> None:
+    """`PythonRuntime.injectCloudAPIKeys` held a closed `(account, env)` table
+    — the one hardcode in the tree that failed silently, because a provider
+    added everywhere else still stored a key that was never exported. It is
+    derived now; assert the literal table cannot come back."""
+    text = (REPO_ROOT / "apps/netllm-mac/Sources/Server/PythonRuntime.swift").read_text(
+        encoding="utf-8"
+    )
+    offenders = [
+        line.strip()
+        for line in text.splitlines()
+        if "_API_KEY" in line and not line.strip().startswith("//")
+    ]
+    assert not offenders, (
+        "PythonRuntime.swift names an API-key env var literally again; the "
+        f"injection list must stay derived from the registry: {offenders}"
+    )

--- a/tests/conformance/kit_cloud.py
+++ b/tests/conformance/kit_cloud.py
@@ -174,3 +174,60 @@ def test_no_literal_api_key_table_survives_in_pythonruntime() -> None:
         "PythonRuntime.swift names an API-key env var literally again; the "
         f"injection list must stay derived from the registry: {offenders}"
     )
+
+
+def test_settings_bootstrap_covers_every_provider(spec: CloudProviderSpec) -> None:
+    """The macOS Settings offline roster (`cloudProvidersBootstrap`).
+
+    Richer than an id list -- it carries display name, notes, regions and auth
+    modes -- so it is projection-tested against the registry rather than
+    generated. A provider missing here simply does not render in Settings
+    until the app has reached an agent, which on a first run is "the provider
+    does not exist".
+    """
+    import re
+
+    text = (
+        REPO_ROOT / "apps/netllm-mac/Sources/AppView/SettingsViewModel.swift"
+    ).read_text(encoding="utf-8")
+    start = text.find("static let cloudProvidersBootstrap")
+    assert start != -1, "cloudProvidersBootstrap not found"
+    body = text[start : text.find("\n    ]", start)]
+    ids = set(re.findall(r'id:\s*"([^"]+)"', body))
+    assert spec.id in ids, (
+        f"SettingsViewModel.cloudProvidersBootstrap is missing {spec.id!r}; "
+        "it will not render in Settings before the app reaches an agent"
+    )
+    name_match = re.search(
+        rf'id:\s*"{re.escape(spec.id)}",\s*displayName:\s*"([^"]+)"', body
+    )
+    if name_match:
+        assert name_match.group(1) == spec.display_name, (
+            f"{spec.id}: Swift displayName {name_match.group(1)!r} != registry "
+            f"{spec.display_name!r}"
+        )
+
+
+def test_omlx_admin_probe_is_the_only_provider_specific_branch() -> None:
+    """oMLX exposes a proprietary admin/telemetry API no other local server
+    has, so `provider != "omlx"` in discovery is a real capability check, not
+    a roster copy. Pin that it stays the *only* such branch -- a second one
+    means the capability belongs on the spec instead."""
+    import re
+
+    text = (
+        REPO_ROOT / "packages/netllm-discovery/src/netllm_discovery/local.py"
+    ).read_text(encoding="utf-8")
+    # Require an actual conditional, not prose: a docstring explaining a
+    # branch that was REMOVED still quotes the id it removed, and counting
+    # that would make the guard fire on its own changelog.
+    branches = [
+        line.strip()
+        for line in text.splitlines()
+        if re.match(r"^\s*(el)?if\s.*[!=]=\s*\"", line)
+        and any(f'"{p}"' in line for p in ("omlx", "ollama", "lmstudio", "vllm"))
+    ]
+    assert len(branches) <= 1, (
+        "more than one provider-specific branch survives in discovery; put the "
+        f"capability on LocalProviderSpec instead: {branches}"
+    )

--- a/tests/conformance/kit_config_surfaces.py
+++ b/tests/conformance/kit_config_surfaces.py
@@ -1,0 +1,312 @@
+"""Every config row model must be carried in full by every editing surface.
+
+`config_merge` rebuilds some row types from the model's defaults plus whatever
+the patch sends, because those rows have no stable identity key. That makes an
+omission on a client destructive rather than inert: a field the Swift struct
+does not declare is not "left alone" on Save, it is **erased**.
+
+That is exactly how `RoutingPolicy.source` was lost -- silently widening a
+source-scoped routing policy to every caller, which is F-01
+(`docs/architecture/07-findings-register.md`) reintroduced through a client.
+It was found by an adversarial audit rather than by CI, twice. These tests are
+the CI answer: they parse the real Swift source and fail naming the missing
+field.
+
+Deliberately a projection test rather than a Swift unit test -- `swift test`
+does not run in CI (only `swift build`, inside the macos-14 menubar-lifecycle
+job), so an assertion that lives in Swift would not guard anything.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from netllm_core.models import BackendOverride, RoutingPolicy, SourceConfig
+
+from conformance.projections import REPO_ROOT
+
+SWIFT_DOC = "apps/netllm-mac/Sources/Config/NetllmConfigDocument.swift"
+
+# Fields a client legitimately does not carry, with the reason. Anything not
+# listed here must appear in the Swift struct -- "we forgot" is not a reason.
+INTENTIONALLY_ABSENT: dict[tuple[str, str], str] = {
+    ("BackendOverride", "api_key"): (
+        "write-only; the Swift app sends it through the Keychain path and "
+        "config_merge preserves the stored value when it is omitted"
+    ),
+    ("SourceConfig", "secret"): (
+        "write-only, same contract as BackendOverride.api_key -- "
+        "ConfigStore.blankSourceSecret relies on empty-preserves-stored"
+    ),
+}
+
+
+def _swift_struct_fields(struct_name: str) -> tuple[set[str], str]:
+    """Declared `var <name>` properties of a Swift struct, plus its location.
+
+    Computed properties (`var id: String { ... }`) are excluded -- they are
+    derived, not encoded, so they are not part of the wire shape.
+    """
+    path = REPO_ROOT / SWIFT_DOC
+    text = path.read_text(encoding="utf-8")
+    start = text.find(f"struct {struct_name}")
+    assert start != -1, f"{SWIFT_DOC}: struct {struct_name} not found"
+    depth = 0
+    end = start
+    for index in range(text.find("{", start), len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                end = index
+                break
+    body = text[start:end]
+    fields = {
+        match.group(1)
+        for match in re.finditer(r"^\s*var\s+([A-Za-z_][A-Za-z0-9_]*)\s*:", body, re.M)
+        if "{" not in body.split(match.group(0))[1].split("\n")[0]
+    }
+    line = text.count("\n", 0, start) + 1
+    return fields, f"{path.name}:{line}"
+
+
+# Row types WITHOUT an identity key. config_merge rebuilds these from the
+# model's defaults, so a field a client omits is ERASED, not preserved. These
+# are the destructive ones and the surface must carry every field.
+IDENTITYLESS = [(RoutingPolicy, "RoutingPolicy")]
+
+# Row types WITH an identity key (BackendOverride keys on base_url,
+# SourceConfig on id). config_merge seeds each row from the prior model dump,
+# so omission is non-destructive -- the field simply is not editable from that
+# surface, which is an Axis D parity question, not data loss. Asserted as
+# non-destructive rather than as present.
+IDENTITY_KEYED = [
+    (BackendOverride, "BackendOverride", "base_url"),
+]
+
+
+@pytest.mark.parametrize(
+    ("model", "struct_name"), IDENTITYLESS, ids=[n for _, n in IDENTITYLESS]
+)
+def test_identityless_swift_struct_carries_every_model_field(
+    model: type, struct_name: str
+) -> None:
+    try:
+        swift_fields, location = _swift_struct_fields(struct_name)
+    except AssertionError:
+        pytest.skip(f"{struct_name} has no Swift counterpart yet")
+
+    expected = set(model.model_fields)
+    excused = {
+        field
+        for (owner, field) in INTENTIONALLY_ABSENT
+        if owner == struct_name and field in expected
+    }
+    missing = expected - swift_fields - excused
+    assert not missing, (
+        f"{location}: Swift {struct_name} is missing {sorted(missing)}. "
+        f"This row has no identity key, so config_merge rebuilds it from "
+        f"defaults and an omitted field is ERASED on the next Save. Add it to "
+        f"the struct, or declare it in INTENTIONALLY_ABSENT with a reason."
+    )
+
+
+@pytest.mark.parametrize(
+    ("model", "struct_name", "key_field"),
+    IDENTITY_KEYED,
+    ids=[n for _, n, _ in IDENTITY_KEYED],
+)
+def test_identity_keyed_omission_is_non_destructive(
+    model: type, struct_name: str, key_field: str
+) -> None:
+    """What actually protects the fields a client does not carry.
+
+    Swift's BackendOverride omits `cloud_provider` and `max_concurrency` --
+    the very two fields F-01 was filed about. That is safe ONLY because these
+    rows merge onto the prior row. Pin the property rather than trusting it,
+    so a future change to the merge strategy fails here instead of silently
+    re-opening F-01.
+    """
+    from netllm_core.config_merge import apply_config_patch
+    from netllm_core.models import NetllmConfig
+
+    swift_fields, location = _swift_struct_fields(struct_name)
+    omitted = set(model.model_fields) - swift_fields
+    if not omitted:
+        pytest.skip(f"{struct_name} carries every field; nothing to protect")
+
+    cfg = NetllmConfig()
+    if struct_name == "BackendOverride":
+        stored = BackendOverride(
+            base_url="http://10.0.0.5:1234/v1",
+            cloud_provider="openai",
+            max_concurrency=7,
+        )
+        cfg.routing.backends = [stored]
+        section = "backends"
+    else:
+        stored = SourceConfig(id="cursor", max_concurrency=7)
+        cfg.routing.sources = [stored]
+        section = "sources"
+
+    before = stored.model_dump(mode="json")
+    patch_row = {k: v for k, v in before.items() if k in swift_fields}
+    assert key_field in patch_row, f"{location}: identity key not carried"
+    merged = apply_config_patch(cfg, {"routing": {section: [patch_row]}})
+    after = getattr(merged.routing, section)[0].model_dump(mode="json")
+
+    for field in sorted(omitted):
+        assert after[field] == before[field], (
+            f"{location}: Swift {struct_name} omits {field!r} and the merge "
+            f"DESTROYED it ({before[field]!r} -> {after[field]!r}). This row "
+            f"is supposed to merge onto the prior row via {key_field!r}."
+        )
+
+
+def test_the_excuse_list_only_excuses_real_fields() -> None:
+    """An excuse for a field that no longer exists is stale cover."""
+    owners = {
+        "RoutingPolicy": RoutingPolicy,
+        "BackendOverride": BackendOverride,
+        "SourceConfig": SourceConfig,
+    }
+    for (owner, field), reason in INTENTIONALLY_ABSENT.items():
+        assert owner in owners, f"unknown model in excuse list: {owner}"
+        assert field in owners[owner].model_fields, (
+            f"{owner}.{field} is excused but no longer exists -- delete the entry"
+        )
+        assert len(reason) > 30, f"{owner}.{field} needs a real reason, not a label"
+
+
+def test_routing_policy_source_survives_a_swift_shaped_save() -> None:
+    """The regression itself, end to end through the real merge path.
+
+    A Swift-shaped patch (only the fields that struct declares) must not erase
+    `source`. This is the assertion that would have caught the original F-01
+    and its reintroduction.
+    """
+    from netllm_core.config_merge import apply_config_patch
+    from netllm_core.models import NetllmConfig
+
+    cfg = NetllmConfig()
+    cfg.routing.policies = [
+        RoutingPolicy(name="cursor-only", model_prefix="gpt", source="cursor")
+    ]
+    swift_fields, _ = _swift_struct_fields("RoutingPolicy")
+    patch_row = {
+        key: value
+        for key, value in cfg.routing.policies[0].model_dump(mode="json").items()
+        if key in swift_fields
+    }
+    merged = apply_config_patch(cfg, {"routing": {"policies": [patch_row]}})
+    assert merged.routing.policies[0].source == "cursor", (
+        "a Save from the macOS app widened a source-scoped policy to every "
+        "caller -- the exact F-01 regression"
+    )
+
+
+def test_swift_carries_sources_as_an_untyped_passthrough() -> None:
+    """`routing.sources` has no Swift struct, and that is the safe choice.
+
+    NetllmConfigDocument declares `var sources: [JSONValue]`, so the app
+    round-trips whatever the agent sent it verbatim -- it cannot drop a field
+    it has never heard of, which is the same forward-compatibility property
+    `extra="allow"` gives the Python models. Pin it: replacing this with a
+    typed struct would silently re-introduce the drop, and the field roster
+    test above would not catch it because there would be no struct to compare.
+    """
+    path = REPO_ROOT / SWIFT_DOC
+    text = path.read_text(encoding="utf-8")
+    assert "var sources: [JSONValue]" in text, (
+        f"{path.name}: routing.sources is no longer an untyped pass-through. "
+        "If it is now a typed struct, add it to IDENTITYLESS or IDENTITY_KEYED "
+        "so its field roster is guarded."
+    )
+
+
+# --- ledger discipline ----------------------------------------------------
+
+PHASE_ORDER = [
+    "phase-0",
+    "phase-1",
+    "phase-2",
+    "phase-3",
+    "phase-4",
+    "phase-5a",
+    "phase-5b",
+    "phase-6",
+    "phase-7",
+    "phase-8",
+]
+
+
+def _ledger() -> dict:
+    import tomllib
+
+    path = REPO_ROOT / "tests/conformance/ledgers/mirrors.toml"
+    return tomllib.loads(path.read_text(encoding="utf-8"))
+
+
+def _entries():
+    for fact_class in _ledger()["fact_class"]:
+        for entry in fact_class.get("allowed_mirrors", []):
+            yield fact_class["id"], entry
+
+
+def test_every_ledger_entry_has_a_real_reason_and_expiry() -> None:
+    """`expires` was read by nothing.
+
+    check-registry-mirrors.py mentions it only in a docstring, so an entry
+    could carry any string -- or an expiry that had already passed -- and stay
+    green. An unenforced expiry is decoration, and the ledger's whole claim is
+    that a mirror is temporary and dated.
+    """
+    valid = set(PHASE_ORDER)
+    for class_id, entry in _entries():
+        where = f"{class_id}:{entry['glob']}"
+        reason = entry.get("reason", "")
+        assert len(reason) > 40, (
+            f"{where}: reason is too thin to justify a mirror: {reason!r}"
+        )
+        expires = entry.get("expires", "")
+        assert expires, f"{where}: no expiry"
+        assert expires in valid or expires.startswith("never"), (
+            f"{where}: expiry {expires!r} is neither a known phase {sorted(valid)} "
+            "nor an explicit 'never — <reason>'"
+        )
+
+
+def test_no_ledger_entry_is_overdue() -> None:
+    """An entry whose phase has already shipped must be closed, not carried."""
+    current = _ledger()["scan"]["current_phase"]
+    assert current in PHASE_ORDER, f"unknown current_phase {current!r}"
+    done_through = PHASE_ORDER.index(current)
+    overdue = [
+        f"{class_id}:{entry['glob']} (expires {entry['expires']})"
+        for class_id, entry in _entries()
+        if entry.get("expires", "") in PHASE_ORDER
+        and PHASE_ORDER.index(entry["expires"]) <= done_through
+    ]
+    assert not overdue, (
+        "these mirrors were due to be removed by the phase this tree has "
+        f"completed ({current}):\n  " + "\n  ".join(overdue) + "\n"
+        "Close them, or re-date them with the reason the phase did not."
+    )
+
+
+def test_the_ledger_tripwire_is_not_yet_tripped() -> None:
+    """PROGRAM.md: 5+ exceptions means the spec is wrong, not the ledger short.
+
+    Recorded as an executable limit rather than prose, per the program's own
+    ledger-discipline section.
+    """
+    per_class: dict[str, int] = {}
+    for class_id, _ in _entries():
+        per_class[class_id] = per_class.get(class_id, 0) + 1
+    for class_id, count in per_class.items():
+        assert count <= 6, (
+            f"{class_id} carries {count} mirror exceptions. Past ~5 the "
+            "registry shape is wrong -- redesign it rather than adding entries."
+        )

--- a/tests/conformance/kit_config_surfaces.py
+++ b/tests/conformance/kit_config_surfaces.py
@@ -275,10 +275,15 @@ def test_every_ledger_entry_has_a_real_reason_and_expiry() -> None:
         )
         expires = entry.get("expires", "")
         assert expires, f"{where}: no expiry"
-        assert expires in valid or expires.startswith("never"), (
-            f"{where}: expiry {expires!r} is neither a known phase {sorted(valid)} "
-            "nor an explicit 'never — <reason>'"
+        # A phase may carry a trailing " — why", which is strictly better than
+        # a bare phase; `never` must carry one.
+        head = expires.split("—")[0].split("--")[0].strip()
+        assert head in valid or head == "never", (
+            f"{where}: expiry {expires!r} is neither a known phase "
+            f"{sorted(valid)} nor an explicit 'never — <reason>'"
         )
+        if head == "never":
+            assert head != expires, f"{where}: 'never' must state why"
 
 
 def test_no_ledger_entry_is_overdue() -> None:
@@ -289,8 +294,9 @@ def test_no_ledger_entry_is_overdue() -> None:
     overdue = [
         f"{class_id}:{entry['glob']} (expires {entry['expires']})"
         for class_id, entry in _entries()
-        if entry.get("expires", "") in PHASE_ORDER
-        and PHASE_ORDER.index(entry["expires"]) <= done_through
+        if entry.get("expires", "").split("—")[0].split("--")[0].strip() in PHASE_ORDER
+        and PHASE_ORDER.index(entry["expires"].split("—")[0].split("--")[0].strip())
+        <= done_through
     ]
     assert not overdue, (
         "these mirrors were due to be removed by the phase this tree has "

--- a/tests/conformance/kit_config_surfaces.py
+++ b/tests/conformance/kit_config_surfaces.py
@@ -12,9 +12,12 @@ It was found by an adversarial audit rather than by CI, twice. These tests are
 the CI answer: they parse the real Swift source and fail naming the missing
 field.
 
-Deliberately a projection test rather than a Swift unit test -- `swift test`
-does not run in CI (only `swift build`, inside the macos-14 menubar-lifecycle
-job), so an assertion that lives in Swift would not guard anything.
+Deliberately a projection test rather than a Swift unit test. `swift test`
+now runs in CI (added to the macos-14 menubar-lifecycle job in the same
+change), but a Swift assertion could only compare the struct against a
+hardcoded field list -- another mirror. Parsing the struct from Python lets
+the assertion compare it against the pydantic model itself, which is the
+actual source of truth.
 """
 
 from __future__ import annotations

--- a/tests/conformance/kit_local.py
+++ b/tests/conformance/kit_local.py
@@ -1,0 +1,221 @@
+"""Axis B conformance kit: the contract every local provider must satisfy.
+
+Parameterized over `LOCAL_PROVIDERS`, so adding a provider acquires this
+whole suite with **zero test-file edits** — that is the point of the kit, and
+the reason the registry is worth having at all. Before it, `grep -rn
+KNOWN_PROVIDERS tests/` returned nothing: eleven parallel maps keyed on the
+same id and not one test that the roster was consistent.
+
+Note the deliberate asymmetry (PROGRAM.md §3 Axis B): label coverage
+parameterizes over `LOCAL_PROVIDERS | NON_DISCOVERABLE_LABELS` because
+`custom` is a labelled routing id with no ports and no probe, while
+everything port- or key-shaped parameterizes over `LOCAL_PROVIDERS` alone.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import get_args
+
+import pytest
+from netllm_core.local_providers import (
+    LOCAL_PROVIDERS,
+    NON_DISCOVERABLE_LABELS,
+    LocalProviderSpec,
+    api_key_env_for,
+    default_api_key_for,
+    get_local_provider_spec,
+    providers_for_platform,
+)
+from netllm_core.models import Backend, NetllmConfig
+from netllm_discovery.local import (
+    _api_key_for_provider,
+    candidate_urls_for_provider,
+)
+
+SPECS = list(LOCAL_PROVIDERS.values())
+IDS = [spec.id for spec in SPECS]
+
+
+@pytest.fixture(params=SPECS, ids=IDS)
+def spec(request: pytest.FixtureRequest) -> LocalProviderSpec:
+    return request.param
+
+
+# --- spec well-formedness -------------------------------------------------
+
+
+def test_spec_is_well_formed(spec: LocalProviderSpec) -> None:
+    assert spec.id and spec.id.islower()
+    assert spec.display_name and spec.short_label
+    assert spec.default_ports, "a discoverable provider needs at least one port"
+    assert all(0 < p < 65536 for p in spec.default_ports)
+    assert spec.platforms, "a provider enabled nowhere is unreachable"
+    assert spec.hint_port() in spec.default_ports
+
+
+def test_registry_key_matches_spec_id() -> None:
+    for key, value in LOCAL_PROVIDERS.items():
+        assert key == value.id, f"registry key {key!r} != spec id {value.id!r}"
+
+
+def test_provider_id_literal_matches_the_registry() -> None:
+    """`ProviderId` stays hand-written (a derived Literal blinds basedpyright),
+    so its agreement with the registry is asserted rather than assumed."""
+    from netllm_core.models import ProviderId
+
+    literal = set(get_args(ProviderId))
+    assert set(LOCAL_PROVIDERS) <= literal, (
+        f"ProviderId is missing {sorted(set(LOCAL_PROVIDERS) - literal)}"
+    )
+
+
+# --- candidate URLs -------------------------------------------------------
+
+
+def test_every_default_port_is_probed_on_both_hosts(spec: LocalProviderSpec) -> None:
+    urls = candidate_urls_for_provider(spec.id, NetllmConfig())
+    for port in spec.default_ports:
+        for host in ("127.0.0.1", "localhost"):
+            assert f"http://{host}:{port}/v1" in urls, (
+                f"{spec.id}: {host}:{port} is in the registry but never probed"
+            )
+
+
+def test_port_env_reaches_the_candidate_list(
+    spec: LocalProviderSpec, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if not spec.port_env:
+        pytest.skip(f"{spec.id} declares no port_env")
+    monkeypatch.setenv(spec.port_env, "9999")
+    urls = candidate_urls_for_provider(spec.id, NetllmConfig())
+    assert "http://127.0.0.1:9999/v1" in urls, (
+        f"{spec.id}: {spec.port_env} is declared but not honoured"
+    )
+
+
+def test_host_env_reaches_the_candidate_list(
+    spec: LocalProviderSpec, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    if not spec.host_env:
+        pytest.skip(f"{spec.id} declares no host_env")
+    monkeypatch.setenv(spec.host_env, "10.0.0.7:4321")
+    urls = candidate_urls_for_provider(spec.id, NetllmConfig())
+    assert "http://10.0.0.7:4321/v1" in urls
+    monkeypatch.setenv(spec.host_env, ":4321")
+    assert "http://127.0.0.1:4321/v1" in candidate_urls_for_provider(
+        spec.id, NetllmConfig()
+    )
+    monkeypatch.setenv(spec.host_env, "10.0.0.8")
+    assert f"http://10.0.0.8:{spec.default_host_port}/v1" in (
+        candidate_urls_for_provider(spec.id, NetllmConfig())
+    )
+
+
+def test_candidates_are_deduped_and_normalized(spec: LocalProviderSpec) -> None:
+    urls = candidate_urls_for_provider(spec.id, NetllmConfig())
+    assert len(urls) == len(set(urls))
+    assert all(u.endswith("/v1") for u in urls)
+
+
+# --- credentials: the two-copy drift this kit exists to kill --------------
+
+
+def test_api_key_env_resolves_through_both_paths(
+    spec: LocalProviderSpec, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The env var must work through discovery *and* through `Backend`.
+
+    These were two independent hand-written maps (`local.py` and
+    `models.py`), free to drift; a provider present in one and absent from
+    the other authenticated on one path and 401'd on the other.
+    """
+    if not spec.api_key_env:
+        pytest.skip(f"{spec.id} declares no api_key_env")
+    monkeypatch.setenv(spec.api_key_env, "sentinel-key")
+    assert _api_key_for_provider(spec.id, NetllmConfig()) == "sentinel-key"
+    backend = Backend(id=spec.id, base_url="http://127.0.0.1:1/v1", provider=spec.id)
+    assert backend.resolve_api_key() == "sentinel-key"
+
+
+def test_default_api_key_applies_on_both_paths(spec: LocalProviderSpec) -> None:
+    if not spec.default_api_key:
+        pytest.skip(f"{spec.id} has no built-in default key")
+    assert _api_key_for_provider(spec.id, NetllmConfig()) == spec.default_api_key
+    backend = Backend(id=spec.id, base_url="http://127.0.0.1:1/v1", provider=spec.id)
+    assert backend.resolve_api_key() == spec.default_api_key
+
+
+@pytest.mark.parametrize("unknown", ["custom", "peer:node-1", "definitely-not-real"])
+def test_non_registry_providers_get_no_env_hint(unknown: str) -> None:
+    """The dict-miss is load-bearing, not an oversight.
+
+    `netllm doctor` names an env var in its 401 fix hint only when one really
+    exists. Deriving the name as `PROVIDER.upper()_API_KEY` would tell an
+    operator to set `CUSTOM_API_KEY`, which nothing reads.
+    """
+    assert api_key_env_for(unknown) == ""
+    assert default_api_key_for(unknown) == ""
+    assert get_local_provider_spec(unknown) is None
+
+
+# --- platform gating ------------------------------------------------------
+
+
+def test_platform_membership_follows_the_spec(spec: LocalProviderSpec) -> None:
+    for platform in ("darwin", "linux", "win32"):
+        enabled = spec.id in providers_for_platform(platform)
+        assert enabled is (platform in spec.platforms), (
+            f"{spec.id} on {platform}: registry says "
+            f"{platform in spec.platforms}, resolver says {enabled}"
+        )
+
+
+def test_default_discovery_providers_matches_this_platform() -> None:
+    from netllm_core.platform import default_discovery_providers
+
+    assert default_discovery_providers() == providers_for_platform(sys.platform)
+
+
+# --- CLI-visible projections ---------------------------------------------
+
+
+def test_every_labelled_id_is_in_a_roster() -> None:
+    from netllm_cli.ui import _PROVIDER_LABELS
+
+    expected = set(LOCAL_PROVIDERS) | set(NON_DISCOVERABLE_LABELS)
+    assert set(_PROVIDER_LABELS) == expected
+
+
+def test_label_matches_the_spec(spec: LocalProviderSpec) -> None:
+    from netllm_cli.ui import _PROVIDER_LABELS
+
+    assert _PROVIDER_LABELS[spec.id] == spec.short_label
+
+
+def test_offline_hint_names_this_platforms_providers_and_ports() -> None:
+    from netllm_cli.ui import default_provider_port_hint
+
+    hint = default_provider_port_hint()
+    for spec_ in SPECS:
+        present = spec_.short_label in hint
+        assert present is (sys.platform in spec_.platforms), (
+            f"{spec_.id}: hint membership disagrees with platform gating"
+        )
+        if present:
+            assert f":{spec_.hint_port()}" in hint, (
+                f"{spec_.id}: hint quotes a port that is not the scanned one"
+            )
+
+
+def test_discovery_roster_is_derived_not_mirrored() -> None:
+    """`KNOWN_PROVIDERS` keeps its public shape but not its own copy."""
+    from netllm_discovery.local import DEFAULT_API_KEYS, KNOWN_PROVIDERS
+
+    assert [row[0] for row in KNOWN_PROVIDERS] == list(LOCAL_PROVIDERS)
+    for pid, name, ports in KNOWN_PROVIDERS:
+        assert name == LOCAL_PROVIDERS[pid].display_name
+        assert ports == list(LOCAL_PROVIDERS[pid].default_ports)
+    assert DEFAULT_API_KEYS == {
+        s.id: s.default_api_key for s in SPECS if s.default_api_key
+    }

--- a/tests/conformance/kit_local.py
+++ b/tests/conformance/kit_local.py
@@ -65,8 +65,16 @@ def test_provider_id_literal_matches_the_registry() -> None:
     from netllm_core.models import ProviderId
 
     literal = set(get_args(ProviderId))
-    assert set(LOCAL_PROVIDERS) <= literal, (
-        f"ProviderId is missing {sorted(set(LOCAL_PROVIDERS) - literal)}"
+    missing = set(LOCAL_PROVIDERS) - literal
+    assert not missing, f"ProviderId is missing {sorted(missing)}"
+    # Equality, not containment, over the discoverable half: ProviderId also
+    # carries routing-only ids (custom, anthropic, openai) that are not local
+    # servers, so the exact contract is "every extra is declared somewhere".
+    routing_only = literal - set(LOCAL_PROVIDERS)
+    declared = set(NON_DISCOVERABLE_LABELS) | {"anthropic", "openai"}
+    assert routing_only <= declared, (
+        f"ProviderId has undeclared ids {sorted(routing_only - declared)} -- "
+        "add them to the registry or to the declared routing-only set"
     )
 
 
@@ -219,3 +227,60 @@ def test_discovery_roster_is_derived_not_mirrored() -> None:
     assert DEFAULT_API_KEYS == {
         s.id: s.default_api_key for s in SPECS if s.default_api_key
     }
+
+
+# --- regressions caught by the Phase 1+3 validation swarm -----------------
+
+
+def test_offline_hint_does_not_repeat_a_port(spec: LocalProviderSpec) -> None:
+    """Every port is probed on BOTH 127.0.0.1 and localhost.
+
+    A naive slice of `probed_urls` therefore rendered
+    "(scanned ports: 1234, 1234, 41334, 41334)" to the operator. This was
+    shipped and had zero coverage -- the whole hint function did, which is why
+    the rewrite was invisible.
+    """
+    from netllm_cli.ui import offline_provider_hints
+
+    if sys.platform not in spec.platforms or len(spec.default_ports) <= 1:
+        pytest.skip(f"{spec.id} renders no port list on this platform")
+    probed = [
+        f"http://{host}:{port}/v1"
+        for port in spec.default_ports
+        for host in ("127.0.0.1", "localhost")
+    ]
+    hints = offline_provider_hints(
+        [{"id": spec.id, "status": "offline", "probed_urls": probed}]
+    )
+    assert hints, f"{spec.id}: offline provider produced no hint at all"
+    listed = hints[0].split("scanned ports: ")[-1].rstrip(")").split(", ")
+    assert listed == list(dict.fromkeys(listed)), (
+        f"{spec.id}: duplicate ports in operator output: {hints[0]}"
+    )
+
+
+def test_offline_hint_falls_back_to_registry_ports(spec: LocalProviderSpec) -> None:
+    """With no probe record, the hint still quotes the real scan ports."""
+    from netllm_cli.ui import offline_provider_hints
+
+    if sys.platform not in spec.platforms or len(spec.default_ports) <= 1:
+        pytest.skip(f"{spec.id} renders no port list on this platform")
+    hints = offline_provider_hints([{"id": spec.id, "status": "offline"}])
+    for port in spec.default_ports:
+        assert str(port) in hints[0]
+
+
+def test_an_unknown_platform_still_gets_cross_platform_providers() -> None:
+    """The allowlist must not strand an unenumerated platform.
+
+    The behaviour this replaced was "everything except oMLX unless darwin" --
+    an else-branch covering freebsd, aix, cygwin and anything else. A bare
+    allowlist silently returns [], turning "works, minus oMLX" into
+    "discovers nothing", with no error to explain why.
+    """
+    for exotic in ("freebsd14", "aix", "cygwin", "sunos5"):
+        got = providers_for_platform(exotic)
+        assert got, f"{exotic} was stranded with no default providers"
+        assert "omlx" not in got, (
+            f"{exotic} was offered oMLX, which is Apple-Silicon only"
+        )

--- a/tests/conformance/kit_local.py
+++ b/tests/conformance/kit_local.py
@@ -284,3 +284,102 @@ def test_an_unknown_platform_still_gets_cross_platform_providers() -> None:
         assert "omlx" not in got, (
             f"{exotic} was offered oMLX, which is Apple-Silicon only"
         )
+
+
+# --- client projections (PROGRAM.md Axis B: "all five client/doc") --------
+
+
+def _swift_bootstrap() -> dict[str, tuple[str, int]]:
+    """Parse SettingsViewModel.localProviderBootstrap into {id: (label, port)}."""
+    import re
+
+    from conformance.projections import REPO_ROOT
+
+    path = REPO_ROOT / "apps/netllm-mac/Sources/AppView/SettingsViewModel.swift"
+    text = path.read_text(encoding="utf-8")
+    start = text.find("static let localProviderBootstrap")
+    assert start != -1, f"{path.name}: localProviderBootstrap not found"
+    # Skip the type annotation's own brackets: the declaration reads
+    # `... : [(id: String, ...)] = [` and a naive find("]") stops inside it.
+    open_at = text.find("= [", start)
+    assert open_at != -1, f"{path.name}: localProviderBootstrap has no literal"
+    body = text[open_at : text.find("\n    ]", open_at)]
+    out: dict[str, tuple[str, int]] = {}
+    for pid, label, port in re.findall(
+        r'id:\s*"([^"]+)",\s*label:\s*"([^"]+)",\s*port:\s*(\d+)', body
+    ):
+        out[pid] = (label, int(port))
+    return out
+
+
+def test_swift_bootstrap_matches_the_registry(spec: LocalProviderSpec) -> None:
+    """The macOS prefill must agree with what discovery actually scans.
+
+    It did not: the prefill URL came from a ternary that gave every provider
+    except oMLX and Ollama port 1234, so vLLM was offered LM Studio's port --
+    a user accepting the default configured a URL nothing serves. Labels came
+    from `.capitalized`, rendering "Omlx", "Lmstudio", "Vllm".
+    """
+    bootstrap = _swift_bootstrap()
+    assert spec.id in bootstrap, (
+        f"SettingsViewModel.localProviderBootstrap is missing {spec.id!r}"
+    )
+    label, port = bootstrap[spec.id]
+    assert label == spec.short_label, (
+        f"{spec.id}: Swift label {label!r} != registry {spec.short_label!r}"
+    )
+    assert port in spec.default_ports, (
+        f"{spec.id}: Swift prefills port {port}, which discovery never scans "
+        f"(registry ports: {list(spec.default_ports)})"
+    )
+
+
+def test_swift_bootstrap_has_no_extra_providers() -> None:
+    assert set(_swift_bootstrap()) == set(LOCAL_PROVIDERS)
+
+
+def test_the_agent_serves_the_registry_to_its_clients() -> None:
+    """The route whose absence forced every client to hand-mirror the roster.
+
+    The cloud tab could derive itself from GET /netllm/v1/cloud/providers; the
+    discovery tab had no equivalent, which is why dashboard.js and three Swift
+    files each kept their own copy -- and why those copies drifted.
+    """
+    from netllm_agent.admin import local_provider_registry_payload
+
+    rows = {row["id"]: row for row in local_provider_registry_payload()}
+    assert set(rows) == set(LOCAL_PROVIDERS)
+    for pid, spec_ in LOCAL_PROVIDERS.items():
+        assert rows[pid]["display_name"] == spec_.display_name
+        assert rows[pid]["default_ports"] == list(spec_.default_ports)
+        assert rows[pid]["platforms"] == list(spec_.platforms)
+        assert rows[pid]["api_key_env"] == spec_.api_key_env
+
+
+def test_the_local_provider_route_is_registered() -> None:
+    import json
+
+    from conformance.projections import REPO_ROOT
+
+    manifest = json.loads(
+        (REPO_ROOT / "tests/contract/routes.json").read_text(encoding="utf-8")
+    )
+    paths = {row["path"] for row in manifest["routes"]}
+    assert "/netllm/v1/local-providers" in paths
+
+
+def test_dashboard_bootstrap_matches_the_registry() -> None:
+    """The dashboard's degraded-mode roster must still list every provider.
+
+    It now fetches GET /netllm/v1/local-providers, but the bootstrap is what
+    renders before that returns or when the agent is unreachable -- so a
+    provider missing here is simply absent from the discovery checkboxes,
+    silently, exactly the class this program exists to make loud.
+    """
+    from conformance.projections import string_array_after
+
+    found = string_array_after(
+        "packages/netllm-agent/src/netllm_agent/static/dashboard.js",
+        "const PROVIDERS_BOOTSTRAP",
+    )
+    found.assert_exactly(set(LOCAL_PROVIDERS))

--- a/tests/conformance/ledgers/mirrors.toml
+++ b/tests/conformance/ledgers/mirrors.toml
@@ -65,9 +65,11 @@ expires = "phase-4"
 
 [[fact_class]]
 id = "local-provider-id"
-source = "packages/netllm-discovery/src/netllm_discovery/local.py"
-# Ids are the first element of each KNOWN_PROVIDERS tuple.
-extract = "tuple-heads:KNOWN_PROVIDERS"
+# Phase 3 moved the source of truth: `local.py`'s KNOWN_PROVIDERS is now a
+# comprehension over this registry, not a literal, so it can no longer be the
+# thing the checker reads. Eleven parallel maps collapsed into this one.
+source = "packages/netllm-core/src/netllm_core/local_providers.py"
+extract = "dict-keys:LOCAL_PROVIDERS"
 
 [[fact_class.allowed_mirrors]]
 glob = "packages/netllm-agent/src/netllm_agent/static/dashboard.js"
@@ -85,28 +87,19 @@ reason = "discovery.providers example plus provider_urls stanzas"
 expires = "phase-3"
 
 [[fact_class.allowed_mirrors]]
-glob = "packages/netllm-cli/src/netllm_cli/ui.py"
-reason = "PROVIDER_LABELS / offline hints; LocalProviderSpec absorbs both"
-expires = "phase-3"
-
-[[fact_class.allowed_mirrors]]
-glob = "packages/netllm-core/src/netllm_core/platform.py"
-reason = "default_discovery_providers per-platform lists; spec.platforms absorbs"
-expires = "phase-3"
-
-[[fact_class.allowed_mirrors]]
 glob = "packages/netllm-core/src/netllm_core/models.py"
 reason = """ProviderId Literal (stays hand-written, asserted by get_args \
 equality), plus the id -> *_API_KEY env map in Backend.resolve_api_key -- \
-one of the three copies of that map, all absorbed by LocalProviderSpec"""
-expires = "phase-3"
+the ProviderId Literal is the ONLY hand-written local-provider fact left \
+after Phase 3 -- a derived Literal blinds basedpyright, so it is asserted by \
+kit_local's get_args equality instead"""
+expires = "never — see reason"
 
 [[fact_class.allowed_mirrors]]
-glob = "packages/netllm-agent/src/netllm_agent/admin.py"
-reason = """doctor's 401/403 env-var hint map -- the third copy of the same \
-id -> *_API_KEY fact (local.py:163 and models.py:596 are the others). Every \
-entry is mechanically PROVIDER.upper()_API_KEY, but it is NOT derivable by \
-that rule alone: the .get(..., "") miss is load-bearing, since a `custom` or \
-`peer:*` backend must produce no hint rather than a CUSTOM_API_KEY that \
-nothing reads. Needs spec membership, i.e. Axis B"""
-expires = "phase-3"
+glob = "packages/netllm-discovery/src/netllm_discovery/local.py"
+reason = """oMLX's admin/telemetry probes (probe_omlx_admin and friends) test \
+`provider != "omlx"`. This is NOT a roster mirror: oMLX exposes a proprietary \
+admin API no other local server has, so the literal marks a genuine \
+capability, not a copy of the id list. Absorbed when LocalProviderSpec gains \
+its optional probe hook"""
+expires = "phase-4"

--- a/tests/conformance/ledgers/mirrors.toml
+++ b/tests/conformance/ledgers/mirrors.toml
@@ -18,6 +18,12 @@
 # The phase this tree has completed. Any entry whose `expires` names this
 # phase or an earlier one is overdue and fails the ledger test -- otherwise an
 # expiry is decoration. (PROGRAM.md §5 phase order: 0,1,2,3,4,5a,5b,6,7,8.)
+# Phase 4 is HALF done and this stays at phase-3 until it is not. The local
+# half landed (GET /netllm/v1/local-providers, both UIs derive from it). The
+# cloud half -- generate-registry-artifacts.py --check, deleting
+# KeychainStore's switch cases, generating the 5 doc rosters and the
+# config.example.toml stanzas -- has not. Setting this to "phase-4" lists
+# exactly the seven mirrors that remain, which is the honest to-do list.
 current_phase = "phase-3"
 files = [
   "packages/netllm-agent/src/netllm_agent/static/dashboard.js",
@@ -77,18 +83,21 @@ extract = "dict-keys:LOCAL_PROVIDERS"
 
 [[fact_class.allowed_mirrors]]
 glob = "packages/netllm-agent/src/netllm_agent/static/dashboard.js"
-reason = """discovery provider checkbox roster. NOT closed by phase 3: that \
-phase consolidated the Python side, and there is no local-provider registry \
-route in routes.json for a client to fetch (contrast the cloud side, which \
-derives from GET /netllm/v1/cloud/providers). Phase 4 adds the route"""
-expires = "phase-4"
+reason = """PROVIDERS_BOOTSTRAP: the degraded-mode roster rendered before \
+GET /netllm/v1/local-providers returns, or when the agent is unreachable. \
+No longer the source of truth (the fetch replaces it at boot) and pinned to \
+the registry by kit_local. Kept because an offline dashboard still has to \
+draw the discovery checkboxes"""
+expires = "never — offline fallback, projection-tested"
 
 [[fact_class.allowed_mirrors]]
 glob = "apps/netllm-mac/Sources/AppView/SettingsViewModel.swift"
-reason = """SettingsViewModel.providers checkbox roster, plus a second copy \
-in AppConfig.swift and inline default ports in SettingsWindowView. Same \
-blocker as dashboard.js: no local-provider route exists to derive from"""
-expires = "phase-4"
+reason = """localProviderBootstrap (labels + first scan port) and the \
+`providers` roster, both pinned to the registry by kit_local. This is the \
+copy that had already drifted: vLLM was prefilled on LM Studio's port and \
+labels came from .capitalized. Retained as the offline fallback, same \
+contract as the cloud bootstrap next to it"""
+expires = "never — offline fallback, projection-tested"
 
 [[fact_class.allowed_mirrors]]
 glob = "config.example.toml"

--- a/tests/conformance/ledgers/mirrors.toml
+++ b/tests/conformance/ledgers/mirrors.toml
@@ -24,7 +24,7 @@
 # KeychainStore's switch cases, generating the 5 doc rosters and the
 # config.example.toml stanzas -- has not. Setting this to "phase-4" lists
 # exactly the seven mirrors that remain, which is the honest to-do list.
-current_phase = "phase-3"
+current_phase = "phase-4"
 files = [
   "packages/netllm-agent/src/netllm_agent/static/dashboard.js",
   "apps/netllm-mac/Sources/AppView/SettingsViewModel.swift",
@@ -47,31 +47,40 @@ extract = "dict-keys:CLOUD_PROVIDERS"
 
 [[fact_class.allowed_mirrors]]
 glob = "packages/netllm-agent/src/netllm_agent/static/dashboard.js"
-reason = "cloud provider bootstrap list; becomes generated between markers"
-expires = "phase-4"
+reason = """cloud + local bootstrap lists, now GENERATED between markers by \
+scripts/generate-registry-artifacts.py with --check in lint. They stay real \
+literals so the dashboard renders offline, but they cannot drift"""
+expires = "never — generated with --check"
 
 [[fact_class.allowed_mirrors]]
 glob = "apps/netllm-mac/Sources/AppView/SettingsViewModel.swift"
-reason = "cloudProvidersBootstrap offline fallback; becomes generated"
-expires = "phase-4"
+reason = """cloudProvidersBootstrap: the Settings offline roster. Carries \
+display name, notes, regions and auth modes, not just ids, so it is \
+projection-tested against the registry by kit_cloud rather than generated -- \
+generating prose would be worse than checking it"""
+expires = "never — offline fallback, projection-tested"
 
 [[fact_class.allowed_mirrors]]
 glob = "apps/netllm-mac/Sources/Config/KeychainStore.swift"
-reason = """accountForCloudProvider switch + bootstrapProviderIDs; the switch \
-cases go away in Axis A (the generic arm is already correct), the id list \
-becomes the generated degraded-mode fallback"""
-expires = "phase-4"
+reason = """bootstrapProviderIDs, now GENERATED between markers with --check \
+in lint. The accountForCloudProvider switch is gone: all six cases returned \
+exactly what the default arm computes"""
+expires = "never — generated with --check"
 
 [[fact_class.allowed_mirrors]]
 glob = "config.example.toml"
-reason = "[cloud.providers.*] example stanzas; become generated"
-expires = "phase-4"
+reason = """discovery.providers is generated between markers with --check. \
+The [cloud.providers.*] example stanzas are still hand-written prose with \
+per-provider commentary, which is documentation rather than a roster copy"""
+expires = "phase-8 — stanzas fold into the worked example"
 
 [[fact_class.allowed_mirrors]]
 glob = "packages/netllm-core/src/netllm_core/models.py"
 reason = """CloudProviderId re-export plus the openai/anthropic api_format \
-Literal, which collides with two provider ids by coincidence of naming"""
-expires = "phase-4"
+Literal, which collides with two provider ids by coincidence of naming. Same \
+rationale as ProviderId: a derived Literal blinds basedpyright, so it stays \
+hand-written and is asserted by get_args equality in kit_cloud"""
+expires = "never — hand-written Literal, get_args-asserted"
 
 [[fact_class]]
 id = "local-provider-id"
@@ -101,8 +110,10 @@ expires = "never — offline fallback, projection-tested"
 
 [[fact_class.allowed_mirrors]]
 glob = "config.example.toml"
-reason = "discovery.providers example plus provider_urls stanzas; generated in phase 4"
-expires = "phase-4"
+reason = """discovery.providers is GENERATED between markers with --check in \
+lint; the provider_urls stanzas below it stay hand-written, being example \
+URLs with commentary rather than a roster"""
+expires = "never — generated with --check"
 
 [[fact_class.allowed_mirrors]]
 glob = "packages/netllm-core/src/netllm_core/models.py"
@@ -115,9 +126,9 @@ expires = "never — see reason"
 
 [[fact_class.allowed_mirrors]]
 glob = "packages/netllm-discovery/src/netllm_discovery/local.py"
-reason = """oMLX's admin/telemetry probes (probe_omlx_admin and friends) test \
-`provider != "omlx"`. This is NOT a roster mirror: oMLX exposes a proprietary \
-admin API no other local server has, so the literal marks a genuine \
-capability, not a copy of the id list. Absorbed when LocalProviderSpec gains \
-its optional probe hook"""
-expires = "phase-4"
+reason = """oMLX's admin/telemetry probes test `provider != "omlx"`. NOT a \
+roster mirror: oMLX exposes a proprietary admin API no other local server \
+has, so the literal marks a genuine capability. kit_cloud pins that it stays \
+the ONLY provider-specific branch in discovery -- a second one means the \
+capability belongs on the spec instead"""
+expires = "never — provider capability, single-branch-asserted"

--- a/tests/conformance/ledgers/mirrors.toml
+++ b/tests/conformance/ledgers/mirrors.toml
@@ -15,6 +15,10 @@
 # detector, not the refactor. Doc rosters join in Phase 3 when they become
 # generated; surface-name fact classes join in Phase 5a.
 [scan]
+# The phase this tree has completed. Any entry whose `expires` names this
+# phase or an earlier one is overdue and fails the ledger test -- otherwise an
+# expiry is decoration. (PROGRAM.md §5 phase order: 0,1,2,3,4,5a,5b,6,7,8.)
+current_phase = "phase-3"
 files = [
   "packages/netllm-agent/src/netllm_agent/static/dashboard.js",
   "apps/netllm-mac/Sources/AppView/SettingsViewModel.swift",
@@ -73,18 +77,23 @@ extract = "dict-keys:LOCAL_PROVIDERS"
 
 [[fact_class.allowed_mirrors]]
 glob = "packages/netllm-agent/src/netllm_agent/static/dashboard.js"
-reason = "discovery provider checkbox roster"
-expires = "phase-3"
+reason = """discovery provider checkbox roster. NOT closed by phase 3: that \
+phase consolidated the Python side, and there is no local-provider registry \
+route in routes.json for a client to fetch (contrast the cloud side, which \
+derives from GET /netllm/v1/cloud/providers). Phase 4 adds the route"""
+expires = "phase-4"
 
 [[fact_class.allowed_mirrors]]
 glob = "apps/netllm-mac/Sources/AppView/SettingsViewModel.swift"
-reason = "SettingsViewModel.providers checkbox roster"
-expires = "phase-3"
+reason = """SettingsViewModel.providers checkbox roster, plus a second copy \
+in AppConfig.swift and inline default ports in SettingsWindowView. Same \
+blocker as dashboard.js: no local-provider route exists to derive from"""
+expires = "phase-4"
 
 [[fact_class.allowed_mirrors]]
 glob = "config.example.toml"
-reason = "discovery.providers example plus provider_urls stanzas"
-expires = "phase-3"
+reason = "discovery.providers example plus provider_urls stanzas; generated in phase 4"
+expires = "phase-4"
 
 [[fact_class.allowed_mirrors]]
 glob = "packages/netllm-core/src/netllm_core/models.py"

--- a/tests/conformance/projections.py
+++ b/tests/conformance/projections.py
@@ -1,0 +1,131 @@
+"""Read a fact back out of a non-Python surface, with its source location.
+
+A *projection* is a place a registry fact has to appear that cannot import
+the registry: Swift, JavaScript, TOML examples, Markdown roster tables.
+Phases 3-4 make several of these generated; until then they are
+projection-tested, which is the middle rung of PROGRAM.md §1's ladder
+(derive > generate with --check > projection-test > mirror, which fails).
+
+Every helper returns `(values, source_location)` so a kit failure reads
+
+    SettingsViewModel.swift:94 is missing 'dashscope'
+
+rather than "assert set1 == set2". The location is what makes a red test
+actionable by someone who has never seen the file.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class Projection:
+    """Values found in a non-Python surface, plus where they came from."""
+
+    values: tuple[str, ...]
+    location: str
+
+    def missing(self, expected: set[str]) -> set[str]:
+        return expected - set(self.values)
+
+    def unexpected(self, expected: set[str]) -> set[str]:
+        return set(self.values) - expected
+
+    def assert_covers(self, expected: set[str]) -> None:
+        missing = self.missing(expected)
+        assert not missing, f"{self.location} is missing {sorted(missing)}"
+
+    def assert_exactly(self, expected: set[str]) -> None:
+        self.assert_covers(expected)
+        extra = self.unexpected(expected)
+        assert not extra, f"{self.location} has unexpected {sorted(extra)}"
+
+
+def _read(rel_path: str) -> tuple[str, Path]:
+    path = REPO_ROOT / rel_path
+    assert path.is_file(), f"projection source missing: {rel_path}"
+    return path.read_text(encoding="utf-8"), path
+
+
+def _line_of(text: str, index: int) -> int:
+    return text.count("\n", 0, index) + 1
+
+
+def string_array_after(rel_path: str, marker: str) -> Projection:
+    """Quoted strings in the first `[...]` literal following `marker`.
+
+    Covers the Swift `static let xs = [ "a", "b" ]` and JS `const xs = [...]`
+    shapes uniformly -- both are quoted, comma-separated, bracket-delimited.
+    """
+    text, path = _read(rel_path)
+    start = text.find(marker)
+    assert start != -1, f"{rel_path}: marker not found: {marker!r}"
+    open_at = text.find("[", start)
+    assert open_at != -1, f"{rel_path}: no '[' after marker {marker!r}"
+    close_at = text.find("]", open_at)
+    assert close_at != -1, f"{rel_path}: unterminated '[' after {marker!r}"
+    inner = text[open_at + 1 : close_at]
+    values = tuple(re.findall(r"""["']([^"']+)["']""", inner))
+    return Projection(values, f"{path.name}:{_line_of(text, open_at)}")
+
+
+def switch_case_labels(rel_path: str, marker: str) -> Projection:
+    """String labels of the `case "x":` arms in the switch following `marker`.
+
+    Swift `switch` over provider ids. The `default:` arm is not a value and is
+    excluded -- it is usually the generic behaviour the cases are redundant
+    with, which is why Axis A deletes them.
+    """
+    text, path = _read(rel_path)
+    start = text.find(marker)
+    assert start != -1, f"{rel_path}: marker not found: {marker!r}"
+    end = text.find("\n    }", start)
+    body = text[start : end if end != -1 else len(text)]
+    values = tuple(re.findall(r'case\s+"([^"]+)"', body))
+    return Projection(values, f"{path.name}:{_line_of(text, start)}")
+
+
+def toml_table_ids(rel_path: str, prefix: str) -> Projection:
+    """Ids from `[prefix.<id>]` headers, e.g. `[cloud.providers.openai]`."""
+    text, path = _read(rel_path)
+    pattern = re.compile(
+        r"^\s*\[+" + re.escape(prefix) + r"\.([A-Za-z0-9_-]+)\]+", re.MULTILINE
+    )
+    match = pattern.search(text)
+    line = _line_of(text, match.start()) if match else 1
+    return Projection(tuple(pattern.findall(text)), f"{path.name}:{line}")
+
+
+def markdown_table_column(rel_path: str, heading: str, column: int = 0) -> Projection:
+    """Cells from one column of the first Markdown table after `heading`.
+
+    Backticks and bold markers are stripped, so `` `omlx` `` reads as `omlx`.
+    Axis A's five doc rosters need this; Phase 4 generates them instead.
+    """
+    text, path = _read(rel_path)
+    start = text.find(heading)
+    assert start != -1, f"{rel_path}: heading not found: {heading!r}"
+    values: list[str] = []
+    first_row = 0
+    for raw in text[start:].splitlines()[1:]:
+        line = raw.strip()
+        if not line.startswith("|"):
+            if values:
+                break
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if not cells or set(cells[0]) <= set("-: "):
+            continue
+        if column >= len(cells):
+            continue
+        cell = cells[column].strip("`* ")
+        if cell and cell.lower() not in ("id", "provider", "name"):
+            if not first_row:
+                first_row = _line_of(text, start)
+            values.append(cell)
+    return Projection(tuple(values), f"{path.name}:{first_row or 1}")

--- a/tests/contract/routes.json
+++ b/tests/contract/routes.json
@@ -98,6 +98,12 @@
       ]
     },
     {
+      "path": "/netllm/v1/local-providers",
+      "methods": [
+        "GET"
+      ]
+    },
+    {
       "path": "/netllm/v1/logs",
       "methods": [
         "GET"

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -230,6 +230,13 @@ def test_swift_cloud_bootstrap_roster_matches_registry() -> None:
     _, _, rest = text.partition(marker)
     assert rest, f"{marker} not found — did the roster move?"
     inner, _, _ = rest.partition("]")
+    # Skip the generation markers: the roster is now written between
+    # `netllm:generated:begin/end` comments by
+    # scripts/generate-registry-artifacts.py, so a naive split picks the
+    # comment lines up as ids.
+    inner = "\n".join(
+        line for line in inner.splitlines() if "netllm:generated:" not in line
+    )
     swift_ids = [part.strip().strip('"') for part in inner.split(",") if part.strip()]
     assert set(swift_ids) == set(CLOUD_PROVIDERS)
 

--- a/tests/test_dashboard_ui_wiring.py
+++ b/tests/test_dashboard_ui_wiring.py
@@ -1,0 +1,87 @@
+"""Dashboard controls the UI audit found DEAD, BROKEN or MISSING.
+
+Each test below corresponds to a defect confirmed by execution during the
+2026-08-09 UI surface audit (149 Swift controls, 99 web controls inventoried).
+They are cheap presence/parity checks rather than browser tests, because the
+failure mode in every case was a control rendering against data the server
+never sent -- which a served-content assertion catches.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from netllm_core.models import NetllmConfig, UiConfig
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STATIC = REPO_ROOT / "packages/netllm-agent/src/netllm_agent/static"
+
+
+def test_config_summary_exports_every_ui_field() -> None:
+    """The dashboard renders the `ui` section straight from the schema.
+
+    `config_summary` exported three of ten fields, so seven controls rendered
+    against `undefined`: the six menubar_* toggles showed CHECKED against a
+    stored False, and the model_favorites editor POSTed `[]` -- which, because
+    lists are full-replace, wiped favourites set from the macOS app.
+    """
+    from netllm_agent.admin import config_summary
+
+    cfg = NetllmConfig()
+    exported = set(config_summary(cfg)["ui"])
+    missing = set(UiConfig.model_fields) - exported
+    assert not missing, (
+        f"config_summary omits {sorted(missing)} — the dashboard renders those "
+        "controls against undefined and can destroy their stored values on save"
+    )
+
+
+def test_model_favorites_survives_a_dashboard_round_trip() -> None:
+    """Read the exported value, send it back, keep the favourites."""
+    from netllm_agent.admin import config_summary
+    from netllm_core.config_merge import apply_config_patch
+
+    cfg = NetllmConfig()
+    cfg.ui.model_favorites = ["qwen3-coder", "gpt-oss-120b"]
+    echoed = config_summary(cfg)["ui"]
+    merged = apply_config_patch(cfg, {"ui": dict(echoed)})
+    assert merged.ui.model_favorites == ["qwen3-coder", "gpt-oss-120b"]
+
+
+def test_drain_has_a_control_on_the_dashboard() -> None:
+    """POST /netllm/v1/admin/drain shipped with no UI on either surface.
+
+    The only dashboard path to take an agent out of rotation was stopping it,
+    which kills in-flight requests — the exact thing drain exists to avoid.
+    """
+    html = (STATIC / "index.html").read_text(encoding="utf-8")
+    js = (STATIC / "dashboard.js").read_text(encoding="utf-8")
+    assert 'id="btn-drain"' in html, "no drain control in the dashboard"
+    assert "btn-drain" in js, "drain control is not bound to a handler"
+    assert "/netllm/v1/admin/drain" in js, "drain handler calls no endpoint"
+
+
+def test_status_json_link_points_at_the_status_endpoint() -> None:
+    """The link read href="/" which 307s back to /ui/ for an HTML Accept —
+    so "Status JSON" reloaded the dashboard instead of showing JSON."""
+    html = (STATIC / "index.html").read_text(encoding="utf-8")
+    marker = 'id="btn-status-json"'
+    line = next(x for x in html.splitlines() if marker in x)
+    assert 'href="/netllm/v1/status"' in line, (
+        f"Status JSON link is wrong: {line.strip()}"
+    )
+
+
+def test_every_html_id_the_js_binds_exists() -> None:
+    """Both directions are silent failures: getElementById on a missing id
+    returns null, and an unbound id is simply dead."""
+    import re
+
+    html = (STATIC / "index.html").read_text(encoding="utf-8")
+    js = (STATIC / "dashboard.js").read_text(encoding="utf-8")
+    html_ids = set(re.findall(r'id="([^"]+)"', html))
+    bound = set(re.findall(r'getElementById\("([^"]+)"\)', js))
+    missing = bound - html_ids
+    assert not missing, (
+        f"dashboard.js binds ids absent from index.html: {sorted(missing)}"
+    )


### PR DESCRIPTION
## Summary

Phases 1 and 3 of the extensibility program, the local half of Phase 4, and every defect that an adversarial validation swarm and a UI surface audit confirmed along the way. Suite **1145 → 1211**, lint exit 0.

The theme: Axis B was measured as the worst extension axis — eleven parallel maps keyed on the same provider id, and `grep -rn KNOWN_PROVIDERS tests/` returned nothing. Collapsing them into one registry was the easy part. What the registry made possible was *asking whether the clients agreed with it* — and they did not.

## Phase 1 + 3 — one registry, and a kit that makes omission loud

`netllm_core.local_providers.LocalProviderSpec` now holds every local-provider fact. It lives in **core**, not discovery, because `models.py`, `ui.py` and `platform.py` all need it and discovery already depends on core.

Eleven maps now derive from it, including three separate copies of the `id -> *_API_KEY` map (`local.py`, `models.py`, `admin.py`) and the `if provider_id == "ollama"` special case, which became a generic `host_env` field.

`tests/conformance/kit_local.py` parameterizes over the registry, so a new provider acquires its suite with no test edits. Demonstrated rather than asserted: adding a fifth provider leaves labels, ports, platform gating, offline hints and the discovery roster **all correct automatically**, and fails on the one fact deliberately left hand-written (`ProviderId`, because a derived `Literal` blinds basedpyright).

Two asymmetries are declared rather than left to be rediscovered as bugs: `custom` is a labelled routing id with no ports or key, so labels parameterize over a wider set than ports do; and `api_key_env` is declared per-spec rather than derived as `PROVIDER.upper()_API_KEY`, because the lookup **miss** is load-bearing — `custom` and `peer:*` must produce no hint rather than a `CUSTOM_API_KEY` nothing reads.

## What the validation swarm found in my own work

Five refutation lenses attacked the Phase 1+3 commit. Two returned FAIL, correctly:

- **A shipped regression with zero coverage.** The rewritten `offline_provider_hints` rendered `(scanned ports: 1234, 1234, 41334, 41334)` — every port is probed on both `127.0.0.1` and `localhost`. The whole function had no test, which is why a full rewrite of it was invisible.
- **A behaviour regression.** `providers_for_platform` turned a "not darwin" else-branch into an allowlist, so any platform outside `{darwin, linux, win32}` silently went from three default providers to **zero**.
- **Over-claims.** The commit said adding a provider fails on "exactly one hand-written fact". It fails four. `projections.py` had zero callers, so it guarded nothing. Both corrected, in the commit history and in `docs/extending/`.

## F-01, reintroduced through the Swift surface

`RoutingPolicy.source` was erased by **every Save from the macOS app**. The Swift struct carried 7 of 8 fields; policies have no identity key, so `config_merge` rebuilds each row from defaults — an omitted field is not left alone, it is **destroyed**. The effect is a source-scoped routing policy silently widening to every caller.

`tests/conformance/kit_config_surfaces.py` parses the real Swift source and fails naming the field.

Writing that guard corrected my own model of the bug: the first version also failed `BackendOverride` for omitting `cloud_provider` and `max_concurrency`, F-01's original two fields — but that is **safe**, because backends key on `base_url` and merge onto the prior row. The contract is now split by identity-key semantics: identity-less rows must carry every field; identity-keyed rows are asserted **non-destructive** instead.

## Phase 4 (local half) — the missing route was the root cause

`GET /netllm/v1/local-providers`, the twin of `/netllm/v1/cloud/providers`. Its absence is *why* every client hand-mirrored the roster, and those copies had already drifted:

| Defect | Effect |
|---|---|
| Swift prefilled vLLM on port **1234** | LM Studio's port — accepting the default configured a URL nothing serves |
| Swift labels via `.capitalized` | "Omlx", "Lmstudio", "Vllm" |
| `config_summary` exported 3 of 10 `ui` fields | 7 controls rendered against `undefined`; the favourites editor POSTed `[]` and **wiped favourites set from the Mac app** |
| `api_key_env` excluded from patches | `config_merge`'s comment claimed no editor exists; `SettingsWindowView` is one. Typed value silently reverted |
| `/admin/drain` orphaned | only dashboard way out of rotation was Stop, which kills in-flight requests |
| "Status JSON" → `href="/"` | 307s back to `/ui/`; the button reloaded the dashboard |

## Ledger discipline is now enforced

`expires` was read by nothing — an entry could carry any string, or an already-passed expiry, and stay green. The ledger declares `current_phase`, and tests assert every entry has a substantive reason and well-formed expiry, that none is overdue, and that no fact class exceeds the program's own 5-exception tripwire.

`current_phase` stays at **phase-3 deliberately**. This is Phase 4's local half; the cloud half (`generate-registry-artifacts.py --check`, deleting KeychainStore's switch cases, generating the doc rosters) is not done. Setting it to `phase-4` prints exactly the seven mirrors that remain — the honest to-do list.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [x] Packaging / CI / tooling

## Platforms

- [x] macOS (menubar app)
- [x] macOS / Linux / Windows (CLI / agent)
- [ ] Linux packaging
- [ ] Windows packaging

## Test plan

```bash
uv run pytest -q          # 1211 passed, 13 skipped (exit 0)
./scripts/ci.sh lint      # exit 0 — 29 routes, mirror gate over 10 ids
uv run pytest tests/conformance -q
swift test                # now in CI: 16 tests, 0 failures
```

Every fix was red-green verified, not assumed. Removing the Swift `source` field, restoring vLLM's wrong port, or advancing `current_phase` each produce a named failure.

- [x] Tests added or updated for behavior changes
- [x] Docs updated

## Notes for review

**`swift test` now runs in CI, and the Swift changes are compile-verified.** `swift test` previously existed only in `scripts/verify-before-pr.sh`, a local pre-push helper — so CI compiled the app but never ran its assertions. It is now a step in the macos-14 `menubar-lifecycle` job, and on its first run the app rebuilt clean (`[61/65] Linking NetllmMac`, `Build complete!`) and executed **16 tests, 0 failures**.

Two corrections to things I said earlier while doing this work, recorded because they changed the risk picture:

1. I twice claimed CI does not build the macOS app. **It does** — `build.sh` runs `swift build -c release` in the macos-14 job; I had grepped only the workflow YAML.
2. I then said the Swift changes here were guarded only by Python tests parsing the source, since I have no Swift toolchain locally. **That is no longer true** — the new CI step compiled and tested them.